### PR TITLE
Make the controls not selectable

### DIFF
--- a/src/components/molecules/SfInputNumber/SfInputNumber.scss
+++ b/src/components/molecules/SfInputNumber/SfInputNumber.scss
@@ -44,6 +44,7 @@ $input-number--large-width: $input-number-width * 2 !default;
     width: 0.75rem;
     padding: .2rem;
     display: flex;
+    user-select: none;
 
     img {
       width: 100%;


### PR DESCRIPTION
# Related issue
--

# Scope of work
Add user-select none

# Screenshots of visual changes

Before:
![vsf-ui-selected](https://user-images.githubusercontent.com/6972822/57448774-7f4ebb00-725a-11e9-8965-92ba2a2e8bf9.png)

After:
![vsf-ui-not selected](https://user-images.githubusercontent.com/6972822/57448780-84136f00-725a-11e9-9eb3-70b8a6654c73.png)


# Checklist

- [x] I followed [composition rules](https://github.com/DivanteLtd/storefront-ui/blob/master/docs/component-rules.md) for my component
- [x] I tested the component in most common device sizes (can be tested in Storybook [from viewport addon in top menu](https://github.com/storybooks/storybook/tree/master/addons/viewport))
