### PR TITLE
[ Desktop ] Create SfTopBar

### DIFF
--- a/packages/vue/html.js
+++ b/packages/vue/html.js
@@ -28,6 +28,7 @@ import SfAccordion from "./dist/SfAccordion.html";
 import SfCarousel from "./dist/SfCarousel.html";
 import SfList from "./dist/SfList.html";
 import SfMegaMenu from "./dist/SfMegaMenu.html";
+import SfTopBar from './dist/SfTopBar.html';
 
 export {
   SfArrow,
@@ -56,5 +57,6 @@ export {
   SfAccordion,
   SfCarousel,
   SfList,
-  SfMegaMenu
+  SfMegaMenu,
+  SfTopBar
  };

--- a/packages/vue/index.js
+++ b/packages/vue/index.js
@@ -28,6 +28,7 @@ import SfAccordion from "./dist/SfAccordion.vue";
 import SfCarousel from "./dist/SfCarousel.vue";
 import SfList from "./dist/SfList.vue";
 import SfMegaMenu from "./dist/SfMegaMenu.vue";
+import SfTopBar from './dist/SfTopBar.vue';
 
 export {
   SfArrow,
@@ -56,5 +57,6 @@ export {
   SfAccordion,
   SfCarousel,
   SfList,
-  SfMegaMenu
+  SfMegaMenu,
+  SfTopBar
  };

--- a/packages/vue/js.js
+++ b/packages/vue/js.js
@@ -28,6 +28,7 @@ import SfAccordion from "./dist/SfAccordion.js";
 import SfCarousel from "./dist/SfCarousel.js";
 import SfList from "./dist/SfList.js";
 import SfMegaMenu from "./dist/SfMegaMenu.js";
+import SfTopBar from "./dist/SfTopBar.js";
 
 export {
   SfArrow,
@@ -56,5 +57,6 @@ export {
   SfAccordion,
   SfCarousel,
   SfList,
-  SfMegaMenu
- };
+  SfMegaMenu,
+  SfTopBar
+};

--- a/packages/vue/src/components/organisms/SfTopBar/SfTopBar.html
+++ b/packages/vue/src/components/organisms/SfTopBar/SfTopBar.html
@@ -1,9 +1,7 @@
 <div class="sf-topbar">
   <div class="sf-topbar__left">
     <!--@slot Custom left content-->
-    <slot name="left">
-
-    </slot>
+    <slot name="left"></slot>
   </div>
 
   <div class="sf-topbar__center">
@@ -11,10 +9,8 @@
     <slot></slot>
   </div>
 
-    <div class="sf-topbar__right">
-      <!--@slot Custom right content-->
-      <slot name="right">
-        <a href="">Help & FAQS</a>
-      </slot>
-    </div>
+  <div class="sf-topbar__right">
+    <!--@slot Custom right content-->
+    <slot name="right"></slot>
+  </div>
 </div>

--- a/packages/vue/src/components/organisms/SfTopBar/SfTopBar.html
+++ b/packages/vue/src/components/organisms/SfTopBar/SfTopBar.html
@@ -1,0 +1,20 @@
+<div class="sf-topbar">
+  <div class="sf-topbar__left">
+    <!--@slot Custom left content-->
+    <slot name="left">
+
+    </slot>
+  </div>
+
+  <div class="sf-topbar__center">
+    <!--@slot Custom center content-->
+    <slot></slot>
+  </div>
+
+    <div class="sf-topbar__right">
+      <!--@slot Custom right content-->
+      <slot name="right">
+        <a href="">Help & FAQS</a>
+      </slot>
+    </div>
+</div>

--- a/packages/vue/src/components/organisms/SfTopBar/SfTopBar.js
+++ b/packages/vue/src/components/organisms/SfTopBar/SfTopBar.js
@@ -1,0 +1,3 @@
+export default {
+  name: "SFTopBar"
+};

--- a/packages/vue/src/components/organisms/SfTopBar/SfTopBar.scss
+++ b/packages/vue/src/components/organisms/SfTopBar/SfTopBar.scss
@@ -1,6 +1,6 @@
 @import '../../../css/variables';
 
-$top-bar-height: 40px !default;
+$top-bar-height: 2.5rem !default;
 $top-bar-hidden-max-width: $desktop-min !default;
 $top-bar-background-color: $c-light-primary !default;
 $top-bar-horizontal-padding: $spacer-extra-big !default;

--- a/packages/vue/src/components/organisms/SfTopBar/SfTopBar.scss
+++ b/packages/vue/src/components/organisms/SfTopBar/SfTopBar.scss
@@ -1,11 +1,13 @@
 @import '../../../css/variables';
 
-$top-bar-background-color: $c-light-primary;
-$top-bar-horizontal-padding: $spacer-extra-big;
+$top-bar-height: 40px !default;
+$top-bar-hidden-max-width: $desktop-min !default;
+$top-bar-background-color: $c-light-primary !default;
+$top-bar-horizontal-padding: $spacer-extra-big !default;
 
 .sf-topbar {
   width: 100%;
-  height: 40px;
+  height: $top-bar-height;
 
   display: flex;
   align-items: center;
@@ -20,7 +22,7 @@ $top-bar-horizontal-padding: $spacer-extra-big;
   }
 }
 
-@media only screen and (max-width: $desktop-min) {
+@media only screen and (max-width: $top-bar-hidden-max-width) {
   .sf-topbar {
     display: none;
   }

--- a/packages/vue/src/components/organisms/SfTopBar/SfTopBar.scss
+++ b/packages/vue/src/components/organisms/SfTopBar/SfTopBar.scss
@@ -1,0 +1,27 @@
+@import '../../../css/variables';
+
+$top-bar-background-color: $c-light-primary;
+$top-bar-horizontal-padding: $spacer-extra-big;
+
+.sf-topbar {
+  width: 100%;
+  height: 40px;
+
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+
+  box-sizing: border-box;
+  padding: 0px $top-bar-horizontal-padding;
+  background-color: $top-bar-background-color;
+
+  &__center {
+    font-size: $font-size-small-desktop;
+  }
+}
+
+@media only screen and (max-width: $desktop-min) {
+  .sf-topbar {
+    display: none;
+  }
+}

--- a/packages/vue/src/components/organisms/SfTopBar/SfTopBar.spec.ts
+++ b/packages/vue/src/components/organisms/SfTopBar/SfTopBar.spec.ts
@@ -1,0 +1,36 @@
+import { shallowMount } from "@vue/test-utils";
+
+import SfTopBar from './SfTopBar.vue'
+
+describe("SfTopBar", () => {
+  it('renders a container element', () => {
+    const component = shallowMount(SfTopBar, {});
+    expect(component.contains('.sf-topbar')).toBe(true);
+  });
+
+  // Left slot check
+  it('renders left slot content when passed', () => {
+    const leftContent = 'LEFT__CONTENT'
+
+    const component = shallowMount(SfTopBar, {
+      slots: {
+        left: leftContent
+      }
+    });
+
+    expect(component.find('.sf-topbar__left').text()).toMatch(leftContent);
+  })
+
+    // Right slot check
+  it('renders right slot content when passed', () => {
+    const rightContent = 'RIGHT__CONTENT'
+
+    const component = shallowMount(SfTopBar, {
+      slots: {
+        right: rightContent
+      }
+    });
+
+    expect(component.find('.sf-topbar__right').text()).toMatch(rightContent);
+  })
+});

--- a/packages/vue/src/components/organisms/SfTopBar/SfTopBar.stories.js
+++ b/packages/vue/src/components/organisms/SfTopBar/SfTopBar.stories.js
@@ -1,6 +1,5 @@
 /* eslint-disable import/no-extraneous-dependencies */
 import { storiesOf } from "@storybook/vue";
-import { withKnobs, text, select } from "@storybook/addon-knobs";
 
 import SfTopBar from "./SfTopBar.vue";
 

--- a/packages/vue/src/components/organisms/SfTopBar/SfTopBar.stories.js
+++ b/packages/vue/src/components/organisms/SfTopBar/SfTopBar.stories.js
@@ -1,0 +1,61 @@
+/* eslint-disable import/no-extraneous-dependencies */
+import { storiesOf } from "@storybook/vue";
+import { withKnobs, text, select } from "@storybook/addon-knobs";
+
+import SfTopBar from "./SfTopBar.vue";
+
+storiesOf("Organisms|TopBar", module)
+  .add(
+    "Basic",
+    () => ({
+      data() {
+        return {
+          style: {
+            textDecoration: "underline"
+          }
+        };
+      },
+      template:
+        "<sf-top-bar>Download our application.<a :style='style'>Find out more.</a></sf-top-bar>",
+      components: {
+        SfTopBar
+      }
+    }),
+    {
+      info: {
+        summary: "<p>Component for displaying Topbar</p>"
+      }
+    }
+  )
+  .add(
+    "[slot] left",
+    () => ({
+      template: `
+    <sf-top-bar>
+      <template slot="left">left content</template>
+    </sf-top-bar>
+    `,
+      components: {
+        SfTopBar
+      }
+    }),
+    {
+      info: true
+    }
+  )
+  .add(
+    "[slot] right",
+    () => ({
+      template: `
+    <sf-top-bar>
+      <template slot="right">right content</template>
+    </sf-top-bar>
+    `,
+      components: {
+        SfTopBar
+      }
+    }),
+    {
+      info: true
+    }
+  );

--- a/packages/vue/src/components/organisms/SfTopBar/SfTopBar.vue
+++ b/packages/vue/src/components/organisms/SfTopBar/SfTopBar.vue
@@ -1,0 +1,3 @@
+<script src="./SfTopBar.js"></script>
+<template lang="html" src="./SfTopBar.html"></template>
+<style lang="scss" src="./SfTopBar.scss"></style>


### PR DESCRIPTION
# Related issue
<!-- paste a link to related issue -->
https://github.com/DivanteLtd/storefront-ui/issues/139
# Scope of work
<!-- describe what you did -->
- Added the `SfTopBar` component, with tests, styles and stories.
- TopBar is hidden on screens less than `$desktop-min`
- TopBar uses three slots: `default` customises center content, `left` customises `left` content and `right` customises `right` content

# Screenshots of visual changes
![Screen Shot 2019-06-07 at 11 14 15 PM](https://user-images.githubusercontent.com/19477966/59136237-1b630380-897a-11e9-985e-cc301b0b1a70.png)

# Checklist

- [x] I followed [composition rules](https://github.com/DivanteLtd/storefront-ui/blob/master/docs/component-rules.md) for my component
- [x] I tested the component in most common device sizes (can be tested in Storybook [from viewport addon in top menu](https://github.com/storybooks/storybook/tree/master/addons/viewport))
