### PR TITLE
fix typos, add missing info, fix prettier errors

### DIFF
--- a/scripts/create-component.js
+++ b/scripts/create-component.js
@@ -130,7 +130,8 @@ const eventsTableConfig = {
 //       components: { ${PrefixComponentName} },
 //       template: \`<${PrefixComponentName}
 //         :class="customClass"
-//       />\`
+//       >
+//       </${PrefixComponentName}>\`
 //     }),
 //     {
 //      info: {

--- a/scripts/create-component.js
+++ b/scripts/create-component.js
@@ -48,26 +48,6 @@ function createComponent(folder, componentName) {
 
   const files = [
     {
-      fileName: "README.md",
-      content: `# ${PrefixComponentName}
-
-## Events
-
-- \`event\` - description
-
-
-## CSS Modifiers
-
-- \`classname\` - description
-
-
-## SCSS variables
-
-- \`variablename\` (defaultvalue) - description
-        
-        `
-    },
-    {
       fileName: `${PrefixComponentName}.html`,
       content: `<div class="${joinedComponentName}"></div>`
     },
@@ -109,19 +89,24 @@ describe("${PrefixComponentName}.vue", () => {
       content: `// /* eslint-disable import/no-extraneous-dependencies */
 import { storiesOf } from "@storybook/vue";
 import { withKnobs, text, select } from "@storybook/addon-knobs";
-import ${PrefixComponentName} from "./${PrefixComponentName}.vue";
 import { generateStorybookTable } from "@/helpers";
 
-// use this to documment scss vars
+import ${PrefixComponentName} from "./${PrefixComponentName}.vue";
+
+// use this to document scss vars
 const scssTableConfig = {
   tableHeadConfig: ["NAME", "DEFAULT", "DESCRIPTION"],
-  tableBodyConfig: [["$component-size", "1.438rem", "size of checkmark"]]
+  tableBodyConfig: [
+    ["$component-size", "1.438rem", "size of checkmark"]
+  ]
 };
 
 // use this to document events
 const eventsTableConfig = {
   tableHeadConfig: ["NAME", "DESCRIPTION"],
-  tableBodyConfig: [["input", "event emited when option is selected"]]
+  tableBodyConfig: [
+    ["input", "event emited when option is selected"]
+  ]
 };
 
 // storiesOf("${PrefixComponentName}", module)
@@ -149,7 +134,7 @@ const eventsTableConfig = {
 //     }),
 //     {
 //      info: {
-//        summary: \`<p>Component for simple group of radio buttons, pass an array get selected value via v-model.</p>
+//        summary: \`<p>Component description.</p>
 //        <h2>Usage</h2>
 //        <pre><code>import ${PrefixComponentName} from "@storefrontui/vue/dist/${PrefixComponentName}.vue"</code></pre>
 //        \${generateStorybookTable(scssTableConfig, "SCSS variables")}

--- a/scripts/create-component.js
+++ b/scripts/create-component.js
@@ -75,8 +75,7 @@ function createComponent(folder, componentName) {
       fileName: `${PrefixComponentName}.js`,
       content: `export default {
   name: "${PrefixComponentName}"
-};
-        `
+};`
     },
     {
       fileName: `${PrefixComponentName}.scss`,
@@ -91,8 +90,7 @@ function createComponent(folder, componentName) {
 //   &--modifier {
 
 //   }
-// }        
-        `
+// }`
     },
     {
       fileName: `${PrefixComponentName}.spec.ts`,
@@ -104,8 +102,7 @@ describe("${PrefixComponentName}.vue", () => {
     const component = shallowMount(${PrefixComponentName});
     expect(component.contains(".${joinedComponentName}")).toBe(true);
   });
-});
-        `
+});`
     },
     {
       fileName: `${PrefixComponentName}.stories.js`,
@@ -118,20 +115,16 @@ import { generateStorybookTable } from "@/helpers";
 // use this to documment scss vars
 const scssTableConfig = {
   tableHeadConfig: ["NAME", "DEFAULT", "DESCRIPTION"],
-  tableBodyConfig: [
-    ["$component-size", "1.438rem", "size of checkmark"],
-  ]
+  tableBodyConfig: [["$component-size", "1.438rem", "size of checkmark"]]
 };
 
-// use this to documment events
+// use this to document events
 const eventsTableConfig = {
   tableHeadConfig: ["NAME", "DESCRIPTION"],
-  tableBodyConfig: [
-    ["input", "event emmited when option is selected"],
-  ]
+  tableBodyConfig: [["input", "event emited when option is selected"]]
 };
 
-// storiesOf("Component", module)
+// storiesOf("${PrefixComponentName}", module)
 //   .addDecorator(withKnobs)
 //   .add(
 //     "[slot] default",
@@ -152,27 +145,25 @@ const eventsTableConfig = {
 //       components: { ${PrefixComponentName} },
 //       template: \`<${PrefixComponentName}
 //         :class="customClass"
-//       >
-//       /${PrefixComponentName}>\`
+//       />\`
 //     }),
 //     {
 //      info: {
 //        summary: \`<p>Component for simple group of radio buttons, pass an array get selected value via v-model.</p>
-//        <h2> Usage </h2>
+//        <h2>Usage</h2>
 //        <pre><code>import ${PrefixComponentName} from "@storefrontui/vue/dist/${PrefixComponentName}.vue"</code></pre>
 //        \${generateStorybookTable(scssTableConfig, "SCSS variables")}
 //        \${generateStorybookTable(eventsTableConfig, "Events")}
 //        \`
 //      }
-//    }   
+//    }
 // );`
     },
     {
       fileName: `${PrefixComponentName}.vue`,
       content: `<script src="./${PrefixComponentName}.js"></script>
 <template lang="html" src="./${PrefixComponentName}.html"></template>
-<style lang="scss" src="./${PrefixComponentName}.scss"></style>
-        `
+<style lang="scss" src="./${PrefixComponentName}.scss"></style>`
     }
   ];
 


### PR DESCRIPTION
# Related issue
No related issue, I'm sorry 🙃 

# Scope of work
I found out some typos, unuseful spaces that could create prettier/lint errors and I added the missing component name into the stories.js in place of "Component".

That's it.
