### PR TITLE
chore: add create-component script

### DIFF
--- a/docs/creating-new-component.md
+++ b/docs/creating-new-component.md
@@ -5,7 +5,15 @@ At this point I assume you are already familiar with composition rules and know 
 
 ### Start with template
 
-If you're creating a new component start with copying a template folder ([`src/components/template`](https://github.com/DivanteLtd/storefront-ui/tree/master/src/components/template)) and renaming it. It contains a starting boilerplate that'll help you create a componentnt in standarized way and save a lot of work.
+If you're creating a new componet start with `npm run create-component` which accepts two arguments, the first is atomic type, the second is compnent name. When running the command, it will generate boilerplate and help you create a componentnt in standarized way and save a lot of work.
+
+For example:
+```bash
+npm run create-component atoms button
+npm run create-component molecules input-number
+```
+
+
 
 If you're picking already existing just follow the tutorial and finish the missing parts.
 

--- a/docs/creating-new-component.md
+++ b/docs/creating-new-component.md
@@ -5,15 +5,14 @@ At this point I assume you are already familiar with composition rules and know 
 
 ### Start with template
 
-If you're creating a new componet start with `npm run create-component` which accepts two arguments, the first is atomic type, the second is compnent name. When running the command, it will generate boilerplate and help you create a componentnt in standarized way and save a lot of work.
+If you're creating a new componet start with `npm run create-component` which accepts two arguments, the first is atomic
+type, the second is component name. When running the command, it will generate boilerplate and help you create a component in standarized way and save a lot of work.
 
 For example:
 ```bash
 npm run create-component atoms button
 npm run create-component molecules input-number
 ```
-
-
 
 If you're picking already existing just follow the tutorial and finish the missing parts.
 

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "postinstall": "node scripts/postinstall.js",
     "prepublishOnly": "npm run build",
     "docs:dev": "vuepress dev docs",
-    "docs:build": "vuepress build docs"
+    "docs:build": "vuepress build docs",
+    "create-component": "node ./scripts/create-component.js"
   },
   "dependencies": {
     "@snowdog/alpaca-components": "^0.3.0-alpha.5",
@@ -46,7 +47,10 @@
     "babel-loader": "^8.0.5",
     "eslint": "^5.16.0",
     "eslint-plugin-vue": "^5.2.2",
+    "file-save": "^0.2.0",
+    "glob": "^7.1.4",
     "html-loader": "^0.5.5",
+    "inquirer": "^6.3.1",
     "lint-staged": "^8.1.6",
     "markdown-loader": "^5.0.0",
     "node-sass": "^4.12.0",
@@ -54,6 +58,7 @@
     "storybook-addon-vue-info": "^1.1.1",
     "ts-jest": "^24.0.1",
     "typescript": "^3.4.5",
+    "uppercamelcase": "^3.0.0",
     "vue-cli-plugin-storybook": "^0.6.0",
     "vue-template-compiler": "^2.6.8",
     "vuepress": "^0.14.10"
@@ -63,7 +68,7 @@
   },
   "main": "./dist/storefront-ui.common.js",
   "lint-staged": {
-    "*.{js,vue}": [
+    "*.{js,vue,html,scss,ts}": [
       "vue-cli-service lint",
       "git add"
     ]

--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
     "file-save": "^0.2.0",
     "glob": "^7.1.4",
     "html-loader": "^0.5.5",
-    "inquirer": "^6.3.1",
     "lint-staged": "^8.1.6",
     "markdown-loader": "^5.0.0",
     "node-sass": "^4.12.0",

--- a/scripts/create-component.js
+++ b/scripts/create-component.js
@@ -31,7 +31,7 @@ function createComponent(folder, componentName ) {
     process.exit(-1);
   }
   const ComponentName = uppercamelcase(componentName);
-  const PrefixComponentName = 'Sf' + ComponentName;
+  const PrefixComponentName = ComponentName.startsWith('Sf') ? ComponentName : 'Sf' + ComponentName;
   const PackagePath = path.resolve(__dirname, `../src/components/${folder}`, `${PrefixComponentName}`);
   const joinedComponentName = 'sf' + ComponentName.replace(/([A-Z])(?=\w)/g, (s1, s2) => '-' + s2.toLowerCase())
   const ret = glob.sync(PackagePath + '/' + PrefixComponentName + '.js')

--- a/scripts/create-component.js
+++ b/scripts/create-component.js
@@ -1,0 +1,182 @@
+'use strict';
+
+process.on('exit', () => {
+  console.log();
+});
+
+const inquirer = require('inquirer');
+const path = require('path');
+const fs = require('fs');
+const fileSave = require('file-save');
+const uppercamelcase = require('uppercamelcase');
+const glob = require('glob');
+
+const FOLDER_NAME = 'Which folder';
+const COMPONENT_NAME = 'Component name (Such as Table)';
+
+inquirer
+  .prompt([
+    {
+      name: FOLDER_NAME,
+      type: 'list',
+      choices: [
+        'atoms',
+        'molecules',
+        'organisms'
+      ]
+    },
+    {
+      name: COMPONENT_NAME,
+      validate: v => v.length > 0
+    }
+  ])
+  .then(answers => {
+    const selectedFolder = answers[FOLDER_NAME]
+    const componentName = answers[COMPONENT_NAME]
+
+    createComponent(selectedFolder, componentName)
+  });
+
+
+
+function createComponent(folder, componentName) {
+  const ComponentName = uppercamelcase(componentName);
+  const PrefixComponentName = 'Sf' + ComponentName;
+  const PackagePath = path.resolve(__dirname, `../src/components/${folder}`, `${PrefixComponentName}`);
+  const joinedComponentName = 'sf' + ComponentName.replace(/([A-Z])(?=\w)/g, (s1, s2) => '-' + s2.toLowerCase())
+  const ret = glob.sync(PackagePath + '/' + PrefixComponentName + '.js')
+
+  if (ret.length > 0) {
+    console.warn(`The ${PrefixComponentName} was already created. \n`)
+    return;
+  }
+
+  const files = [
+    {
+      fileName: 'README.md',
+      content: `# ${PrefixComponentName}
+
+## Events
+
+- \`event\` - description
+
+
+## CSS Modifiers
+
+- \`classname\` - description
+
+
+## SCSS variables
+
+- \`variablename\` (defaultvalue) - description
+        
+        `
+    },
+    {
+      fileName: `${PrefixComponentName}.html`,
+      content: `<div class="${joinedComponentName}"></div>`
+    },
+    {
+      fileName: `${PrefixComponentName}.js`,
+      content: `export default {
+  name: "${PrefixComponentName}"
+};
+        `
+    },
+    {
+      fileName: `${PrefixComponentName}.scss`,
+      content: `@import '../../../css/variables';
+
+// $component__block-property: value;
+
+// .${joinedComponentName} {
+//   &__element {
+
+//   }
+//   &--modifier {
+
+//   }
+// }        
+        `
+    },
+    {
+      fileName: `${PrefixComponentName}.spec.ts`,
+      content: `import { shallowMount } from "@vue/test-utils";
+import ${PrefixComponentName} from "@/components/${folder}/${PrefixComponentName}.vue";
+
+describe("${PrefixComponentName}.vue", () => {
+  it("renders a component", () => {
+    const component = shallowMount(${PrefixComponentName});
+    expect(component.contains(".${joinedComponentName}")).toBe(true);
+  });
+});
+        `
+    },
+    {
+      fileName: `${PrefixComponentName}.stories.js`,
+      content: `// /* eslint-disable import/no-extraneous-dependencies */
+import { storiesOf } from "@storybook/vue";
+import { withKnobs, text, select } from "@storybook/addon-knobs";
+import notes from "./README.md"
+import ${PrefixComponentName} from "./${PrefixComponentName}.vue";
+
+// storiesOf("Component", module)
+//   .addDecorator(withKnobs)
+//   .add(
+//     "[slot] default",
+//     () => ({
+//       props: {
+//         editableProp: {
+//           default: text("(prop) propname")
+//         },
+//         customClass: {
+//           default: select(
+//             "CSS Modifier",
+//             ["null", "${joinedComponentName}--modifier"],
+//             "null",
+//             "CSS-Modifiers"
+//           )
+//         }
+//       },
+//       components: { SfComponent },
+//       template: \`<SfComponent
+//         :class="customClass"
+//         :
+//       >
+//         Hello Button<
+//       /SfComponent>\`
+//     }),
+//     {
+//       info: true,
+//       notes
+//     }
+//   );
+        `
+    },
+    {
+      fileName: `${PrefixComponentName}.vue`,
+      content: `<script src="./${PrefixComponentName}.js"></script>
+<template lang="html" src="./${PrefixComponentName}.html"></template>
+<style lang="scss" src="./${PrefixComponentName}.scss"></style>
+        `
+    },
+  ]
+
+
+  files.forEach(file => {
+    fileSave(path.join(PackagePath, file.fileName))
+      .write(file.content, 'utf8')
+      .end('\n');
+  });
+
+  console.log('DONE!');
+}
+
+
+
+
+
+
+
+
+

--- a/scripts/create-component.js
+++ b/scripts/create-component.js
@@ -1,45 +1,35 @@
 'use strict';
 
-process.on('exit', () => {
-  console.log();
+process.on('exit', code => {
+  if(code === 0) {
+    console.log(`New component is created successfully.`)
+  }
 });
 
-const inquirer = require('inquirer');
 const path = require('path');
 const fs = require('fs');
 const fileSave = require('file-save');
 const uppercamelcase = require('uppercamelcase');
 const glob = require('glob');
+const ATOMIC_TYPE = [
+  'atoms',
+  'molecules',
+  'organisms'
+]
 
-const FOLDER_NAME = 'Which folder';
-const COMPONENT_NAME = 'Component name (Such as Table)';
+if(process.argv.length < 4) {
+  console.warn('Please input atomic type and component name')
+  process.exit(-1);
+}
 
-inquirer
-  .prompt([
-    {
-      name: FOLDER_NAME,
-      type: 'list',
-      choices: [
-        'atoms',
-        'molecules',
-        'organisms'
-      ]
-    },
-    {
-      name: COMPONENT_NAME,
-      validate: v => v.length > 0
-    }
-  ])
-  .then(answers => {
-    const selectedFolder = answers[FOLDER_NAME]
-    const componentName = answers[COMPONENT_NAME]
-
-    createComponent(selectedFolder, componentName)
-  });
+createComponent(process.argv[2],process.argv[3])
 
 
-
-function createComponent(folder, componentName) {
+function createComponent(folder, componentName ) {
+  if(!ATOMIC_TYPE.includes(folder)) {
+    console.warn('Following atomic types are supported: atoms, molecules, organisms')
+    process.exit(-1);
+  }
   const ComponentName = uppercamelcase(componentName);
   const PrefixComponentName = 'Sf' + ComponentName;
   const PackagePath = path.resolve(__dirname, `../src/components/${folder}`, `${PrefixComponentName}`);
@@ -47,8 +37,8 @@ function createComponent(folder, componentName) {
   const ret = glob.sync(PackagePath + '/' + PrefixComponentName + '.js')
 
   if (ret.length > 0) {
-    console.warn(`The ${PrefixComponentName} was already created. \n`)
-    return;
+    console.warn(`${PrefixComponentName} component was already created. \n`)
+    process.exit(-1);
   }
 
   const files = [
@@ -169,7 +159,6 @@ import ${PrefixComponentName} from "./${PrefixComponentName}.vue";
       .end('\n');
   });
 
-  console.log('DONE!');
 }
 
 


### PR DESCRIPTION
# Scope of work
Whenever we are ready to create a new component, we have to copy several required files then rename them. Under this situation, I write a script to auto-generate those files by user's inputs.

# Screenshots of visual changes

# Checklist

- [ ] I followed [composition rules](https://github.com/DivanteLtd/storefront-ui/blob/master/docs/component-rules.md) for my component
- [ ] I tested the component in most common device sizes (can be tested in Storybook [from viewport addon in the top menu](https://github.com/storybooks/storybook/tree/master/addons/viewport))
