### PR TITLE
ref. #152 improve create-component after monorepo

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
   },
   "homepage": "https://github.com/DivanteLtd/storefront-ui#readme",
   "dependencies": {
-    "lerna": "^3.0.0-rc.0"
+    "lerna": "^3.0.0-rc.0",
+    "prompts": "^2.1.0"
   },
   "workspaces": [
     "packages/*"

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "create-component": "node ./scripts/create-component.js"
   },
   "repository": {
     "type": "git",

--- a/packages/vue/scripts/component-template/component.html
+++ b/packages/vue/scripts/component-template/component.html
@@ -1,0 +1,1 @@
+<div class="ComponentNameKebabCase"></div>

--- a/packages/vue/scripts/component-template/component.js
+++ b/packages/vue/scripts/component-template/component.js
@@ -1,0 +1,3 @@
+export default {
+  name: "ComponentNameCamelCase"
+};

--- a/packages/vue/scripts/component-template/component.spec.ts
+++ b/packages/vue/scripts/component-template/component.spec.ts
@@ -1,0 +1,9 @@
+import { shallowMount } from "@vue/test-utils";
+import ComponentNameCamelCase from "@/components/ComponentFolder/ComponentNameCamelCase.vue";
+
+describe("ComponentNameCamelCase.vue", () => {
+  it("renders a component", () => {
+    const component = shallowMount(ComponentNameCamelCase);
+    expect(component.contains(".ComponentNameKebabCase")).toBe(true);
+  });
+});

--- a/packages/vue/scripts/component-template/component.stories.js
+++ b/packages/vue/scripts/component-template/component.stories.js
@@ -1,0 +1,53 @@
+// /* eslint-disable import/no-extraneous-dependencies */
+import { storiesOf } from "@storybook/vue";
+import { withKnobs, text, select } from "@storybook/addon-knobs";
+import { generateStorybookTable } from "@/helpers";
+
+import ComponentNameCamelCase from "./ComponentNameCamelCase.vue";
+
+// use this to document scss vars
+const scssTableConfig = {
+  tableHeadConfig: ["NAME", "DEFAULT", "DESCRIPTION"],
+  tableBodyConfig: [["$component-size", "1.438rem", "size of checkmark"]]
+};
+
+// use this to document events
+const eventsTableConfig = {
+  tableHeadConfig: ["NAME", "DESCRIPTION"],
+  tableBodyConfig: [["input", "event emited when option is selected"]]
+};
+
+// storiesOf("ComponentType|ComponentName", module)
+//   .addDecorator(withKnobs)
+//   .add(
+//     "[slot] default",
+//     () => ({
+//       props: {
+//         editableProp: {
+//           default: text("(prop) propname")
+//         },
+//         customClass: {
+//           default: select(
+//             "CSS Modifier",
+//             ["null", "ComponentNameKebabCase--modifier"],
+//             "null",
+//             "CSS-Modifiers"
+//           )
+//         }
+//       },
+//       components: { ComponentNameCamelCase },
+//       template: `<ComponentNameCamelCase
+//         :class="customClass"
+//       >
+//       </ComponentNameCamelCase>`
+//     }),
+//     {
+//       info: {
+//         summary: `<p>Component description.</p>
+//        <h2>Usage</h2>
+//        <pre><code>import { ComponentNameCamelCase } from "@storefrontui/vue"</code></pre>
+//        ${generateStorybookTable(scssTableConfig, "SCSS variables")}
+//        ${generateStorybookTable(eventsTableConfig, "Events")}`
+//       }
+//     }
+//   );

--- a/packages/vue/scripts/component-template/component.vue
+++ b/packages/vue/scripts/component-template/component.vue
@@ -1,0 +1,5 @@
+<script src="./ComponentNameCamelCase.js"></script>
+<template lang="html" src="./ComponentNameCamelCase.html"></template>
+<style lang="scss">
+@import "~@storefrontui/shared/styles/components/ComponentNameCamelCase.scss";
+</style>

--- a/packages/vue/scripts/create-component.js
+++ b/packages/vue/scripts/create-component.js
@@ -14,7 +14,9 @@ const glob = require("glob");
 const ATOMIC_TYPE = ["atoms", "molecules", "organisms"];
 
 if (process.argv.length < 4) {
-  console.warn("Please input atomic type and component name");
+  console.warn(
+    "Please input atomic type and component name:\n\n\nyarn create-component <type> <name>\n\n"
+  );
   process.exit(-1);
 }
 
@@ -27,6 +29,7 @@ function createComponent(folder, componentName) {
     );
     process.exit(-1);
   }
+  const ComponentType = uppercamelcase(folder);
   const ComponentName = uppercamelcase(componentName);
   const PrefixComponentName = ComponentName.startsWith("Sf")
     ? ComponentName
@@ -35,6 +38,10 @@ function createComponent(folder, componentName) {
     __dirname,
     `../src/components/${folder}`,
     `${PrefixComponentName}`
+  );
+  const SharedFilesPath = path.resolve(
+    __dirname,
+    `../../shared/styles/components`
   );
   const joinedComponentName =
     "sf" +
@@ -59,6 +66,7 @@ function createComponent(folder, componentName) {
     },
     {
       fileName: `${PrefixComponentName}.scss`,
+      filePath: SharedFilesPath,
       content: `@import '../variables';
 
 // $component__block-property: value;
@@ -109,7 +117,7 @@ const eventsTableConfig = {
   ]
 };
 
-// storiesOf("${PrefixComponentName}", module)
+// storiesOf("${ComponentType}|${ComponentName}", module)
 //   .addDecorator(withKnobs)
 //   .add(
 //     "[slot] default",
@@ -149,12 +157,14 @@ const eventsTableConfig = {
       fileName: `${PrefixComponentName}.vue`,
       content: `<script src="./${PrefixComponentName}.js"></script>
 <template lang="html" src="./${PrefixComponentName}.html"></template>
-<style lang="scss" src="./${PrefixComponentName}.scss"></style>`
+<style lang="scss">
+@import "~@storefrontui/shared/styles/components/${PrefixComponentName}.scss";
+</style>`
     }
   ];
 
   files.forEach(file => {
-    fileSave(path.join(PackagePath, file.fileName))
+    fileSave(path.join(file.filePath || PackagePath, file.fileName))
       .write(file.content, "utf8")
       .end("\n");
   });

--- a/scripts/create-component.js
+++ b/scripts/create-component.js
@@ -13,9 +13,16 @@ const uppercamelcase = require("uppercamelcase");
 const glob = require("glob");
 const prompts = require("prompts");
 
+const PACKAGE_TYPE = ["vue"]; // @todo: before adding new framework ensure you also generate the correct files for that (ie. component.vue)
 const ATOMIC_TYPE = ["atoms", "molecules", "organisms"];
 
 const questions = [
+  {
+    type: "select",
+    name: "framework",
+    message: "Which framework do you want to create the component with?",
+    choices: PACKAGE_TYPE
+  },
   {
     type: "select",
     name: "component",
@@ -34,25 +41,26 @@ const questions = [
 (async () => {
   const response = await prompts(questions);
 
+  const framework = PACKAGE_TYPE[response.framework];
   const component = ATOMIC_TYPE[response.component];
   const name = response.name;
 
-  createComponent(component, name);
+  createComponent(framework, component, name);
 
-  function createComponent(folder, componentName) {
-    const ComponentType = uppercamelcase(folder);
+  function createComponent(packageFolder, componentFolder, componentName) {
+    const ComponentType = uppercamelcase(componentFolder);
     const ComponentName = uppercamelcase(componentName);
     const PrefixComponentName = ComponentName.startsWith("Sf")
       ? ComponentName
       : "Sf" + ComponentName;
     const PackagePath = path.resolve(
       __dirname,
-      `../src/components/${folder}`,
+      `../packages/${packageFolder}/src/components/${componentFolder}`,
       `${PrefixComponentName}`
     );
     const SharedFilesPath = path.resolve(
       __dirname,
-      `../../shared/styles/components`
+      `../packages/shared/styles/components`
     );
     const joinedComponentName =
       "sf" +
@@ -97,7 +105,7 @@ const questions = [
       {
         fileName: `${PrefixComponentName}.spec.ts`,
         content: `import { shallowMount } from "@vue/test-utils";
-import ${PrefixComponentName} from "@/components/${folder}/${PrefixComponentName}.vue";
+import ${PrefixComponentName} from "@/components/${componentFolder}/${PrefixComponentName}.vue";
 
 describe("${PrefixComponentName}.vue", () => {
   it("renders a component", () => {

--- a/scripts/create-component.js
+++ b/scripts/create-component.js
@@ -1,7 +1,7 @@
 "use strict";
 process.on("exit", code => {
   if (code === 0) {
-    console.log(`New component is created successfully.`);
+    console.log(`\n\nNew component created successfully. Refresh your files tree, if you can't see the new files :)\n\n`);
   }
 });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -9408,6 +9408,10 @@ kleur@^2.0.1:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/kleur/-/kleur-2.0.2.tgz#b704f4944d95e255d038f0cb05fb8a602c55a300"
 
+kleur@^3.0.2:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/kleur/-/kleur-3.0.3.tgz#a79c9ecc86ee1ce3fa6206d1216c501f147fc07e"
+
 koa-compose@^3.0.0, koa-compose@^3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/koa-compose/-/koa-compose-3.2.1.tgz#a85ccb40b7d986d8e5a345b3a1ace8eabcf54de7"
@@ -12109,6 +12113,13 @@ prompts@^0.1.9:
     kleur "^2.0.1"
     sisteransi "^0.1.1"
 
+prompts@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/prompts/-/prompts-2.1.0.tgz#bf90bc71f6065d255ea2bdc0fe6520485c1b45db"
+  dependencies:
+    kleur "^3.0.2"
+    sisteransi "^1.0.0"
+
 promzard@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/promzard/-/promzard-0.3.0.tgz#26a5d6ee8c7dee4cb12208305acfb93ba382a9ee"
@@ -13512,6 +13523,10 @@ simplebar@^4.0.0:
 sisteransi@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/sisteransi/-/sisteransi-0.1.1.tgz#5431447d5f7d1675aac667ccd0b865a4994cb3ce"
+
+sisteransi@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/sisteransi/-/sisteransi-1.0.0.tgz#77d9622ff909080f1c19e5f4a1df0c1b0a27b88c"
 
 slash@^1.0.0:
   version "1.0.0"
@@ -15149,7 +15164,6 @@ webpack-dev-middleware@3.6.0, webpack-dev-middleware@^3.0.0:
 webpack-dev-middleware@^3.7.0:
   version "3.7.0"
   resolved "https://registry.yarnpkg.com/webpack-dev-middleware/-/webpack-dev-middleware-3.7.0.tgz#ef751d25f4e9a5c8a35da600c5fda3582b5c6cff"
-  integrity sha512-qvDesR1QZRIAZHOE3iQ4CXLZZSQ1lAUsSpnQmlB1PBfoN/xdRjmge3Dok0W4IdaVLJOGJy3sGI4sZHwjRU0PCA==
   dependencies:
     memory-fs "^0.4.1"
     mime "^2.4.2"


### PR DESCRIPTION
# Related issue
#152

# Scope of work
I fixed the path where the scss must be created. The script was already into packages/vue and must run from here to use it.

# Screenshots of visual changes

# Checklist

- [x] I followed [composition rules](https://github.com/DivanteLtd/storefront-ui/blob/master/docs/component-rules.md) for my component
- [x] I tested the component in most common device sizes (can be tested in Storybook [from viewport addon in top menu](https://github.com/storybooks/storybook/tree/master/addons/viewport))
