### PR TITLE
improve documentation for trying out StorefrontUI

### DIFF
--- a/packages/vue/docs/introduction.md
+++ b/packages/vue/docs/introduction.md
@@ -20,7 +20,25 @@ it is not suitable for production!
 Expect things to be broken and APIs to possibly change. 
 
 
-## How to test StorefrontUI?
+## How to test StorefrontUI standalone
+
+- checkout the repository and branch you want to test from https://github.com/DivanteLtd/storefront-ui
+- install dependencies
+```bash
+yarn install
+```
+- change into directory
+```bash
+cd ./packages/vue/
+```
+- start Storybook Server
+
+```bash
+yarn storybook:serve
+```
+
+
+## How to test StorefrontUI on your own Application?
 
 **Right now StorefrontUI is working only with Nuxt and Vue CLI!**
 


### PR DESCRIPTION
I added to the documentation a part which explains, how to test/run StorefrontUI independently of an own project.

# Related issue
<!-- paste a link to related issue -->

# Scope of work
website content of https://docs.storefrontui.io/introduction.html#current-state-of-the-project

# Screenshots of visual changes

# Checklist

- [ ] I followed [composition rules](https://github.com/DivanteLtd/storefront-ui/blob/master/docs/component-rules.md) for my component
- [ ] I tested the component in most common device sizes (can be tested in Storybook [from viewport addon in top menu](https://github.com/storybooks/storybook/tree/master/addons/viewport))
