### PR TITLE
Fixed SfBannerGrid column child stretch

### DIFF
--- a/packages/shared/styles/components/SfBannerGrid.scss
+++ b/packages/shared/styles/components/SfBannerGrid.scss
@@ -4,7 +4,6 @@
   &__row {
     @media screen and (min-width: $desktop-min) {
       display: flex;
-      flex-wrap: wrap;
       flex: 0 0 100%;
     }
     & + & {
@@ -27,6 +26,12 @@
     & + & {
       @media screen and (min-width: $desktop-min) {
         margin-left: $spacer-extra-big;
+      }
+    }
+    & > * {
+      @media screen and (min-width: $desktop-min) {
+        display: flex;
+        flex: 1;
       }
     }
     &--small {

--- a/packages/vue/src/examples/pages/home/Home.vue
+++ b/packages/vue/src/examples/pages/home/Home.vue
@@ -14,17 +14,20 @@
     </SfHero>
     <SfBannerGrid :bannerGrid="1" class="banners">
       <template #bannerA>
-        <SfBanner
-          subtitle="Dresses"
-          title="COCKTAIL PARTY"
-          description="Find stunning women's cocktail dresses and party dresses. Stand out in lace and metallic cocktail dresses from all your favorite brands."
-          button-text="SHOP NOW"
-          image="assets/storybook/homepage/bannerF.png"
-          class="sf-banner--left sf-banner--container-full"
-        />
+        <a href="#">
+          <SfBanner
+            subtitle="Dresses"
+            title="COCKTAIL PARTY"
+            description="Find stunning women's cocktail dresses and party dresses. Stand out in lace and metallic cocktail dresses from all your favorite brands."
+            button-text="SHOP NOW"
+            image="assets/storybook/homepage/bannerF.png"
+            class="sf-banner--left sf-banner--container-full"
+          />
+        </a>
       </template>
       <template #bannerB>
-        <SfBanner
+        <a href="#">
+          <SfBanner
           subtitle="Dresses"
           title="LINEN DRESSES"
           description="Find stunning women's cocktail dresses and party dresses. Stand out in lace and metallic cocktail dresses from all your favorite brands."
@@ -32,6 +35,7 @@
           image="assets/storybook/homepage/bannerE.png"
           class="sf-banner--left"
         />
+        </a>
       </template>
       <template #bannerC>
         <a href="#">

--- a/packages/vue/src/examples/pages/home/Home.vue
+++ b/packages/vue/src/examples/pages/home/Home.vue
@@ -34,20 +34,24 @@
         />
       </template>
       <template #bannerC>
-        <SfBanner
-          subtitle="T-Shirts"
-          title="THE OFFICE LIFE"
-          image="assets/storybook/homepage/bannerC.png"
-          class="sf-banner--left sf-banner--container-full"
-        />
+        <a href="#">
+          <SfBanner
+            subtitle="T-Shirts"
+            title="THE OFFICE LIFE"
+            image="assets/storybook/homepage/bannerC.png"
+            class="sf-banner--left sf-banner--container-full"
+          />
+        </a>
       </template>
       <template #bannerD>
-        <SfBanner
-          subtitle="Summer shoes"
-          title="ECO SANDALS"
-          image="assets/storybook/homepage/bannerG.png"
-          class="sf-banner--left sf-banner--container-full"
-        />
+        <a href="#">
+          <SfBanner
+            subtitle="Summer shoes"
+            title="ECO SANDALS"
+            image="assets/storybook/homepage/bannerG.png"
+            class="sf-banner--left sf-banner--container-full"
+          />
+        </a>
       </template>
     </SfBannerGrid>
     <SfCallToAction

--- a/packages/vue/src/examples/pages/home/Home.vue
+++ b/packages/vue/src/examples/pages/home/Home.vue
@@ -28,13 +28,13 @@
       <template #bannerB>
         <a href="#">
           <SfBanner
-          subtitle="Dresses"
-          title="LINEN DRESSES"
-          description="Find stunning women's cocktail dresses and party dresses. Stand out in lace and metallic cocktail dresses from all your favorite brands."
-          button-text="SHOP NOW"
-          image="assets/storybook/homepage/bannerE.png"
-          class="sf-banner--left"
-        />
+            subtitle="Dresses"
+            title="LINEN DRESSES"
+            description="Find stunning women's cocktail dresses and party dresses. Stand out in lace and metallic cocktail dresses from all your favorite brands."
+            button-text="SHOP NOW"
+            image="assets/storybook/homepage/bannerE.png"
+            class="sf-banner--left"
+          />
         </a>
       </template>
       <template #bannerC>


### PR DESCRIPTION
# Related issue
<!-- paste a link to related issue -->

# Scope of work
<!-- describe what you did -->
Changed column child to `display: flex` and stretch it to full height


# Screenshots of visual changes
before
![image](https://user-images.githubusercontent.com/12138170/62270748-0c0eac80-b437-11e9-8e62-28492302065e.png)

after
![A](https://user-images.githubusercontent.com/12138170/62271230-63f9e300-b438-11e9-95ff-eeff07790a42.png)

# Checklist

- [x] I followed [composition rules](https://github.com/DivanteLtd/storefront-ui/blob/master/docs/component-rules.md) for my component
- [x] I tested the component in most common device sizes (can be tested in Storybook [from viewport addon in top menu](https://github.com/storybooks/storybook/tree/master/addons/viewport))
