### PR TITLE
#249 SfProductCard tweaks

### DIFF
--- a/packages/shared/styles/components/SfProductCard.scss
+++ b/packages/shared/styles/components/SfProductCard.scss
@@ -61,10 +61,16 @@ $product__image-blend-mode:       darken !default;
     margin: 10px;
     padding: 0;
     cursor: pointer;
+    visibility: visible;
     outline: none;
     background: transparent;
     border: none;
-    fill: $c-pink-primary
+
+    @media (min-width: $desktop-min) {
+      &:not(.__on-wishlist) {
+        visibility: hidden;
+      }
+    }
   }
 
   &:hover {

--- a/packages/shared/styles/components/SfProductCard.scss
+++ b/packages/shared/styles/components/SfProductCard.scss
@@ -61,14 +61,10 @@ $product__image-blend-mode:       darken !default;
     margin: 10px;
     padding: 0;
     cursor: pointer;
-    visibility: visible;
     outline: none;
     background: transparent;
     border: none;
-
-    @media (min-width: $desktop-min) {
-      visibility: hidden;
-    }
+    fill: $c-pink-primary
   }
 
   &:hover {

--- a/packages/shared/styles/components/SfProductCard.scss
+++ b/packages/shared/styles/components/SfProductCard.scss
@@ -67,7 +67,7 @@ $product__image-blend-mode:       darken !default;
     border: none;
 
     @media (min-width: $desktop-min) {
-      &:not(.__on-wishlist) {
+      &:not(.sf-product-card--on-wishlist) {
         visibility: hidden;
       }
     }

--- a/packages/vue/src/components/molecules/SfProductCard/SfProductCard.html
+++ b/packages/vue/src/components/molecules/SfProductCard/SfProductCard.html
@@ -5,7 +5,7 @@
     @click="toggleOnWishlist"  
     :class="wishlistIconClasses">
     <slot name="wishlist-icon">
-      <sf-icon :path="currentWishlistIcon" color="black" rsize="sm" data-test="sf-wishlist-icon"/>
+      <sf-icon :path="currentWishlistIcon" color="black" size="sm" data-test="sf-wishlist-icon"/>
     </slot>
   </button>
   <slot name="image">

--- a/packages/vue/src/components/molecules/SfProductCard/SfProductCard.html
+++ b/packages/vue/src/components/molecules/SfProductCard/SfProductCard.html
@@ -1,7 +1,7 @@
 <div class="sf-product-card">
-  <button :aria-label="ariaLabel" @click="toggleOnWishlist" class="sf-product-card__wishlist-icon">
+  <button v-if="wishlistIcon !== false" :aria-label="ariaLabel" @click="toggleOnWishlist" class="sf-product-card__wishlist-icon">
     <slot name="wishlist-icon">
-      <sf-icon :path="currentWishlistIcon" :color="onWishlistColor" size="sm" data-test="sf-wishlist-icon"/>
+      <sf-icon :path="currentWishlistIcon" color="black" rsize="sm" data-test="sf-wishlist-icon"/>
     </slot>
   </button>
   <slot name="image">

--- a/packages/vue/src/components/molecules/SfProductCard/SfProductCard.html
+++ b/packages/vue/src/components/molecules/SfProductCard/SfProductCard.html
@@ -1,5 +1,9 @@
 <div class="sf-product-card">
-  <button v-if="wishlistIcon !== false" :aria-label="ariaLabel" @click="toggleOnWishlist" class="sf-product-card__wishlist-icon">
+  <button 
+    v-if="wishlistIcon !== false" 
+    :aria-label="ariaLabel" 
+    @click="toggleOnWishlist"  
+    :class="wishlistIconClasses">
     <slot name="wishlist-icon">
       <sf-icon :path="currentWishlistIcon" color="black" rsize="sm" data-test="sf-wishlist-icon"/>
     </slot>

--- a/packages/vue/src/components/molecules/SfProductCard/SfProductCard.js
+++ b/packages/vue/src/components/molecules/SfProductCard/SfProductCard.js
@@ -89,7 +89,7 @@ export default {
     wishlistIconClasses() {
       const defaultClass = "sf-product-card__wishlist-icon";
 
-      return `${defaultClass} ${this.isOnWishlist ? "__on-wishlist" : ""}`;
+      return `${defaultClass} ${this.isOnWishlist ? "sf-product-card--on-wishlist" : ""}`;
     }
   },
   methods: {

--- a/packages/vue/src/components/molecules/SfProductCard/SfProductCard.js
+++ b/packages/vue/src/components/molecules/SfProductCard/SfProductCard.js
@@ -54,7 +54,7 @@ export default {
      * It can be a icon name from our icons list, or array or string as SVG path(s).
      */
     wishlistIcon: {
-      type: [String, Array],
+      type: [String, Array, Boolean],
       default: "heart"
     },
     /**
@@ -62,23 +62,16 @@ export default {
      * This is the icon for product added to wish list. Default visible on mobile. Visible only on hover on desktop.
      * It can be a icon name from our icons list, or array or string as SVG path(s).
      */
-    onWishlistIcon: {
+    isOnWishlistIcon: {
       type: [String, Array],
       default: "heart_fill"
     },
     /**
      * Status of whether product is on wish list or not
      */
-    onWishlist: {
+    isOnWishlist: {
       type: [Boolean],
       default: false
-    },
-    /**
-     * Custom color of the wish list icon, can be HEX, RGB or any color in our colors list for SfIcon.
-     * By default it will be black.``
-     */
-    onWishlistColor: {
-      type: String
     }
   },
   components: {
@@ -88,15 +81,15 @@ export default {
   },
   computed: {
     currentWishlistIcon() {
-      return this.onWishlist ? this.onWishlistIcon : this.wishlistIcon;
+      return this.isOnWishlist ? this.isOnWishlistIcon : this.wishlistIcon;
     },
     ariaLabel() {
-      return this.onWishlist ? "Remove from wishlist" : "Add to wishlist";
+      return this.isOnWishlist ? "Remove from wishlist" : "Add to wishlist";
     }
   },
   methods: {
     toggleOnWishlist() {
-      this.$emit("click:wishlist", !this.onWishlist);
+      this.$emit("click:wishlist", !this.isOnWishlist);
     }
   }
 };

--- a/packages/vue/src/components/molecules/SfProductCard/SfProductCard.js
+++ b/packages/vue/src/components/molecules/SfProductCard/SfProductCard.js
@@ -85,6 +85,11 @@ export default {
     },
     ariaLabel() {
       return this.isOnWishlist ? "Remove from wishlist" : "Add to wishlist";
+    },
+    wishlistIconClasses() {
+      const defaultClass = "sf-product-card__wishlist-icon";
+
+      return `${defaultClass} ${this.isOnWishlist ? "__on-wishlist" : ""}`;
     }
   },
   methods: {

--- a/packages/vue/src/components/molecules/SfProductCard/SfProductCard.spec.ts
+++ b/packages/vue/src/components/molecules/SfProductCard/SfProductCard.spec.ts
@@ -1,32 +1,32 @@
 import { shallowMount } from "@vue/test-utils";
-import SfOptions from "@/components/molecules/SfProductCard/SfProductCard.vue";
+import SfProductCard from "@/components/molecules/SfProductCard/SfProductCard.vue";
 
 describe("SfProductCard.vue", () => {
   const rating = { max: 5, score: 4 };
   const price = { regular: "$10,99" };
   const title = "Product A";
-  let onWishlist = false;
+  let isOnWishlist = false;
 
   it("renders Product Card", () => {
-    onWishlist = false;
-    const component = shallowMount(SfOptions, {
+    isOnWishlist = false;
+    const component = shallowMount(SfProductCard, {
       propsData: {
         rating,
         price,
         title,
-        onWishlist
+        isOnWishlist
       }
     });
 
     expect(component.contains(".sf-product-card")).toBe(true);
   });
   it("renders default wishlist icon", () => {
-    const component = shallowMount(SfOptions, {
+    const component = shallowMount(SfProductCard, {
       propsData: {
         rating,
         price,
         title,
-        onWishlist
+        isOnWishlist
       }
     });
 
@@ -34,13 +34,13 @@ describe("SfProductCard.vue", () => {
   });
 
   it("renders default wish list icon when none is passed", () => {
-    onWishlist = false;
-    const component = shallowMount(SfOptions, {
+    isOnWishlist = false;
+    const component = shallowMount(SfProductCard, {
       propsData: {
         rating,
         price,
         title,
-        onWishlist
+        isOnWishlist
       }
     });
 
@@ -48,16 +48,16 @@ describe("SfProductCard.vue", () => {
   });
 
   it("render custom wish list icon", () => {
-    onWishlist = false;
+    isOnWishlist = false;
     const path =
       "M10 0C4.48561 0 0 4.48561 0 10C0 15.5144 4.48561 20 10 20C15.5144 20 20 15.5144 20 10C20 4.48561 15.5144 0 10 0ZM10 1.46341C14.7237 1.46341 18.5366 5.27634 18.5366 10C18.5366 14.7237 14.7237 18.5366 10 18.5366C5.27634 18.5366 1.46341 14.7237 1.46341 10C1.46341 5.27634 5.27634 1.46341 10 1.46341ZM10 2.68293C9.59605 2.68293 9.26829 3.01068 9.26829 3.41463V10C9.26829 10.2706 9.41597 10.5059 9.63415 10.6326L14.9161 13.6814C15.2658 13.8834 15.7126 13.7643 15.9146 13.4146C16.1166 13.065 15.9975 12.6181 15.6478 12.4161L10.7317 9.58078V3.41468C10.7317 3.01073 10.404 2.68298 10 2.68298V2.68293Z";
 
-    const component = shallowMount(SfOptions, {
+    const component = shallowMount(SfProductCard, {
       propsData: {
         rating,
         price,
         title,
-        onWishlist,
+        isOnWishlist,
         wishlistIcon: path
       }
     });
@@ -71,30 +71,45 @@ describe("SfProductCard.vue", () => {
   });
 
   it("renders default on wish list icon when none is passed", () => {
-    onWishlist = true;
-    const component = shallowMount(SfOptions, {
+    isOnWishlist = true;
+    const component = shallowMount(SfProductCard, {
       propsData: {
         rating,
         price,
         title,
-        onWishlist
+        isOnWishlist
       }
     });
 
     expect(component.contains("[data-test='sf-wishlist-icon'")).toBe(true);
   });
 
-  it("render custom on wish list icon", () => {
-    onWishlist = true;
-    const path =
-      "M10 0C4.48561 0 0 4.48561 0 10C0 15.5144 4.48561 20 10 20C15.5144 20 20 15.5144 20 10C20 4.48561 15.5144 0 10 0ZM10 1.46341C14.7237 1.46341 18.5366 5.27634 18.5366 10C18.5366 14.7237 14.7237 18.5366 10 18.5366C5.27634 18.5366 1.46341 14.7237 1.46341 10C1.46341 5.27634 5.27634 1.46341 10 1.46341ZM10 2.68293C9.59605 2.68293 9.26829 3.01068 9.26829 3.41463V10C9.26829 10.2706 9.41597 10.5059 9.63415 10.6326L14.9161 13.6814C15.2658 13.8834 15.7126 13.7643 15.9146 13.4146C16.1166 13.065 15.9975 12.6181 15.6478 12.4161L10.7317 9.58078V3.41468C10.7317 3.01073 10.404 2.68298 10 2.68298V2.68293Z";
-
-    const component = shallowMount(SfOptions, {
+  it("does not render wish list icon when false is passed", () => {
+    isOnWishlist = true;
+    const component = shallowMount(SfProductCard, {
       propsData: {
         rating,
         price,
         title,
-        onWishlist,
+        isOnWishlist,
+        wishlistIcon: false
+      }
+    });
+
+    expect(component.contains("[data-test='sf-wishlist-icon'")).toBe(false);
+  });
+
+  it("render custom on wish list icon", () => {
+    isOnWishlist = true;
+    const path =
+      "M10 0C4.48561 0 0 4.48561 0 10C0 15.5144 4.48561 20 10 20C15.5144 20 20 15.5144 20 10C20 4.48561 15.5144 0 10 0ZM10 1.46341C14.7237 1.46341 18.5366 5.27634 18.5366 10C18.5366 14.7237 14.7237 18.5366 10 18.5366C5.27634 18.5366 1.46341 14.7237 1.46341 10C1.46341 5.27634 5.27634 1.46341 10 1.46341ZM10 2.68293C9.59605 2.68293 9.26829 3.01068 9.26829 3.41463V10C9.26829 10.2706 9.41597 10.5059 9.63415 10.6326L14.9161 13.6814C15.2658 13.8834 15.7126 13.7643 15.9146 13.4146C16.1166 13.065 15.9975 12.6181 15.6478 12.4161L10.7317 9.58078V3.41468C10.7317 3.01073 10.404 2.68298 10 2.68298V2.68293Z";
+
+    const component = shallowMount(SfProductCard, {
+      propsData: {
+        rating,
+        price,
+        title,
+        isOnWishlist,
         onWishlistIcon: path
       }
     });
@@ -108,13 +123,13 @@ describe("SfProductCard.vue", () => {
   });
 
   it("renders default wish list icon when none is passed", () => {
-    onWishlist = false;
-    const component = shallowMount(SfOptions, {
+    isOnWishlist = false;
+    const component = shallowMount(SfProductCard, {
       propsData: {
         rating,
         price,
         title,
-        onWishlist
+        isOnWishlist
       }
     });
     (component.vm as any).toggleOnWishlist();

--- a/packages/vue/src/components/molecules/SfProductCard/SfProductCard.stories.js
+++ b/packages/vue/src/components/molecules/SfProductCard/SfProductCard.stories.js
@@ -1,7 +1,13 @@
 /* eslint-disable import/no-extraneous-dependencies */
 import { storiesOf } from "@storybook/vue";
 import { generateStorybookTable } from "@/helpers";
-import { withKnobs, text, boolean, number } from "@storybook/addon-knobs";
+import {
+  withKnobs,
+  text,
+  boolean,
+  number,
+  select
+} from "@storybook/addon-knobs";
 import SfProductCard from "./SfProductCard.vue";
 
 const scssTableConfig = {
@@ -34,7 +40,7 @@ const scssTableConfig = {
 storiesOf("Molecules|ProductCard", module)
   .addDecorator(withKnobs)
   .add(
-    "Template",
+    "Basic",
     () => ({
       props: {
         image: {
@@ -56,16 +62,13 @@ storiesOf("Molecules|ProductCard", module)
           default: number("maxRating (prop)", 4)
         },
         wishlistIcon: {
-          default: text("wishlistIcon (prop)", "heart")
+          default: select("wishlistIcon (prop)", [false, "heart"])
         },
-        onWishlist: {
-          default: boolean("onWishlist (prop)", false)
+        isOnWishlist: {
+          default: boolean("isOnWishlist (prop)", false)
         },
-        onWishlistIcon: {
-          default: text("onWishlistIcon (prop)", "heart_fill")
-        },
-        onWishlistColor: {
-          default: text("onWishlistColor (prop)", "pink-primary")
+        isOnWishlistIcon: {
+          default: text("isOnWishlistIcon (prop)", "heart_fill")
         }
       },
       components: { SfProductCard },
@@ -77,9 +80,8 @@ storiesOf("Molecules|ProductCard", module)
         :rating="rating"
         :max-rating="maxRating"
         :wishlistIcon="wishlistIcon"
-        :onWishlistIcon="onWishlistIcon"
-        :onWishlistColor="onWishlistColor"
-        :onWishlist="onWishlist"
+        :isOnWishlistIcon="isOnWishlistIcon"
+        :isOnWishlist="isOnWishlist"
       />`
     }),
     {

--- a/packages/vue/src/components/molecules/SfProductCard/SfProductCard.stories.js
+++ b/packages/vue/src/components/molecules/SfProductCard/SfProductCard.stories.js
@@ -62,7 +62,7 @@ storiesOf("Molecules|ProductCard", module)
           default: number("maxRating (prop)", 4)
         },
         wishlistIcon: {
-          default: select("wishlistIcon (prop)", [false, "heart"])
+          default: select("wishlistIcon (prop)", [false, "heart"], "heart")
         },
         isOnWishlist: {
           default: boolean("isOnWishlist (prop)", false)

--- a/packages/vue/src/examples/pages/category/Category.vue
+++ b/packages/vue/src/examples/pages/category/Category.vue
@@ -136,7 +136,7 @@
             :regular-price="product.price.regular"
             :special-price="product.price.special"
             :rating="product.rating.score"
-            :onWishlist="product.onWishlist"
+            :isOnWishlist="product.isOnWishlist"
             @click:wishlist="
               () => {
                 toggleWishlist(i);
@@ -308,56 +308,56 @@ export default {
           image: "assets/storybook/homepage/productA.png",
           price: { regular: "$50.00", special: "$20.00" },
           rating: { max: 5, score: false },
-          onWishlist: true
+          isOnWishlist: true
         },
         {
           title: "Cream Beach Bag",
           image: "assets/storybook/homepage/productB.png",
           price: { regular: "$50.00" },
           rating: { max: 5, score: 4 },
-          onWishlist: false
+          isOnWishlist: false
         },
         {
           title: "Cream Beach Bag",
           image: "assets/storybook/homepage/productC.png",
           price: { regular: "$50.00" },
           rating: { max: 5, score: 4 },
-          onWishlist: false
+          isOnWishlist: false
         },
         {
           title: "Cream Beach Bag",
           image: "assets/storybook/homepage/productA.png",
           price: { regular: "$50.00" },
           rating: { max: 5, score: 4 },
-          onWishlist: false
+          isOnWishlist: false
         },
         {
           title: "Cream Beach Bag",
           image: "assets/storybook/homepage/productB.png",
           price: { regular: "$50.00" },
           rating: { max: 5, score: 4 },
-          onWishlist: false
+          isOnWishlist: false
         },
         {
           title: "Cream Beach Bag",
           image: "assets/storybook/homepage/productC.png",
           price: { regular: "$50.00" },
           rating: { max: 5, score: 4 },
-          onWishlist: false
+          isOnWishlist: false
         },
         {
           title: "Cream Beach Bag",
           image: "assets/storybook/homepage/productA.png",
           price: { regular: "$50.00" },
           rating: { max: 5, score: 4 },
-          onWishlist: false
+          isOnWishlist: false
         },
         {
           title: "Cream Beach Bag",
           image: "assets/storybook/homepage/productB.png",
           price: { regular: "$50.00" },
           rating: { max: 5, score: 4 },
-          onWishlist: false
+          isOnWishlist: false
         }
       ],
       filtersOptions: {
@@ -404,7 +404,7 @@ export default {
       this.filters = filters;
     },
     toggleWishlist(index) {
-      this.products[index].onWishlist = !this.products[index].onWishlist;
+      this.products[index].isOnWishlist = !this.products[index].isOnWishlist;
     }
   },
   components: {


### PR DESCRIPTION
# Related issue
![](https://github.com/DivanteLtd/storefront-ui/issues/249)

# Scope of work
1. Remove `onWishlistColor` prop
2. Change `onWishlistIcon` and `onWishlist` to `isOnWishlistIcon` and `isOnWishlist`
3. Make Wishlist icon always be visible when product is on wishlist
4. Allow to disable showing wishlist icon when `wishlistIcon` received `false`

# Screenshots of visual changes
<img width="790" alt="Screen Shot 2019-07-29 at 13 05 22" src="https://user-images.githubusercontent.com/6650139/62040104-a1286000-b201-11e9-9076-a1d28bf97151.png">

# Checklist

- [x] I followed [composition rules](https://github.com/DivanteLtd/storefront-ui/blob/master/docs/component-rules.md) for my component
- [x] I tested the component in most common device sizes (can be tested in Storybook [from viewport addon in top menu](https://github.com/storybooks/storybook/tree/master/addons/viewport))
