### PR TITLE
 #170 [ Desktop / Mobile ] implement SfDivider

### DIFF
--- a/packages/shared/styles/components/SfDivider.scss
+++ b/packages/shared/styles/components/SfDivider.scss
@@ -1,0 +1,7 @@
+@import '../variables';
+
+$divider__color: $c-light-primary;
+
+.sf-divider {
+    border-top: 1px solid $c-light-primary;
+}

--- a/packages/vue/src/components/atoms/SfDivider/SfDivider.html
+++ b/packages/vue/src/components/atoms/SfDivider/SfDivider.html
@@ -1,0 +1,2 @@
+<hr class="sf-divider" />
+

--- a/packages/vue/src/components/atoms/SfDivider/SfDivider.js
+++ b/packages/vue/src/components/atoms/SfDivider/SfDivider.js
@@ -1,0 +1,3 @@
+export default {
+  name: "SfDivider"
+};

--- a/packages/vue/src/components/atoms/SfDivider/SfDivider.spec.ts
+++ b/packages/vue/src/components/atoms/SfDivider/SfDivider.spec.ts
@@ -1,0 +1,9 @@
+import { shallowMount } from "@vue/test-utils";
+import SfDivider from "@/components/atoms/SfDivider.vue";
+
+describe("SfDivider.vue", () => {
+  it("renders a component", () => {
+    const component = shallowMount(SfDivider);
+    expect(component.contains(".sf-divider")).toBe(true);
+  });
+});

--- a/packages/vue/src/components/atoms/SfDivider/SfDivider.stories.js
+++ b/packages/vue/src/components/atoms/SfDivider/SfDivider.stories.js
@@ -1,0 +1,32 @@
+// /* eslint-disable import/no-extraneous-dependencies */
+import { storiesOf } from "@storybook/vue";
+import { withKnobs, text, select } from "@storybook/addon-knobs";
+import { generateStorybookTable } from "@/helpers";
+
+import SfDivider from "./SfDivider.vue";
+
+// use this to document scss vars
+const scssTableConfig = {
+  tableHeadConfig: ["NAME", "DEFAULT", "DESCRIPTION"],
+  tableBodyConfig: [
+    ["$divider__color", "$c-light-primary", "Divider line color"],
+  ]
+};
+
+storiesOf("Atoms|Divider", module)
+  .addDecorator(withKnobs)
+  .add(
+    "Basic",
+    () => ({
+      components: { SfDivider },
+      template: `<SfDivider />`
+    }),
+    {
+     info: {
+       summary: `<p>Divider element.</p>
+       <h2>Usage</h2>
+       <pre><code>import SfDivider from "@storefrontui/vue/dist/SfDivider.vue"</code></pre>
+       ${generateStorybookTable(scssTableConfig, "SCSS variables")}`
+     }
+   }
+);

--- a/packages/vue/src/components/atoms/SfDivider/SfDivider.vue
+++ b/packages/vue/src/components/atoms/SfDivider/SfDivider.vue
@@ -1,5 +1,5 @@
 <script src="./SfDivider.js"></script>
-<template lang="html" src="./SfDivider.html"></template>
+<template functional lang="html" src="./SfDivider.html"></template>
 <style lang="scss">
 @import "~@storefrontui/shared/styles/components/SfDivider.scss";
 </style>

--- a/packages/vue/src/components/atoms/SfDivider/SfDivider.vue
+++ b/packages/vue/src/components/atoms/SfDivider/SfDivider.vue
@@ -1,0 +1,5 @@
+<script src="./SfDivider.js"></script>
+<template lang="html" src="./SfDivider.html"></template>
+<style lang="scss">
+@import "~@storefrontui/shared/styles/components/SfDivider.scss";
+</style>


### PR DESCRIPTION
# Related issue
#170 

# Scope of work
Create divider component.

# Screenshots of visual changes
<img width="1268" alt="Schermata 2019-06-19 alle 10 46 02" src="https://user-images.githubusercontent.com/3791799/59750702-7f8d9d80-927f-11e9-9b00-6a876c0a1f76.png">

# Checklist

- [X] I followed [composition rules](https://github.com/DivanteLtd/storefront-ui/blob/master/docs/component-rules.md) for my component
- [X] I tested the component in most common device sizes (can be tested in Storybook [from viewport addon in top menu](https://github.com/storybooks/storybook/tree/master/addons/viewport))
