### PR TITLE
SfHeading && Sfsection tweaks

### DIFF
--- a/packages/shared/styles/components/SfHeading.scss
+++ b/packages/shared/styles/components/SfHeading.scss
@@ -4,8 +4,14 @@ $heading--border-color: #F1F2F4 !default;
 $heading--underline-subtitle-color: #A3A5AD !default;
 
 .sf-heading {
-    text-align: left;
-  @media screen and (min-width: $desktop-min){
+  text-align: left;
+  padding-bottom: 10px;
+  border-bottom: 1px solid $heading--border-color;
+
+  @media screen and (min-width: $desktop-min) {
+    display: block;
+    padding-bottom: 0;
+    border: 0;
     text-align: center;
   }
   &__title {
@@ -19,16 +25,12 @@ $heading--underline-subtitle-color: #A3A5AD !default;
   }
 
   &--underline {
-    padding-bottom: 10px;
-    border-bottom: 1px solid $heading--border-color;
 
-    @media screen and (min-width: $desktop-min) {
-      display: block;
-      padding-bottom: 0;
-      border: 0;
-    }
   }
-
+  &--no-underline{
+    padding-bottom: 0;
+    border-bottom: 0;
+  }
   &--left{
     text-align: left;
   }

--- a/packages/vue/src/components/atoms/SfHeading/SfHeading.stories.js
+++ b/packages/vue/src/components/atoms/SfHeading/SfHeading.stories.js
@@ -58,7 +58,7 @@ storiesOf("Atoms|Heading", module)
             "CSS Modifier",
             {
               null: "null",
-              "sf-heading--underline": "sf-heading--underline",
+              "sf-heading--no-underline": "sf-heading--no-underline",
               "sf-heading--left": "sf-heading--left",
               "sf-heading--right": "sf-heading--right"
             },

--- a/packages/vue/src/components/molecules/SfSection/SfSection.html
+++ b/packages/vue/src/components/molecules/SfSection/SfSection.html
@@ -1,7 +1,7 @@
 <section class="sf-section">
   <!--@slot Section heading. Slot content will replace default <sf-heading> component-->
   <slot name="heading">
-    <sf-heading :level="level" :title="title" :subtitle="subtitle" :class="{'sf-heading--underline': hasUnderlinedModifier}"/>
+    <sf-heading :level="level" :title="title" :subtitle="subtitle" :class="{'sf-heading--no-underline': hasUnderlinedModifier}"/>
   </slot>
   <!--@slot Section content.-->
   <div class="sf-section__content">

--- a/packages/vue/src/components/molecules/SfSection/SfSection.html
+++ b/packages/vue/src/components/molecules/SfSection/SfSection.html
@@ -1,7 +1,7 @@
 <section class="sf-section">
   <!--@slot Section heading. Slot content will replace default <sf-heading> component-->
   <slot name="heading">
-    <sf-heading :level="heading.level" :title="heading.title" :subtitle="heading.subtitle" :class="{'sf-heading--underline': hasUnderlinedModifier}"/>
+    <sf-heading :level="level" :title="title" :subtitle="subtitle" :class="{'sf-heading--underline': hasUnderlinedModifier}"/>
   </slot>
   <!--@slot Section content.-->
   <div class="sf-section__content">

--- a/packages/vue/src/components/molecules/SfSection/SfSection.js
+++ b/packages/vue/src/components/molecules/SfSection/SfSection.js
@@ -3,15 +3,25 @@ export default {
   name: "SfSection",
   props: {
     /**
-     * Section heading
+     * Heading title
      */
-    heading: {
-      type: Object,
-      default: () => ({
-        title: "",
-        subtitle: "",
-        level: 2
-      })
+    title: {
+      type: String,
+      default: ""
+    },
+    /**
+     * Heading subtitle
+     */
+    subtitle:{
+      type: String,
+      default: ""
+    },
+    /**
+     * Heading tag level
+     */
+    level: {
+      type: Number,
+      default: ""
     }
   },
   data() {

--- a/packages/vue/src/components/molecules/SfSection/SfSection.js
+++ b/packages/vue/src/components/molecules/SfSection/SfSection.js
@@ -34,7 +34,7 @@ export default {
   },
   mounted: function() {
     this.hasUnderlinedModifier = this.$el.classList.contains(
-      "sf-section--underline"
+      "sf-section--no-underline"
     );
   }
 };

--- a/packages/vue/src/components/molecules/SfSection/SfSection.js
+++ b/packages/vue/src/components/molecules/SfSection/SfSection.js
@@ -12,7 +12,7 @@ export default {
     /**
      * Heading subtitle
      */
-    subtitle:{
+    subtitle: {
       type: String,
       default: ""
     },

--- a/packages/vue/src/components/molecules/SfSection/SfSection.stories.js
+++ b/packages/vue/src/components/molecules/SfSection/SfSection.stories.js
@@ -1,6 +1,6 @@
 // /* eslint-disable import/no-extraneous-dependencies */
 import { storiesOf } from "@storybook/vue";
-import { withKnobs, object, select } from "@storybook/addon-knobs";
+import {withKnobs, object, select, text, number} from "@storybook/addon-knobs";
 import { generateStorybookTable } from "@/helpers";
 
 import SfSection from "./SfSection.vue";
@@ -27,12 +27,14 @@ storiesOf("Molecules|Section", module)
     "Basic",
     () => ({
       props: {
-        heading: {
-          default: object("Heading", {
-            title: "Share your look",
-            subtitle: "#YOURLOOK",
-            level: 2
-          })
+        title: {
+          default: text("(prop) title", "Share your look")
+        },
+        subtitle: {
+          default: text("(prop) subtitle", "#YOURLOOK")
+        },
+        level: {
+          default: number("(prop) level", 2)
         },
         customClass: {
           default: select(
@@ -75,7 +77,7 @@ storiesOf("Molecules|Section", module)
       components: { SfSection },
       template: `
       <div>
-        <SfSection :class="customClass" :heading="heading">
+        <SfSection :class="customClass" :title="title" :subtitle="subtitle" :level="level">
           <div :style="row">
             <div :style="colFirst">1</div>
             <div :style="col">2</div>

--- a/packages/vue/src/components/molecules/SfSection/SfSection.stories.js
+++ b/packages/vue/src/components/molecules/SfSection/SfSection.stories.js
@@ -45,8 +45,8 @@ storiesOf("Molecules|Section", module)
         customClass: {
           default: select(
             "CSS Modifier",
-            ["null", "sf-section--underline"],
-            "null",
+            ["null", "sf-section--no-underline"],
+            "sf-section--no-underline",
             "CSS-Modifiers"
           )
         }

--- a/packages/vue/src/components/molecules/SfSection/SfSection.stories.js
+++ b/packages/vue/src/components/molecules/SfSection/SfSection.stories.js
@@ -1,6 +1,12 @@
 // /* eslint-disable import/no-extraneous-dependencies */
 import { storiesOf } from "@storybook/vue";
-import {withKnobs, object, select, text, number} from "@storybook/addon-knobs";
+import {
+  withKnobs,
+  object,
+  select,
+  text,
+  number
+} from "@storybook/addon-knobs";
 import { generateStorybookTable } from "@/helpers";
 
 import SfSection from "./SfSection.vue";


### PR DESCRIPTION
# Related issue
<!-- paste a link to related issue -->
#261
# Scope of work
<!-- describe what you did -->
Changed default SfHeading and SfSection style to underline on mobile 

# Screenshots of visual changes
![___](https://user-images.githubusercontent.com/12138170/62219849-564c4b00-b3af-11e9-8412-1ffb9a748dbf.png)

# Checklist

- [x] I followed [composition rules](https://github.com/DivanteLtd/storefront-ui/blob/master/docs/component-rules.md) for my component
- [x] I tested the component in most common device sizes (can be tested in Storybook [from viewport addon in top menu](https://github.com/storybooks/storybook/tree/master/addons/viewport))
