### PR TITLE
Document SCSS variables, CSS modifiers In Atoms

### DIFF
--- a/packages/vue/src/components/atoms/SfBadge/SfBadge.scss
+++ b/packages/vue/src/components/atoms/SfBadge/SfBadge.scss
@@ -32,5 +32,5 @@ $badge--line-height: 1.3;
   &--full-width {
     width: 100%;
   }
-}        
-        
+}
+

--- a/packages/vue/src/components/atoms/SfBadge/SfBadge.stories.js
+++ b/packages/vue/src/components/atoms/SfBadge/SfBadge.stories.js
@@ -1,8 +1,30 @@
 // /* eslint-disable import/no-extraneous-dependencies */
 import { storiesOf } from "@storybook/vue";
 import { withKnobs, text, select } from "@storybook/addon-knobs";
-import notes from "./README.md";
+import { generateStorybookTable } from "@/helpers";
 import SfBadge from "./SfBadge.vue";
+
+const scssTableConfig = {
+  tableHeadConfig: ["NAME", "DEFAULT", "DESCRIPTION"],
+  tableBodyConfig: [
+    ["$badge--text-color", "$c-white", "badge text color"],
+    ["$badge--alert", "$c-pink-primary", "alert badge color"],
+    ["$badge--warning", "$c-blue-primary", "warning badge color"],
+    ["$badge--info", "$c-green-primary", "info badge color"],
+    ["$badge--font-size", "0.875rem", "badge font-size"],
+    ["$badge--padding", "0.3125rem 0.625rem", "badge padding"],
+    ["$badge--line-height", "1.3", "line height of badge"]
+  ]
+};
+
+const cssTableConfig = {
+  tableHeadConfig: ["NAME", "DESCRIPTION"],
+  tableBodyConfig: [
+    [".sf-badge--warning", "sets blue color for badge"],
+    [".sf-badge--alert", "sets pink color for badge"],
+    [".sf-badge--full-width", "sets the badge with 100%"]
+  ]
+};
 
 storiesOf("Atoms|Badge", module)
   .addDecorator(withKnobs)
@@ -36,6 +58,8 @@ storiesOf("Atoms|Badge", module)
         <p>Badge component. Place desired content into its default slot.</p>
         <h2> Usage </h2>
         <pre><code>import SfBadge from "@storefrontui/vue/dist/SfBadge.vue"</code></pre>
+        ${generateStorybookTable(scssTableConfig, "SCSS variables")}
+        ${generateStorybookTable(cssTableConfig, "CSS modifiers")}
         `
       }
     }

--- a/packages/vue/src/components/atoms/SfBreadcrumbs/SfBreadcrumbs.js
+++ b/packages/vue/src/components/atoms/SfBreadcrumbs/SfBreadcrumbs.js
@@ -12,18 +12,18 @@ export default {
   },
 
   computed: {
-    last () {
-      return this.breadcrumbs.length - 1
+    last() {
+      return this.breadcrumbs.length - 1;
     }
   },
 
   methods: {
-    click (breadcrumb) {
+    click(breadcrumb) {
       /**
        * Event for breadcrumb click, passes `breadcrumb.route` as value
        * @type {Event}
        */
-      this.$emit('click', breadcrumb.route)
+      this.$emit("click", breadcrumb.route);
     }
   }
 };

--- a/packages/vue/src/components/atoms/SfBreadcrumbs/SfBreadcrumbs.stories.js
+++ b/packages/vue/src/components/atoms/SfBreadcrumbs/SfBreadcrumbs.stories.js
@@ -9,20 +9,26 @@ import SfBreadcrumbs from "./SfBreadcrumbs.vue";
 const scssTableConfig = {
   tableHeadConfig: ["NAME", "DEFAULT", "DESCRIPTION"],
   tableBodyConfig: [
+    ["$breadcrumbs__item-separator", "|", "Separator between breadcrumb items"],
     [
-      "$breadcrumbs__item-separator", "|", "Separator between breadcrumb items"
+      "$breadcrumbs__item-padding",
+      ".75rem",
+      "Space between breadcrumbs and separator"
     ],
     [
-      "$breadcrumbs__item-padding", ".75rem", "Space between breadcrumbs and separator"
+      "$breadcrumbs__item-color",
+      "$c-gray-primary",
+      "Default color breadcrumb items"
     ],
     [
-      "$breadcrumbs__item-color", "$c-gray-primary", "Default color breadcrumb items"
+      "$breadcrumbs__link-color",
+      "$c-dark-primary",
+      "Color for breadcrumb links"
     ],
     [
-      "$breadcrumbs__link-color", "$c-dark-primary", "Color for breadcrumb links"
-    ],
-    [
-      "$breadcrumbs__item-separator-color", "$breadcrumbs__link-color", "Breadcrumbs separator color"
+      "$breadcrumbs__item-separator-color",
+      "$breadcrumbs__link-color",
+      "Breadcrumbs separator color"
     ]
   ]
 };
@@ -31,32 +37,32 @@ const data = () => {
   return {
     breadcrumbs: [
       {
-        text: 'Home',
+        text: "Home",
         route: {
-          link: '#home'
+          link: "#home"
         }
       },
       {
-        text: 'Category',
+        text: "Category",
         route: {
-          link: '#category'
+          link: "#category"
         }
       },
       {
-        text: 'Pants',
+        text: "Pants",
         route: {
-          link: '#pants'
+          link: "#pants"
         }
       }
     ]
-  }
-}
+  };
+};
 
 const methods = {
-  click (route) {
-    alert(JSON.stringify(route, null, 2))
+  click(route) {
+    alert(JSON.stringify(route, null, 2));
   }
-}
+};
 
 storiesOf("Atoms|Breadcrumbs", module)
   .addDecorator(withKnobs)

--- a/packages/vue/src/components/atoms/SfCircleIcon/SfCircleIcon.stories.js
+++ b/packages/vue/src/components/atoms/SfCircleIcon/SfCircleIcon.stories.js
@@ -1,7 +1,45 @@
 import { storiesOf } from "@storybook/vue";
-import notes from "./README.md";
 import SfCircleIcon from "./SfCircleIcon.vue";
+import { generateStorybookTable } from "@/helpers";
 import { withKnobs, text, select } from "@storybook/addon-knobs";
+
+const scssTableConfig = {
+  tableHeadConfig: ["NAME", "DEFAULT", "DESCRIPTION"],
+  tableBodyConfig: [
+    [
+      "$sf-circle-icon-background-primary",
+      "$c-green-primary",
+      "circle icon background"
+    ],
+    [
+      "$sf-circle-icon-background-secondary",
+      "$c-dark-primary",
+      "circle icon background"
+    ],
+    ["$sf-circle-icon-icon-color", "$c-white", "warning badge color"],
+    ["$sf-circle-icon-size", "3.25rem !default", "size of icon"],
+    ["$sf-circle-icon-big-size", "3.25rem !default", "large size icon"],
+    ["$sf-circle-icon-small-size", "1.625rem !default", "small size icon"],
+    [
+      "$sf-circle-icon-background-small",
+      "$c-gray-secondary",
+      "icon background color"
+    ],
+    [
+      "$sf-circle-icon-background-small-hover",
+      "$c-dark-secondary",
+      "icon background color on hover"
+    ]
+  ]
+};
+
+const cssTableConfig = {
+  tableHeadConfig: ["NAME", "DESCRIPTION"],
+  tableBodyConfig: [
+    [".sf-circle-icon--secondary", "change color to dark"],
+    [".sf-ciricle-button--small", "change size, color and hover / active state"]
+  ]
+};
 
 storiesOf("Atoms|CircleIcon", module)
   .addDecorator(withKnobs)
@@ -32,9 +70,10 @@ storiesOf("Atoms|CircleIcon", module)
         <p>Rounded button with icon as content.</p>
         <h2> Usage </h2>
         <pre><code>import SfCircleIcon from "@storefrontui/vue/dist/SfCircleIcon.vue"</code></pre>
+        ${generateStorybookTable(scssTableConfig, "SCSS variables")}
+        ${generateStorybookTable(cssTableConfig, "CSS modifiers")}
         `
-      },
-      notes
+      }
     }
   )
   .add(
@@ -47,7 +86,6 @@ storiesOf("Atoms|CircleIcon", module)
       info: {
         summary:
           "Use this slot if passing image source is not enough for you (e.g. you want to inline SVG icon). Slot content will replace the default icon."
-      },
-      notes
+      }
     }
   );

--- a/packages/vue/src/components/atoms/SfPrice/SfPrice.stories.js
+++ b/packages/vue/src/components/atoms/SfPrice/SfPrice.stories.js
@@ -1,9 +1,24 @@
 /* eslint-disable import/no-extraneous-dependencies */
 import { storiesOf } from "@storybook/vue";
 import { withKnobs, text } from "@storybook/addon-knobs";
-import notes from "./README.md";
+import { generateStorybookTable } from "@/helpers";
 import SfPrice from "./SfPrice.vue";
 
+const scssTableConfig = {
+  tableHeadConfig: ["NAME", "DEFAULT", "DESCRIPTION"],
+  tableBodyConfig: [
+    [
+      "$price-desktop-font-size",
+      "$font-size-regular-desktop",
+      "font size (desktop)"
+    ],
+    [
+      "$price-mobile-font-size",
+      "$font-size-regular-mobile",
+      "font size (mobile)"
+    ]
+  ]
+};
 storiesOf("Atoms|Price", module)
   .addDecorator(withKnobs)
   .add(
@@ -26,8 +41,8 @@ storiesOf("Atoms|Price", module)
         summary: `<p>Component for displaying product price.</p>
         <h2> Usage </h2>
         <pre><code>import SfPrice from "@storefrontui/vue/dist/SfPrice.vue"</code></pre>
+        ${generateStorybookTable(scssTableConfig, "SCSS variables")}
         `
-      },
-      notes
+      }
     }
   );

--- a/packages/vue/src/components/atoms/SfRating/SfRating.stories.js
+++ b/packages/vue/src/components/atoms/SfRating/SfRating.stories.js
@@ -1,8 +1,24 @@
 /* eslint-disable import/no-extraneous-dependencies */
 import { storiesOf } from "@storybook/vue";
 import { withKnobs, number, select } from "@storybook/addon-knobs";
-import notes from "./README.md";
+import { generateStorybookTable } from "@/helpers";
 import SfRating from "./SfRating.vue";
+
+const scssTableConfig = {
+  tableHeadConfig: ["NAME", "DEFAULT", "DESCRIPTION"],
+  tableBodyConfig: [
+    [
+      "$rating__icon-positive-fill",
+      "$c-green-primary",
+      "positive star icon color"
+    ],
+    [
+      "$rating__icon-negative-fill",
+      "$c-dark-primary",
+      "negative star icon color"
+    ]
+  ]
+};
 
 storiesOf("Atoms|Rating", module)
   .addDecorator(withKnobs)
@@ -23,9 +39,10 @@ storiesOf("Atoms|Rating", module)
     {
       info: {
         summary: `<h2> Usage </h2>
-        <pre><code>import SfRating from "@storefrontui/vue/dist/SfRating.vue"</code></pre>`
-      },
-      notes
+        <pre><code>import SfRating from "@storefrontui/vue/dist/SfRating.vue"</code></pre>
+        ${generateStorybookTable(scssTableConfig, "SCSS variables")}
+        `
+      }
     }
   )
   .add(
@@ -42,13 +59,12 @@ storiesOf("Atoms|Rating", module)
       components: { SfRating },
       template: `<SfRating :score="rating" :max="max">
         <template #icon-positive>
-          <img src="assets/storybook/cat_green.svg" height="14px" />    
+          <img src="assets/storybook/cat_green.svg" height="14px" />
         </template>
       </SfRating>`
     }),
     {
-      info: true,
-      notes
+      info: true
     }
   )
   .add(
@@ -70,7 +86,6 @@ storiesOf("Atoms|Rating", module)
     </SfRating>`
     }),
     {
-      info: true,
-      notes
+      info: true
     }
   );

--- a/packages/vue/src/components/molecules/SfGallery/SfGallery.js
+++ b/packages/vue/src/components/molecules/SfGallery/SfGallery.js
@@ -29,12 +29,12 @@ export default {
      */
     sliderOptions: {
       type: Object,
-      default () {
+      default() {
         return {
-          type: 'slider',
+          type: "slider",
           autoplay: false,
           rewind: false
-        }
+        };
       }
     }
   },
@@ -71,7 +71,7 @@ export default {
     this.glide = glide;
     // handle lazy load for big images with lozad
     // https://apoorv.pro/lozad.js/
-    const observer = lozad('.sf-gallery__big-image');
+    const observer = lozad(".sf-gallery__big-image");
     observer.observe();
   },
 

--- a/packages/vue/src/components/molecules/SfGallery/SfGallery.stories.js
+++ b/packages/vue/src/components/molecules/SfGallery/SfGallery.stories.js
@@ -1,7 +1,35 @@
 /* eslint-disable import/no-extraneous-dependencies */
 import { storiesOf } from "@storybook/vue";
 import { withKnobs, text, number, boolean } from "@storybook/addon-knobs";
+import { generateStorybookTable } from "@/helpers";
 import SfGallery from "./SfGallery.vue";
+
+const scssTableConfig = {
+  tableHeadConfig: ["NAME", "DEFAULT", "DESCRIPTION"],
+  tableBodyConfig: [
+    ["$pagination__list-padding", "1rem", "padding for paginated list"],
+    ["$gallery-flex-direction", "row", "flex direction for gallery"],
+    ["$gallery__nav-width", "100px", "minimum height for menu item"],
+    [
+      "$gallery__nav-margin",
+      "0 $spacing-extra-big 0 0",
+      "nav margin for gallery"
+    ],
+    [
+      "$gallery__item-margin-bottom",
+      "$spacing-medium",
+      "margin for gsllery item"
+    ],
+    ["$gallery__item-opacity", ".5", "opacity for gallery item"],
+    [
+      "$gallery__item-transition",
+      "opacity .15s linear",
+      "transistion for gallery item"
+    ],
+    ["$gallery__item-mobile-size", "10px", "size of gallery item on mobile"],
+    ["$gallery__stage-width", "400px", "width of gallery stage"]
+  ]
+};
 
 const data = () => {
   return {
@@ -93,6 +121,7 @@ storiesOf("Molecules|Gallery", module)
           </p>
           <h2> Usage </h2>
           <pre><code>import SfGallery from "@storefrontui/vue/dist/SfGallery.vue"</code></pre>
+          ${generateStorybookTable(scssTableConfig, "SCSS variables")}
           `
       }
     }


### PR DESCRIPTION
# Related issue
#123 

# Scope of work
I refactored the documentation for SCSS vars, CSS modifiers in the atoms folder by moving it to Storybook info tab and removing the README since it's redundant.

# Screenshots of visual changes
<img width="1440" alt="Screen Shot 2019-06-04 at 10 27 13 AM" src="https://user-images.githubusercontent.com/17781315/58867999-5aabfe80-86b3-11e9-82c1-64787cd1bf9d.png">
# Checklist

- [x] I followed [composition rules](https://github.com/DivanteLtd/storefront-ui/blob/master/docs/component-rules.md) for my component
- [x] I tested the component in most common device sizes (can be tested in Storybook [from viewport addon in the top menu](https://github.com/storybooks/storybook/tree/master/addons/viewport))
