### PR TITLE
#55 - Fresh installation giving errors for Playground.vue / Prettier

### DIFF
--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -25,9 +25,9 @@ if (currentDir.includes("node_modules")) {
 
 <script>
 // Use this component to play with other components
-export default {}
+export default {};
 </script>
-  `,
+`,
     err => {
       if (err) throw err;
     }


### PR DESCRIPTION
# Related issue
https://github.com/DivanteLtd/storefront-ui/issues/55

# Scope of work
Fixed the issues with there being compilation errors out of the box, a fresh install shouldn't show any errors (prettier or otherwise). (when running npm serve)

# Screenshots of visual changes
Before:
![image](https://user-images.githubusercontent.com/2095899/55796875-e2fe9080-5ac2-11e9-95c2-17f26c3858d1.png)

After:
![image](https://user-images.githubusercontent.com/2095899/55796868-de39dc80-5ac2-11e9-89ef-381352254ce5.png)
