### PR TITLE
Fix prettier warnings in sfDivider

### DIFF
--- a/packages/vue/src/components/atoms/SfDivider/SfDivider.stories.js
+++ b/packages/vue/src/components/atoms/SfDivider/SfDivider.stories.js
@@ -9,7 +9,7 @@ import SfDivider from "./SfDivider.vue";
 const scssTableConfig = {
   tableHeadConfig: ["NAME", "DEFAULT", "DESCRIPTION"],
   tableBodyConfig: [
-    ["$divider__color", "$c-light-primary", "Divider line color"],
+    ["$divider__color", "$c-light-primary", "Divider line color"]
   ]
 };
 
@@ -22,11 +22,11 @@ storiesOf("Atoms|Divider", module)
       template: `<SfDivider />`
     }),
     {
-     info: {
-       summary: `<p>Divider element.</p>
+      info: {
+        summary: `<p>Divider element.</p>
        <h2>Usage</h2>
        <pre><code>import SfDivider from "@storefrontui/vue/dist/SfDivider.vue"</code></pre>
        ${generateStorybookTable(scssTableConfig, "SCSS variables")}`
-     }
-   }
-);
+      }
+    }
+  );


### PR DESCRIPTION
# Related issue
#214

# Scope of work
Fix prettier warnings. 


# Checklist

- [x] I followed [composition rules](https://github.com/DivanteLtd/storefront-ui/blob/master/docs/component-rules.md) for my component
- [x] I tested the component in most common device sizes (can be tested in Storybook [from viewport addon in top menu](https://github.com/storybooks/storybook/tree/master/addons/viewport))
