### PR TITLE
Creates slots for carousel controls

### DIFF
--- a/packages/vue/src/components/organisms/SfCarousel/SfCarousel.html
+++ b/packages/vue/src/components/organisms/SfCarousel/SfCarousel.html
@@ -2,18 +2,27 @@
   <div class="glide" ref="glide">
     <div class="glide__track" data-glide-el="track">
       <ul class="glide__slides sf-carousel__slides">
+        <!--@slot default slot for SfCarouselItem tags -->
         <slot />
       </ul>
     </div>
   </div>
   <div class="sf-carousel__controls">
-    <SfArrow
-      @click="go('<')"
-      class="sf-arrow--long"
-      aria-label="previous"/>
-    <SfArrow
-    @click="go('>')"
-      class="sf-arrow--long sf-arrow--right"
-      aria-label="next"/>
+    <div @click="go('prev')">
+      <!--@slot slot for icon moving to the previous item -->
+      <slot name="arrow-left">
+        <SfArrow
+          class="sf-arrow--long"
+          aria-label="previous"/>
+      </slot>
+    </div>
+    <div @click="go('next')">
+      <!--@slot slot for icon moving to the next item -->
+      <slot name="arrow-right">
+        <SfArrow
+          class="sf-arrow--long sf-arrow--right"
+          aria-label="next"/>
+      </slot>
+    </div>
   </div>
 </div>

--- a/packages/vue/src/components/organisms/SfCarousel/SfCarousel.html
+++ b/packages/vue/src/components/organisms/SfCarousel/SfCarousel.html
@@ -10,7 +10,7 @@
   <div class="sf-carousel__controls">
     <div @click="go('prev')">
       <!--@slot slot for icon moving to the previous item -->
-      <slot name="arrow-left">
+      <slot name="prev">
         <SfArrow
           class="sf-arrow--long"
           aria-label="previous"/>
@@ -18,7 +18,7 @@
     </div>
     <div @click="go('next')">
       <!--@slot slot for icon moving to the next item -->
-      <slot name="arrow-right">
+      <slot name="next">
         <SfArrow
           class="sf-arrow--long sf-arrow--right"
           aria-label="next"/>

--- a/packages/vue/src/components/organisms/SfCarousel/SfCarousel.js
+++ b/packages/vue/src/components/organisms/SfCarousel/SfCarousel.js
@@ -42,10 +42,10 @@ export default {
   methods: {
     go(direct) {
       switch (direct) {
-        case "<":
+        case "prev":
           this.glide.go("<");
           break;
-        case ">":
+        case "next":
           this.glide.go(">");
           break;
       }

--- a/packages/vue/src/components/organisms/SfCarousel/SfCarousel.stories.js
+++ b/packages/vue/src/components/organisms/SfCarousel/SfCarousel.stories.js
@@ -76,7 +76,7 @@ storiesOf("Organisms|Carousel", module)
     }
   )
   .add(
-    "[slots] arrows",
+    "[slot] prev",
     () => ({
       components: { SfCarousel },
       data,
@@ -107,12 +107,61 @@ storiesOf("Organisms|Carousel", module)
           <SfCarouselItem>
             <div :style="style">8</div>
           </SfCarouselItem>
-          <template #arrow-left>
+          
+          <template #prev>
             <span style="margin: 12px; cursor: pointer; font-weight: 900; font-size: 18px;">&lt; PREV</span>
           </template>
-          <template #arrow-right>
+
+        </SfCarousel>
+      </div>
+      `
+    }),
+    {
+      info: {
+        summary: `<h2> Usage </h2>
+        <pre><code>import { SfCarousel } from "@storefrontui/vue"</code></pre>
+        ${generateStorybookTable(scssTableConfig, "SCSS variables")}
+        `
+      }
+    }
+  )
+  .add(
+    "[slot] next",
+    () => ({
+      components: { SfCarousel },
+      data,
+      template: `
+      <div style="max-width: 1140px">
+        <SfCarousel :options="options">
+          <SfCarouselItem>
+            <div :style="style">1</div>
+          </SfCarouselItem>
+          <SfCarouselItem>
+            <div :style="style">2</div>
+          </SfCarouselItem>
+          <SfCarouselItem>
+            <div :style="style">3</div>
+          </SfCarouselItem>
+          <SfCarouselItem>
+            <div :style="style">4</div>
+          </SfCarouselItem>
+          <SfCarouselItem>
+            <div :style="style">5</div>
+          </SfCarouselItem>
+          <SfCarouselItem>
+            <div :style="style">6</div>
+          </SfCarouselItem>
+          <SfCarouselItem>
+            <div :style="style">7</div>
+          </SfCarouselItem>
+          <SfCarouselItem>
+            <div :style="style">8</div>
+          </SfCarouselItem>
+
+          <template #next>
             <span style="margin: 12px; cursor: pointer; font-weight: 900; font-size: 18px;">NEXT &gt;</span>
           </template>
+
         </SfCarousel>
       </div>
       `

--- a/packages/vue/src/components/organisms/SfCarousel/SfCarousel.stories.js
+++ b/packages/vue/src/components/organisms/SfCarousel/SfCarousel.stories.js
@@ -9,28 +9,31 @@ const scssTableConfig = {
     ["$carousel-mobile-breakpoint", "$mobile-max", "default mobile breakpoint"]
   ]
 };
+
+const data = () => {
+  return {
+    style: {
+      color: "#FFF",
+      display: "flex",
+      "justify-content": "center",
+      "font-size": "3rem",
+      "align-items": "center",
+      height: "300px",
+      "background-color": "#5ECE7B"
+    },
+    options: {
+      perView: 4
+    }
+  };
+};
+
 storiesOf("Organisms|Carousel", module)
   .addDecorator(withKnobs)
   .add(
     "Basic",
     () => ({
       components: { SfCarousel },
-      data() {
-        return {
-          style: {
-            color: "#FFF",
-            display: "flex",
-            "justify-content": "center",
-            "font-size": "3rem",
-            "align-items": "center",
-            height: "300px",
-            "background-color": "#5ECE7B"
-          },
-          options: {
-            perView: 4
-          }
-        };
-      },
+      data,
       template: `
       <div style="max-width: 1140px">
         <SfCarousel :options="options">
@@ -59,6 +62,57 @@ storiesOf("Organisms|Carousel", module)
             <div :style="style">8</div>
           </SfCarouselItem>
           
+        </SfCarousel>
+      </div>
+      `
+    }),
+    {
+      info: {
+        summary: `<h2> Usage </h2>
+        <pre><code>import { SfCarousel } from "@storefrontui/vue"</code></pre>
+        ${generateStorybookTable(scssTableConfig, "SCSS variables")}
+        `
+      }
+    }
+  )
+  .add(
+    "[slots] arrows",
+    () => ({
+      components: { SfCarousel },
+      data,
+      template: `
+      <div style="max-width: 1140px">
+        <SfCarousel :options="options">
+          <SfCarouselItem>
+            <div :style="style">1</div>
+          </SfCarouselItem>
+          <SfCarouselItem>
+            <div :style="style">2</div>
+          </SfCarouselItem>
+          <SfCarouselItem>
+            <div :style="style">3</div>
+          </SfCarouselItem>
+          <SfCarouselItem>
+            <div :style="style">4</div>
+          </SfCarouselItem>
+          <SfCarouselItem>
+            <div :style="style">5</div>
+          </SfCarouselItem>
+          <SfCarouselItem>
+            <div :style="style">6</div>
+          </SfCarouselItem>
+          <SfCarouselItem>
+            <div :style="style">7</div>
+          </SfCarouselItem>
+          <SfCarouselItem>
+            <div :style="style">8</div>
+          </SfCarouselItem>
+          <template #arrow-left>
+            <span style="margin: 12px; cursor: pointer; font-weight: 900; font-size: 18px;">&lt; PREV</span>
+          </template>
+          <template #arrow-right>
+            <span style="margin: 12px; cursor: pointer; font-weight: 900; font-size: 18px;">NEXT &gt;</span>
+          </template>
         </SfCarousel>
       </div>
       `


### PR DESCRIPTION
# Related issue
https://github.com/DivanteLtd/storefront-ui/issues/206

# Scope of work
Creates slots for <code>SfCarousel</code> controls

# Screenshots of visual changes
![carousel-slots](https://user-images.githubusercontent.com/26803550/60284494-fb38bb80-990b-11e9-85a3-76fe343d800a.png)

# Checklist

- [ ] I followed [composition rules](https://github.com/DivanteLtd/storefront-ui/blob/master/docs/component-rules.md) for my component
- [ ] I tested the component in most common device sizes (can be tested in Storybook [from viewport addon in top menu](https://github.com/storybooks/storybook/tree/master/addons/viewport))
