### PR TITLE
#158 docs update import script in storybook

### DIFF
--- a/packages/vue/config/storybook/home/home.js
+++ b/packages/vue/config/storybook/home/home.js
@@ -36,7 +36,7 @@ storiesOf(" |Introduction", module)
           <pre>import "@storefrontui/vue/dist/css/all.scss";</pre>
         </li>
         <li> It's done! Now you can import and use any of the components: 
-          <pre> import { SfComponentName } from "@storefrontui/vue/dist/SfComponentName.vue"</pre>
+          <pre> import { SfComponentName } from "@storefrontui/vue"</pre>
         </li>
         <li> You can find detailed information about every component inside each component's story. </li>
       </ol>

--- a/packages/vue/src/components/atoms/SfArrow/SfArrow.stories.js
+++ b/packages/vue/src/components/atoms/SfArrow/SfArrow.stories.js
@@ -65,7 +65,7 @@ storiesOf("Atoms|Arrow", module)
     {
       info: {
         summary: `<h2> Usage </h2>
-        <pre><code>import SfArrow from "@storefrontui/vue/dist/SfArrow.vue"</code></pre>
+        <pre><code>import { SfArrow } from "@storefrontui/vue"</code></pre>
         ${generateStorybookTable(scssTableConfig, "SCSS variables")}
         ${generateStorybookTable(cssTableConfig, "CSS modifiers")}
         `

--- a/packages/vue/src/components/atoms/SfBadge/SfBadge.stories.js
+++ b/packages/vue/src/components/atoms/SfBadge/SfBadge.stories.js
@@ -57,7 +57,7 @@ storiesOf("Atoms|Badge", module)
         <h2> Description </h2>
         <p>Badge component. Place desired content into its default slot.</p>
         <h2> Usage </h2>
-        <pre><code>import SfBadge from "@storefrontui/vue/dist/SfBadge.vue"</code></pre>
+        <pre><code>import { SfBadge } from "@storefrontui/vue"</code></pre>
         ${generateStorybookTable(scssTableConfig, "SCSS variables")}
         ${generateStorybookTable(cssTableConfig, "CSS modifiers")}
         `

--- a/packages/vue/src/components/atoms/SfBreadcrumbs/SfBreadcrumbs.stories.js
+++ b/packages/vue/src/components/atoms/SfBreadcrumbs/SfBreadcrumbs.stories.js
@@ -108,7 +108,7 @@ storiesOf("Atoms|Breadcrumbs", module)
           on breadcrumbs nav.
         </p>
         <h2>Usage</h2>
-        <pre><code>import SfBreadcrumbs from "@storefrontui/vue/dist/SfBreadcrumbs.vue"</code></pre>
+        <pre><code>import { SfBreadcrumbs } from "@storefrontui/vue"</code></pre>
         ${generateStorybookTable(scssTableConfig, "SCSS variables")}
         `
       }

--- a/packages/vue/src/components/atoms/SfButton/SfButton.stories.js
+++ b/packages/vue/src/components/atoms/SfButton/SfButton.stories.js
@@ -29,7 +29,7 @@ storiesOf("Atoms|Button", module)
         <h2> Description </h2>
         <p>Button component. Place desired content into its default slot.</p>
         <h2> Usage </h2>
-        <pre><code>import SfButton from "@storefrontui/vue/dist/SfButton.vue"</code></pre>
+        <pre><code>import { SfButton } from "@storefrontui/vue"</code></pre>
         `
       }
     }

--- a/packages/vue/src/components/atoms/SfCheckbox/SfCheckbox.stories.js
+++ b/packages/vue/src/components/atoms/SfCheckbox/SfCheckbox.stories.js
@@ -61,7 +61,7 @@ export default storiesOf("Atoms|Checkbox", module)
             to fill label content.
           </p>
           <h2> Usage </h2>
-          <pre><code>import SfCheckbox from "@storefrontui/vue/dist/SfCheckbox.vue"</code></pre>
+          <pre><code>import { SfCheckbox } from "@storefrontui/vue"</code></pre>
           `
       }
     }

--- a/packages/vue/src/components/atoms/SfCircleIcon/SfCircleIcon.stories.js
+++ b/packages/vue/src/components/atoms/SfCircleIcon/SfCircleIcon.stories.js
@@ -69,7 +69,7 @@ storiesOf("Atoms|CircleIcon", module)
         summary: `
         <p>Rounded button with icon as content.</p>
         <h2> Usage </h2>
-        <pre><code>import SfCircleIcon from "@storefrontui/vue/dist/SfCircleIcon.vue"</code></pre>
+        <pre><code>import { SfCircleIcon } from "@storefrontui/vue"</code></pre>
         ${generateStorybookTable(scssTableConfig, "SCSS variables")}
         ${generateStorybookTable(cssTableConfig, "CSS modifiers")}
         `

--- a/packages/vue/src/components/atoms/SfDivider/SfDivider.stories.js
+++ b/packages/vue/src/components/atoms/SfDivider/SfDivider.stories.js
@@ -25,7 +25,7 @@ storiesOf("Atoms|Divider", module)
      info: {
        summary: `<p>Divider element.</p>
        <h2>Usage</h2>
-       <pre><code>import SfDivider from "@storefrontui/vue/dist/SfDivider.vue"</code></pre>
+       <pre><code>import { SfDivider } from "@storefrontui/vue"</code></pre>
        ${generateStorybookTable(scssTableConfig, "SCSS variables")}`
      }
    }

--- a/packages/vue/src/components/atoms/SfHeading/SfHeading.stories.js
+++ b/packages/vue/src/components/atoms/SfHeading/SfHeading.stories.js
@@ -76,7 +76,7 @@ storiesOf("Atoms|Heading", module)
     {
       info: {
         summary: `<h2>Usage</h2>
-       <pre><code>import SfHeading from "@storefrontui/vue/dist/SfHeading.vue"</code></pre>
+       <pre><code>import { SfHeading } from "@storefrontui/vue"</code></pre>
        ${generateStorybookTable(scssTableConfig, "SCSS variables")}
        ${generateStorybookTable(cssTableConfig, "CSS modifiers")}
        `

--- a/packages/vue/src/components/atoms/SfIcon/SfIcon.stories.js
+++ b/packages/vue/src/components/atoms/SfIcon/SfIcon.stories.js
@@ -91,7 +91,7 @@ storiesOf("Atoms|Icon", module)
         summary: `
         <p>Component for rendering SVG path as icon.</p>
         <h2> Usage </h2>
-        <pre><code>import SfIcon from "@storefrontui/vue/dist/SfIcon.vue"</code></pre>
+        <pre><code>import { SfIcon } from "@storefrontui/vue"</code></pre>
         <h3>SCSS variables</h3>
         ${generateStorybookTable(
           {

--- a/packages/vue/src/components/atoms/SfLoader/SfLoader.stories.js
+++ b/packages/vue/src/components/atoms/SfLoader/SfLoader.stories.js
@@ -40,7 +40,7 @@ storiesOf("Atoms|Loader", module)
       info: {
         summary: `<p>Component to indicate loading state. Use it to cover content until data is fetched. Set **isLoading** to false once data is fetched.</p>
         <h2> Usage </h2>
-        <pre><code>import SfLoader from "@storefrontui/vue/dist/SfLoader.vue"</code></pre>
+        <pre><code>import { SfLoader } from "@storefrontui/vue"</code></pre>
         ${generateStorybookTable(scssTableConfig, "SCSS variables")}
         `
       }

--- a/packages/vue/src/components/atoms/SfPrice/SfPrice.stories.js
+++ b/packages/vue/src/components/atoms/SfPrice/SfPrice.stories.js
@@ -40,7 +40,7 @@ storiesOf("Atoms|Price", module)
       info: {
         summary: `<p>Component for displaying product price.</p>
         <h2> Usage </h2>
-        <pre><code>import SfPrice from "@storefrontui/vue/dist/SfPrice.vue"</code></pre>
+        <pre><code>import { SfPrice } from "@storefrontui/vue"</code></pre>
         ${generateStorybookTable(scssTableConfig, "SCSS variables")}
         `
       }

--- a/packages/vue/src/components/atoms/SfProperty/SfProperty.stories.js
+++ b/packages/vue/src/components/atoms/SfProperty/SfProperty.stories.js
@@ -29,7 +29,7 @@ export default storiesOf("Atoms|Property", module)
       info: {
         summary: `<p>Simple label and data component created for product description</p>
         <h2> Usage </h2>
-        <pre><code>import SfProperty from "@storefrontui/vue/dist/SfProperty.vue"</code></pre>`
+        <pre><code>import { SfProperty } from "from "@storefrontui/vue"</code></pre>`
       }
     }
   );

--- a/packages/vue/src/components/atoms/SfProperty/SfProperty.stories.js
+++ b/packages/vue/src/components/atoms/SfProperty/SfProperty.stories.js
@@ -29,7 +29,7 @@ export default storiesOf("Atoms|Property", module)
       info: {
         summary: `<p>Simple label and data component created for product description</p>
         <h2> Usage </h2>
-        <pre><code>import { SfProperty } from "from "@storefrontui/vue"</code></pre>`
+        <pre><code>import { SfProperty } from "@storefrontui/vue"</code></pre>`
       }
     }
   );

--- a/packages/vue/src/components/atoms/SfRating/SfRating.stories.js
+++ b/packages/vue/src/components/atoms/SfRating/SfRating.stories.js
@@ -39,7 +39,7 @@ storiesOf("Atoms|Rating", module)
     {
       info: {
         summary: `<h2> Usage </h2>
-        <pre><code>import SfRating from "@storefrontui/vue/dist/SfRating.vue"</code></pre>
+        <pre><code>import { SfRating } from "@storefrontui/vue"</code></pre>
         ${generateStorybookTable(scssTableConfig, "SCSS variables")}
         `
       }

--- a/packages/vue/src/components/molecules/SfAlert/SfAlert.stories.js
+++ b/packages/vue/src/components/molecules/SfAlert/SfAlert.stories.js
@@ -74,7 +74,7 @@ storiesOf("Molecules|Alert", module)
     {
       info: {
         summary: `<h2> Usage </h2>
-        <pre><code>import SfAlert from "@storefrontui/vue/dist/SfAlert.vue"</code></pre>
+        <pre><code>import { SfAlert } from "@storefrontui/vue"</code></pre>
         ${generateStorybookTable(scssTableConfig, "SCSS variables")}
         ${generateStorybookTable(cssTableConfig, "CSS modifiers")}
         `

--- a/packages/vue/src/components/molecules/SfBanner/SfBanner.stories.js
+++ b/packages/vue/src/components/molecules/SfBanner/SfBanner.stories.js
@@ -128,7 +128,7 @@ storiesOf("Molecules|Banner", module)
     {
       info: {
         summary: `<h2> Usage </h2>
-        <pre><code>import SfBanner from "@storefrontui/vue/dist/SfBanner.vue"</code></pre>
+        <pre><code>import { SfBanner } from "@storefrontui/vue"</code></pre>
         ${generateStorybookTable(scssTableConfig, "SCSS variables")}
         ${generateStorybookTable(cssTableConfig, "CSS modifiers")}
         `

--- a/packages/vue/src/components/molecules/SfCallToAction/SfCallToAction.stories.js
+++ b/packages/vue/src/components/molecules/SfCallToAction/SfCallToAction.stories.js
@@ -45,7 +45,7 @@ storiesOf("Molecules|CallToAction", module)
     {
       info: {
         summary: `<h2> Usage </h2>
-        <pre><code>import SfCallToAction from "@storefrontui/vue/dist/SfCallToAction.vue"</code></pre>`
+        <pre><code>import { SfCallToAction } from "@storefrontui/vue"</code></pre>`
       }
     }
   )

--- a/packages/vue/src/components/molecules/SfCounter/SfCounter.stories.js
+++ b/packages/vue/src/components/molecules/SfCounter/SfCounter.stories.js
@@ -115,7 +115,7 @@ storiesOf("Molecules|Counter", module)
     {
       info: {
         summary: `<h2> Usage </h2>
-        <pre><code>import SfCounter from "@storefrontui/vue/dist/SfCounter.vue"</code></pre>
+        <pre><code>import { SfCounter } from "@storefrontui/vue"</code></pre>
         ${generateStorybookTable(scssTableConfig, "SCSS variables")}
         ${generateStorybookTable(cssTableConfig, "CSS modifiers")}
         ${generateStorybookTable(eventTableConfig, "Events")}

--- a/packages/vue/src/components/molecules/SfFilter/SfFilter.stories.js
+++ b/packages/vue/src/components/molecules/SfFilter/SfFilter.stories.js
@@ -97,7 +97,7 @@ export default storiesOf("Molecules|Filter", module)
             <li> color - (optional) color that will be displayed in a box on the left side (all valid CSS colors can be passed)</li>
           </ul>
           <h2> Usage </h2>
-          <pre><code>import SfFilter from "@storefrontui/vue/dist/SfFilter.vue"</code></pre>
+          <pre><code>import { SfFilter } from "@storefrontui/vue"</code></pre>
           ${generateStorybookTable(scssTableConfig, "SCSS variables")}
           `
       }

--- a/packages/vue/src/components/molecules/SfGallery/SfGallery.stories.js
+++ b/packages/vue/src/components/molecules/SfGallery/SfGallery.stories.js
@@ -120,7 +120,7 @@ storiesOf("Molecules|Gallery", module)
             </code>
           </p>
           <h2> Usage </h2>
-          <pre><code>import SfGallery from "@storefrontui/vue/dist/SfGallery.vue"</code></pre>
+          <pre><code>import { SfGallery } from "@storefrontui/vue"</code></pre>
           ${generateStorybookTable(scssTableConfig, "SCSS variables")}
           `
       }

--- a/packages/vue/src/components/molecules/SfMenuItem/SfMenuItem.stories.js
+++ b/packages/vue/src/components/molecules/SfMenuItem/SfMenuItem.stories.js
@@ -55,7 +55,7 @@ export default storiesOf("Molecules|[WIP]MenuItem", module)
     {
       info: {
         summary: `<h2> Usage </h2>
-        <pre><code>import SfMenuItem from "@storefrontui/vue/dist/SfMenuItem.vue"</code></pre>
+        <pre><code>import { SfMenuItem } from "@storefrontui/vue"</code></pre>
         ${generateStorybookTable(scssTableConfig, "SCSS variables")}
         `
       }

--- a/packages/vue/src/components/molecules/SfOptions/SfOptions.stories.js
+++ b/packages/vue/src/components/molecules/SfOptions/SfOptions.stories.js
@@ -97,7 +97,7 @@ storiesOf("Molecules|Options", module)
     {
       info: {
         summary: `<h2> Usage </h2>
-        <pre><code>import SfOptions from "@storefrontui/vue/dist/SfOptions.vue"</code></pre>
+        <pre><code>import { SfOptions } from "@storefrontui/vue"</code></pre>
         ${generateStorybookTable(scssTableConfig, "SCSS variables")}
         ${generateStorybookTable(cssTableConfig, "CSS modifiers")}
         `

--- a/packages/vue/src/components/molecules/SfPagination/SfPagination.stories.js
+++ b/packages/vue/src/components/molecules/SfPagination/SfPagination.stories.js
@@ -83,7 +83,7 @@ storiesOf("Molecules|Pagination", module)
     {
       info: {
         summary: `<h2> Usage </h2>
-        <pre><code>import SfPagination from "@storefrontui/vue/dist/SfPagination.vue"</code></pre>
+        <pre><code>import { SfPagination } from "@storefrontui/vue"</code></pre>
         ${generateStorybookTable(scssTableConfig, "SCSS variables")}
         ${generateStorybookTable(eventTableConfig, "Events")}
         `

--- a/packages/vue/src/components/molecules/SfProductCard/SfProductCard.stories.js
+++ b/packages/vue/src/components/molecules/SfProductCard/SfProductCard.stories.js
@@ -18,7 +18,7 @@ storiesOf("Molecules|ProductCard", module)
     {
       info: {
         summary: `<h2> Usage </h2>
-        <pre><code>import SfProductCard from "@storefrontui/vue/dist/SfProductCard.vue"</code></pre>`
+        <pre><code>import { SfProductCard } from "@storefrontui/vue"</code></pre>`
       }
     }
   );

--- a/packages/vue/src/components/molecules/SfProductOption/SfProductOption.stories.js
+++ b/packages/vue/src/components/molecules/SfProductOption/SfProductOption.stories.js
@@ -57,7 +57,7 @@ export default storiesOf("Molecules|ProductOption", module)
       info: {
         summary: `
           <h2> Usage </h2>
-          <pre><code>import SfProductOption from "@storefrontui/vue/dist/SfProductOption.vue"</code></pre>
+          <pre><code>import { SfProductOption } from "@storefrontui/vue"</code></pre>
           ${generateStorybookTable(scssTableConfig, "SCSS variables")}
           `
       }

--- a/packages/vue/src/components/molecules/SfRadio/SfRadio.stories.js
+++ b/packages/vue/src/components/molecules/SfRadio/SfRadio.stories.js
@@ -78,7 +78,7 @@ storiesOf("Molecules|Radio", module)
       info: {
         summary: `<p>Component for simple group of radio buttons, pass an array get selected value via v-model.</p>
         <h2> Usage </h2>
-        <pre><code>import SfRadio from "@storefrontui/vue/dist/SfRadio.vue"</code></pre>
+        <pre><code>import { SfRadio } from "@storefrontui/vue"</code></pre>
         ${generateStorybookTable(scssTableConfig, "SCSS variables")}
         `
       }

--- a/packages/vue/src/components/molecules/SfSearchBar/SfSearchBar.stories.js
+++ b/packages/vue/src/components/molecules/SfSearchBar/SfSearchBar.stories.js
@@ -81,7 +81,7 @@ storiesOf("Molecules|SearchBar", module)
 
       info: {
         summary: `<h2> Usage </h2>
-        <pre><code>import SfSearchBar from "@storefrontui/vue/dist/SfSearchBar.vue"</code></pre>
+        <pre><code>import { SfSearchBar } from "@storefrontui/vue"</code></pre>
         ${generateStorybookTable(scssTableConfig, "SCSS variables")}`
       }
     }

--- a/packages/vue/src/components/molecules/SfSection/SfSection.stories.js
+++ b/packages/vue/src/components/molecules/SfSection/SfSection.stories.js
@@ -88,7 +88,7 @@ storiesOf("Molecules|Section", module)
       info: {
         summary: `<p>Component description.</p>
        <h2>Usage</h2>
-       <pre><code>import SfSection from "@storefrontui/vue/dist/SfSection.vue"</code></pre>
+       <pre><code>import { SfSection } from "@storefrontui/vue"</code></pre>
        ${generateStorybookTable(scssTableConfig, "SCSS variables")}
        ${generateStorybookTable(cssTableConfig, "CSS modifiers")}
        `

--- a/packages/vue/src/components/molecules/SfSticky/SfSticky.stories.js
+++ b/packages/vue/src/components/molecules/SfSticky/SfSticky.stories.js
@@ -59,7 +59,7 @@ storiesOf("Molecules|Sticky", module)
     {
       info: {
         summary: `<h2>Usage</h2>
-       <pre><code>import SfSticky from "@storefrontui/vue/dist/SfSticky.vue"</code></pre>`
+       <pre><code>import { SfSticky } from "@storefrontui/vue"</code></pre>`
       }
     }
   );

--- a/packages/vue/src/components/organisms/SfCarousel/SfCarousel.stories.js
+++ b/packages/vue/src/components/organisms/SfCarousel/SfCarousel.stories.js
@@ -66,7 +66,7 @@ storiesOf("Organisms|Carousel", module)
     {
       info: {
         summary: `<h2> Usage </h2>
-        <pre><code>import SfCarousel from "@storefrontui/vue/dist/SfCarousel.vue"</code></pre>
+        <pre><code>import { SfCarousel } from "@storefrontui/vue"</code></pre>
         ${generateStorybookTable(scssTableConfig, "SCSS variables")}
         `
       }

--- a/packages/vue/src/components/organisms/SfList/SfList.stories.js
+++ b/packages/vue/src/components/organisms/SfList/SfList.stories.js
@@ -18,7 +18,7 @@ storiesOf("Organisms|List", module)
     {
       info: {
         summary: `<h2> Usage </h2>
-        <pre><code>import SfList from "@storefrontui/vue/dist/SfList.vue"</code></pre>`
+        <pre><code>import { SfList } from "@storefrontui/vue"</code></pre>`
       }
     }
   )

--- a/packages/vue/src/components/organisms/SfMegaMenu/SfMegaMenu.stories.js
+++ b/packages/vue/src/components/organisms/SfMegaMenu/SfMegaMenu.stories.js
@@ -11,7 +11,7 @@ storiesOf("Organisms|MegaMenu", module).add(
   {
     info: {
       summary: `<h2> Usage </h2>
-      <pre><code>import SfMegaMenu from "@storefrontui/vue/dist/SfMegaMenu.vue"</code></pre>`
+      <pre><code>import { SfMegaMenu } from "@storefrontui/vue"</code></pre>`
     }
   }
 );

--- a/packages/vue/src/components/organisms/SfSidebar/SfSidebar.stories.js
+++ b/packages/vue/src/components/organisms/SfSidebar/SfSidebar.stories.js
@@ -55,7 +55,7 @@ storiesOf("Organisms|Sidebar", module)
         summary:
           "`SfSidebar` will add `overflow: hidden` CSS property to body once instantiated. This is why you should always use `v-if`." +
           `<h2> Usage </h2>
-          <pre><code>import SfSidebar from "@storefrontui/vue/dist/SfSidebar.vue"</code></pre>
+          <pre><code>import { SfSidebar } from "@storefrontui/vue"</code></pre>
           ${generateStorybookTable(scssTableConfig, "SCSS variables")}
           ${generateStorybookTable(cssTableConfig, "CSS modifiers")}
           `


### PR DESCRIPTION
# Related issue
#158

# Scope of work
I updated almost all import scripts in components stories, except:
sfSelect, sfTopbar, sfTabs, Category and all transitions.
These components don't have any import instruction in story, should it be added? 

# Checklist

- [x] I followed [composition rules](https://github.com/DivanteLtd/storefront-ui/blob/master/docs/component-rules.md) for my component
- [x] I tested the component in most common device sizes (can be tested in Storybook [from viewport addon in top menu](https://github.com/storybooks/storybook/tree/master/addons/viewport))
