### PR TITLE
[TESTS] Fix default test case for SfSidebar

### DIFF
--- a/src/components/molecules/SfSidebar/SfSidebar.spec.ts
+++ b/src/components/molecules/SfSidebar/SfSidebar.spec.ts
@@ -1,9 +1,9 @@
 import { shallowMount } from "@vue/test-utils";
-import SfComponent from "@/components/template/SfComponent.vue";
+import SfSidebar from "./SfSidebar.vue";
 
 describe("SfSidebar.vue", () => {
   it("renders a component", () => {
-    const component = shallowMount(SfComponent);
+    const component = shallowMount(SfSidebar);
     expect(component.contains(".sf-sidebar")).toBe(true);
   });
 });


### PR DESCRIPTION
# Scope of work
Fixed the default test case for SfSidebar to make all tests pass again.

# Checklist

- [x] I followed [composition rules](https://github.com/DivanteLtd/storefront-ui/blob/master/docs/component-rules.md) for my component
- [x] I tested the component in most common device sizes (can be tested in Storybook [from viewport addon in top menu](https://github.com/storybooks/storybook/tree/master/addons/viewport))
