### PR TITLE
Fix tests and documentation

### DIFF
--- a/src/components/atoms/SfRating/README.md
+++ b/src/components/atoms/SfRating/README.md
@@ -10,8 +10,8 @@ Rating component to display star (or other icons) ratings.
 
 ## Slots
 
-- `iconPositive` - slot for positive icon, repeated (score) times
-- `iconNegative` - slot for  negative icon, repeated (max-score) times
+- `icon-positive` - slot for positive icon, repeated (score) times
+- `icon-negative` - slot for  negative icon, repeated (max-score) times
 
 
 ## SCSS variables

--- a/src/components/atoms/SfRating/SfRating.spec.ts
+++ b/src/components/atoms/SfRating/SfRating.spec.ts
@@ -38,7 +38,7 @@ describe("SfRating.vue", () => {
         max
       },
       slots: {
-        iconPositive: '<div class="sf-rating__icon-clock"></div>'
+        'icon-positive': '<div class="sf-rating__icon-clock"></div>'
       }
     });
     expect(component.findAll(".sf-rating__icon-clock").length).toBe(score)
@@ -53,7 +53,7 @@ describe("SfRating.vue", () => {
         max
       },
       slots: {
-        iconNegative: '<div class="sf-rating__icon-close"></div>'
+        'icon-negative': '<div class="sf-rating__icon-close"></div>'
       }
     });
     expect(component.findAll(".sf-rating__icon-close").length).toBe(max - score)

--- a/src/components/atoms/SfRating/SfRating.stories.js
+++ b/src/components/atoms/SfRating/SfRating.stories.js
@@ -26,7 +26,7 @@ storiesOf("Atoms|Rating", module)
     }
   )
   .add(
-    "[slot] iconPositive",
+    "[slot] icon-positive",
     () => ({
       props: {
         rating: {
@@ -49,7 +49,7 @@ storiesOf("Atoms|Rating", module)
     }
   )
   .add(
-    "[slot] iconNegative",
+    "[slot] icon-negative",
     () => ({
       props: {
         rating: {

--- a/src/components/molecules/SfMenuItem/SfMenuItem.spec.ts
+++ b/src/components/molecules/SfMenuItem/SfMenuItem.spec.ts
@@ -9,14 +9,14 @@ describe("SfMenuItem.vue", () => {
 
   it("renders correct count prop", () => {
     const countText = "10 item(s)";
-    const titleText = "Example title";
+    const labelText = "Example title";
     const component = shallowMount(SfMenuItem, {
       propsData: {
-        title: titleText,
+        label: labelText,
         count: countText
       }
     });
-    expect(component.find(".sf-menu-item__title").text()).toMatch(titleText);
+    expect(component.find(".sf-menu-item__label").text()).toMatch(labelText);
     expect(component.find(".sf-menu-item__count").text()).toMatch(countText);
   });
 


### PR DESCRIPTION
# Related issue
#63 

# Scope of work
Saw in [this commit](https://github.com/DivanteLtd/storefront-ui/commit/c306ee5c1cbee5787329d6ff5cd93a1499a14edb) that the names of the slots in SfRating were changed back to kebab case, so I've fixed the tests and documentation.

# Screenshots of visual changes

# Checklist

- [x] I followed [composition rules](https://github.com/DivanteLtd/storefront-ui/blob/master/docs/component-rules.md) for my component
- [x] I tested the component in most common device sizes (can be tested in Storybook [from viewport addon in top menu](https://github.com/storybooks/storybook/tree/master/addons/viewport))
