### PR TITLE
chore: add SfBadge component

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "build": "vue-cli-service build --target lib --name storefront-ui ./src/index.js",
     "lint": "vue-cli-service lint",
     "test:unit": "vue-cli-service test:unit",
+    "test:dev": "vue-cli-service test:unit --watch",
     "storybook:serve": "vue-cli-service storybook:serve -s ./public -p 6006 -c config/storybook",
     "storybook:build": "vue-cli-service storybook:build -s ./public -c config/storybook",
     "postinstall": "node scripts/postinstall.js",

--- a/src/components/atoms/SfBadge/README.md
+++ b/src/components/atoms/SfBadge/README.md
@@ -1,9 +1,9 @@
 ## SfBadge
 
 ## Screen
-![default type](https://user-images.githubusercontent.com/7866718/58382433-ae0bb600-7ffc-11e9-98ba-e45dbcf600e3.png)
+![default type](https://user-images.githubusercontent.com/7866718/58428800-4164ea00-80d6-11e9-8824-1cae51ce1f23.png)
 
-![alert  type](https://user-images.githubusercontent.com/7866718/58382436-b7951e00-7ffc-11e9-84a0-de7750effee7.png)
+![warning type](https://user-images.githubusercontent.com/7866718/58428815-4cb81580-80d6-11e9-9d9a-a12055c02d7a.png)
 
 ![full width](https://user-images.githubusercontent.com/7866718/58382441-c380e000-7ffc-11e9-971e-7e164968c4cf.png)
 
@@ -12,18 +12,18 @@
 - `default` - slot for custom content
 
 ## SCSS variables
-```scss
-$sf-badge--text-color: $c-white;
-$sf-badge--alert: $c-pink-primary;
-$sf-badge--warning: $c-blue-primary;
-$sf-badge--info: $c-green-primary;
-$sf-badge--font-size: 0.875rem;
-$sf-badge--padding: 0.625rem 0.3125rem;
-```
+- `$badge--text-color` ($c-white);
+- `$badge--alert` ($c-pink-primary);
+- `$badge--warning` ($c-blue-primary);
+- `$badge--info` ($c-green-primary);
+- `$badge--font-size` (0.875rem);
+- `$badge--padding` (0.3125rem 0.625rem);
+- `$badge--line-height` (1.3);
+
 
 ## CSS Modifiers
-- `.sf-badge--warning` - sets blue color for badge
-- `.sf-badge--alert` - sets pink color for badge
-- `.sf-badge--full-width` - sets the badge with 100%
+- `.sf-badge--warning` (sets blue color for badge);
+- `.sf-badge--alert` (sets pink color for badge);
+- `.sf-badge--full-width` (sets the badge with 100%);
         
         

--- a/src/components/atoms/SfBadge/README.md
+++ b/src/components/atoms/SfBadge/README.md
@@ -1,0 +1,33 @@
+# SfBadge
+
+## Props
+
+- `type` - defines badge type, defaul "info"
+
+
+## Slots
+
+- `default` - slot for custom content
+
+## CSCSS variables
+
+- `classname` - description
+
+
+## SCSS variables
+```scss
+$sf-badge--text-color: $c-white;
+$sf-badge--alert: $c-pink-primary;
+$sf-badge--warning: $c-blue-primary;
+$sf-badge--info: $c-green-primary;
+$sf-badge--font-size: 0.875rem;
+$sf-badge--padding: 0.625rem;
+```
+
+## CSS Modifiers
+
+- `.sf-badge--info` - sets green color for badge
+- `.sf-badge--warning` - sets blue color for badge
+- `.sf-badge--alert` - sets pink color for badge
+        
+        

--- a/src/components/atoms/SfBadge/README.md
+++ b/src/components/atoms/SfBadge/README.md
@@ -1,18 +1,15 @@
-# SfBadge
+## SfBadge
 
-## Props
+## Screen
+![default type](https://user-images.githubusercontent.com/7866718/58382433-ae0bb600-7ffc-11e9-98ba-e45dbcf600e3.png)
 
-- `type` - defines badge type, defaul "info"
+![alert  type](https://user-images.githubusercontent.com/7866718/58382436-b7951e00-7ffc-11e9-84a0-de7750effee7.png)
 
+![full width](https://user-images.githubusercontent.com/7866718/58382441-c380e000-7ffc-11e9-971e-7e164968c4cf.png)
 
 ## Slots
 
 - `default` - slot for custom content
-
-## CSCSS variables
-
-- `classname` - description
-
 
 ## SCSS variables
 ```scss
@@ -21,13 +18,12 @@ $sf-badge--alert: $c-pink-primary;
 $sf-badge--warning: $c-blue-primary;
 $sf-badge--info: $c-green-primary;
 $sf-badge--font-size: 0.875rem;
-$sf-badge--padding: 0.625rem;
+$sf-badge--padding: 0.625rem 0.3125rem;
 ```
 
 ## CSS Modifiers
-
-- `.sf-badge--info` - sets green color for badge
 - `.sf-badge--warning` - sets blue color for badge
 - `.sf-badge--alert` - sets pink color for badge
+- `.sf-badge--full-width` - sets the badge with 100%
         
         

--- a/src/components/atoms/SfBadge/SfBadge.html
+++ b/src/components/atoms/SfBadge/SfBadge.html
@@ -1,3 +1,4 @@
-<div class="sf-badge" :class="`sf-badge--${type}`">
+<div class="sf-badge">
+  <!--@slot Use this slot to place content inside the badge.-->
   <slot />
 </div>

--- a/src/components/atoms/SfBadge/SfBadge.html
+++ b/src/components/atoms/SfBadge/SfBadge.html
@@ -1,0 +1,3 @@
+<div class="sf-badge" :class="`sf-badge--${type}`">
+  <slot />
+</div>

--- a/src/components/atoms/SfBadge/SfBadge.js
+++ b/src/components/atoms/SfBadge/SfBadge.js
@@ -1,0 +1,13 @@
+export default {
+  name: "SfBadge",  
+  props: {
+    type: {
+      type: String,
+      default: "info",
+      validator: function(value) {
+        return ["alert", "warning", "info"].indexOf(value) !== -1;
+      }
+    }
+  }
+};
+        

--- a/src/components/atoms/SfBadge/SfBadge.js
+++ b/src/components/atoms/SfBadge/SfBadge.js
@@ -1,13 +1,4 @@
 export default {
-  name: "SfBadge",  
-  props: {
-    type: {
-      type: String,
-      default: "info",
-      validator: function(value) {
-        return ["alert", "warning", "info"].indexOf(value) !== -1;
-      }
-    }
-  }
+  name: "SfBadge",
 };
         

--- a/src/components/atoms/SfBadge/SfBadge.scss
+++ b/src/components/atoms/SfBadge/SfBadge.scss
@@ -7,15 +7,19 @@ $sf-badge--alert: $c-pink-primary;
 $sf-badge--warning: $c-blue-primary;
 $sf-badge--info: $c-green-primary;
 $sf-badge--font-size: 0.875rem;
-$sf-badge--padding: 0.625rem;
+$sf-badge--padding: 0.625rem 0.3125rem;
 
 
 
 .sf-badge {
+  display: inline-block;
+  min-width: 10rem;
   color: $sf-badge--text-color;
   font-size: $sf-badge--font-size;
-  padding: $sf-badge--padding 0;
+  padding: $sf-badge--padding;
   text-align: center;
+  background-color: $sf-badge--info;
+  box-sizing: border-box;
 
   &--alert {
     background-color: $sf-badge--alert
@@ -25,8 +29,8 @@ $sf-badge--padding: 0.625rem;
     background-color: $sf-badge--warning
   }
 
-  &--info {
-    background-color: $sf-badge--info
+  &--full-width {
+    width: 100%;
   }
 }        
         

--- a/src/components/atoms/SfBadge/SfBadge.scss
+++ b/src/components/atoms/SfBadge/SfBadge.scss
@@ -1,32 +1,32 @@
 @import '../../../css/variables';
 
 
-$sf-badge--text-color: $c-white;
+$badge--text-color: $c-white;
 
-$sf-badge--alert: $c-pink-primary;
-$sf-badge--warning: $c-blue-primary;
-$sf-badge--info: $c-green-primary;
-$sf-badge--font-size: 0.875rem;
-$sf-badge--padding: 0.625rem 0.3125rem;
-
+$badge--alert: $c-pink-primary;
+$badge--warning: $c-blue-primary;
+$badge--info: $c-green-primary;
+$badge--font-size: 0.875rem;
+$badge--padding: 0.3125rem 0.625rem;
+$badge--line-height: 1.3;
 
 
 .sf-badge {
   display: inline-block;
-  min-width: 10rem;
-  color: $sf-badge--text-color;
-  font-size: $sf-badge--font-size;
-  padding: $sf-badge--padding;
+  color: $badge--text-color;
+  font-size: $badge--font-size;
+  padding: $badge--padding;
   text-align: center;
-  background-color: $sf-badge--info;
+  background-color: $badge--info;
   box-sizing: border-box;
+  line-height: $badge--line-height;
 
   &--alert {
-    background-color: $sf-badge--alert
+    background-color: $badge--alert
   }
 
   &--warning {
-    background-color: $sf-badge--warning
+    background-color: $badge--warning
   }
 
   &--full-width {

--- a/src/components/atoms/SfBadge/SfBadge.scss
+++ b/src/components/atoms/SfBadge/SfBadge.scss
@@ -1,0 +1,32 @@
+@import '../../../css/variables';
+
+
+$sf-badge--text-color: $c-white;
+
+$sf-badge--alert: $c-pink-primary;
+$sf-badge--warning: $c-blue-primary;
+$sf-badge--info: $c-green-primary;
+$sf-badge--font-size: 0.875rem;
+$sf-badge--padding: 0.625rem;
+
+
+
+.sf-badge {
+  color: $sf-badge--text-color;
+  font-size: $sf-badge--font-size;
+  padding: $sf-badge--padding 0;
+  text-align: center;
+
+  &--alert {
+    background-color: $sf-badge--alert
+  }
+
+  &--warning {
+    background-color: $sf-badge--warning
+  }
+
+  &--info {
+    background-color: $sf-badge--info
+  }
+}        
+        

--- a/src/components/atoms/SfBadge/SfBadge.spec.ts
+++ b/src/components/atoms/SfBadge/SfBadge.spec.ts
@@ -1,0 +1,34 @@
+import { shallowMount } from "@vue/test-utils";
+import SfBadge from "./SfBadge.vue";
+
+describe("SfBadge.vue", () => {
+  it("renders a badge", () => {
+    const component = shallowMount(SfBadge);
+    expect(component.contains(".sf-badge")).toBe(true);
+  });
+
+  it("renders a badge with css modifier", () => {
+    const component = shallowMount(SfBadge, {
+      propsData: {
+        type: "warning",
+      }
+    });
+    expect(component.contains(".sf-badge--warning")).toBe(true);
+  });
+ 
+  it("renders a badge content via default slot", () => {
+    const content = 'sfbadge content'
+    const component = shallowMount(SfBadge, {
+      propsData: {
+        type: "warning",
+      },
+      slots: {
+        default: content,
+      }
+    });
+    expect(component.find(".sf-badge").text()).toBe(content);
+  });
+
+
+});
+        

--- a/src/components/atoms/SfBadge/SfBadge.spec.ts
+++ b/src/components/atoms/SfBadge/SfBadge.spec.ts
@@ -8,10 +8,10 @@ describe("SfBadge.vue", () => {
   });
 
   it("renders a badge with css modifier", () => {
-    const component = shallowMount(SfBadge, {
-      propsData: {
-        type: "warning",
-      }
+    const component = shallowMount({
+      components: {SfBadge},
+      template : `<SfBadge class="sf-badge--warning" />`,
+      
     });
     expect(component.contains(".sf-badge--warning")).toBe(true);
   });
@@ -19,9 +19,6 @@ describe("SfBadge.vue", () => {
   it("renders a badge content via default slot", () => {
     const content = 'sfbadge content'
     const component = shallowMount(SfBadge, {
-      propsData: {
-        type: "warning",
-      },
       slots: {
         default: content,
       }

--- a/src/components/atoms/SfBadge/SfBadge.stories.js
+++ b/src/components/atoms/SfBadge/SfBadge.stories.js
@@ -1,0 +1,38 @@
+// /* eslint-disable import/no-extraneous-dependencies */
+import { storiesOf } from "@storybook/vue";
+import { withKnobs, text, select } from "@storybook/addon-knobs";
+import notes from "./README.md"
+import SfBadge from "./SfBadge.vue";
+
+storiesOf("Atoms|Badge", module)
+  .addDecorator(withKnobs)
+  .add(
+    "info",
+    () => ({
+      components: { SfBadge },
+      template: `<SfBadge>
+        default type
+        </SfBadge>`
+    }),
+  )
+  .add(
+    "warning",
+    () => ({
+      components: { SfBadge },
+      template: `<SfBadge type="warning">
+        warning type
+        </SfBadge>`
+    }),
+  )
+  .add(
+    "alert",
+    () => ({
+      components: { SfBadge },
+      template: `<SfBadge type="alert">
+        alert type
+        </SfBadge>`
+    }),
+  )
+
+
+        

--- a/src/components/atoms/SfBadge/SfBadge.stories.js
+++ b/src/components/atoms/SfBadge/SfBadge.stories.js
@@ -7,31 +7,32 @@ import SfBadge from "./SfBadge.vue";
 storiesOf("Atoms|Badge", module)
   .addDecorator(withKnobs)
   .add(
-    "info",
+    "Basic",
     () => ({
       components: { SfBadge },
-      template: `<SfBadge>
-        default type
-        </SfBadge>`
+      props: {
+        customClass: {
+          default: select(
+            "CSS Modifier",
+            ["null", "sf-badge--alert", "sf-badge--warning", "sf-button--full-width","sf-button--full-width  sf-badge--warning"],
+            "null"
+          )
+        }
+      },
+      template: `<SfBadge :class="customClass">
+      LIMITED
+</SfBadge>`
     }),
-  )
-  .add(
-    "warning",
-    () => ({
-      components: { SfBadge },
-      template: `<SfBadge type="warning">
-        warning type
-        </SfBadge>`
-    }),
-  )
-  .add(
-    "alert",
-    () => ({
-      components: { SfBadge },
-      template: `<SfBadge type="alert">
-        alert type
-        </SfBadge>`
-    }),
+    {
+      info: {
+        summary: `
+        <h2> Description </h2>
+        <p>Badge component. Place desired content into its default slot.</p>
+        <h2> Usage </h2>
+        <pre><code>import SfBadge from "@storefrontui/vue/dist/SfBadge.vue"</code></pre>
+        `
+      }
+    }
   )
 
 

--- a/src/components/atoms/SfBadge/SfBadge.vue
+++ b/src/components/atoms/SfBadge/SfBadge.vue
@@ -1,0 +1,4 @@
+<script src="./SfBadge.js"></script>
+<template lang="html" src="./SfBadge.html"></template>
+<style lang="scss" src="./SfBadge.scss"></style>
+        

--- a/src/components/molecules/SfCallToAction/SfCallToAction.spec.ts
+++ b/src/components/molecules/SfCallToAction/SfCallToAction.spec.ts
@@ -27,7 +27,6 @@ describe("SfCallToAction.vue", () => {
         buttonText: msg
       }
     });
-    console.log(component.html());
     const wrapper = component.find(".sf-call-to-action__button");
     expect(wrapper.text()).toMatch(msg);
   });


### PR DESCRIPTION
# Scope of work
Finish SfBadge Component

# Screenshots of visual changes
![default type](https://user-images.githubusercontent.com/7866718/58428800-4164ea00-80d6-11e9-8824-1cae51ce1f23.png)
![warning type](https://user-images.githubusercontent.com/7866718/58428815-4cb81580-80d6-11e9-9d9a-a12055c02d7a.png)
![full width](https://user-images.githubusercontent.com/7866718/58382441-c380e000-7ffc-11e9-971e-7e164968c4cf.png)

supports different types and full-width via CSS modifier


# Checklist

- [x] I followed [composition rules](https://github.com/DivanteLtd/storefront-ui/blob/master/docs/component-rules.md) for my component
- [x] I tested the component in most common device sizes (can be tested in Storybook [from viewport addon in top menu](https://github.com/storybooks/storybook/tree/master/addons/viewport))
