### PR TITLE
#293 rename props path to icon SfIcon

### DIFF
--- a/packages/vue/src/components/atoms/SfCheckbox/SfCheckbox.html
+++ b/packages/vue/src/components/atoms/SfCheckbox/SfCheckbox.html
@@ -18,7 +18,7 @@
       <div class="sf-checkbox__checkmark" :class="{'is-active': isChecked}">
         <SfIcon
           v-if="isChecked"
-          path="check"
+          icon="check"
           size="xxs"
           style="width: 11px; height: 9px"
           color="white"

--- a/packages/vue/src/components/atoms/SfIcon/SfIcon.js
+++ b/packages/vue/src/components/atoms/SfIcon/SfIcon.js
@@ -13,7 +13,7 @@ export default {
      * It can be single SVG path (string) or array of SVG paths or icon name
      * from our icons list (such as 'added_to_cart`)
      */
-    path: {
+    icon: {
       type: [String, Array],
       default: ""
     },
@@ -64,18 +64,18 @@ export default {
       return this.isSFSizes ? `sf-icon--size-${this.size.trim()}` : "";
     },
     isSFIcons() {
-      return SF_ICONS.includes(this.path.trim());
+      return SF_ICONS.includes(this.icon.trim());
     },
     iconViewBox() {
       return this.isSFIcons
-        ? icons[this.path].viewBox || this.viewBox
+        ? icons[this.icon].viewBox || this.viewBox
         : this.viewBox;
     },
     iconPaths() {
       if (this.isSFIcons) {
-        return icons[this.path].paths;
+        return icons[this.icon].paths;
       } else {
-        return Array.isArray(this.path) ? this.path : [this.path];
+        return Array.isArray(this.icon) ? this.icon : [this.icon];
       }
     }
   },

--- a/packages/vue/src/components/atoms/SfIcon/SfIcon.spec.ts
+++ b/packages/vue/src/components/atoms/SfIcon/SfIcon.spec.ts
@@ -24,7 +24,7 @@ describe("SfIcon.vue", () => {
 
     const component = shallowMount(SfIcon, {
       propsData: {
-        path: path
+        icon: path
       }
     });
 

--- a/packages/vue/src/components/atoms/SfIcon/SfIcon.stories.js
+++ b/packages/vue/src/components/atoms/SfIcon/SfIcon.stories.js
@@ -80,9 +80,9 @@ storiesOf("Atoms|Icon", module)
             "null"
           )
         },
-        path: {
+        icon: {
           default: text(
-            "path (prop)",
+            "icon (prop)",
             "M10 0C4.48561 0 0 4.48561 0 10C0 15.5144 4.48561 20 10 20C15.5144 20 20 15.5144 20 10C20 4.48561 15.5144 0 10 0ZM10 1.46341C14.7237 1.46341 18.5366 5.27634 18.5366 10C18.5366 14.7237 14.7237 18.5366 10 18.5366C5.27634 18.5366 1.46341 14.7237 1.46341 10C1.46341 5.27634 5.27634 1.46341 10 1.46341ZM10 2.68293C9.59605 2.68293 9.26829 3.01068 9.26829 3.41463V10C9.26829 10.2706 9.41597 10.5059 9.63415 10.6326L14.9161 13.6814C15.2658 13.8834 15.7126 13.7643 15.9146 13.4146C16.1166 13.065 15.9975 12.6181 15.6478 12.4161L10.7317 9.58078V3.41468C10.7317 3.01073 10.404 2.68298 10 2.68298V2.68293Z"
           )
         },
@@ -99,7 +99,7 @@ storiesOf("Atoms|Icon", module)
       components: { SfIcon },
       template: `<sf-icon
         :class="customClass"
-        :path="path"
+        :icon="icon"
         :color="color"
         :size="size"
         :viewBox="viewBox"
@@ -132,11 +132,11 @@ storiesOf("Atoms|Icon", module)
     }
   )
   .add(
-    "[path] - Icons list",
+    "[icon] - Icons list",
     () => ({
       props: {
-        path: {
-          default: text("path (prop)", "add_to_cart")
+        icon: {
+          default: text("icon (prop)", "add_to_cart")
         },
         color: {
           default: text("color (prop)", "pink-primary")
@@ -150,7 +150,7 @@ storiesOf("Atoms|Icon", module)
       },
       components: { SfIcon },
       template: `<sf-icon
-        :path="path"
+        :icon="icon"
         :color="color"
         :size="size"
         :viewBox="viewBox"
@@ -166,7 +166,7 @@ storiesOf("Atoms|Icon", module)
             tableHeadConfig: tableHeaderConfig,
             tableBodyConfig: iconsList
           },
-          "`path` - icon name or SVG path(s)"
+          "`icon` - icon name or SVG path(s)"
         )}
         `
       }
@@ -181,7 +181,7 @@ storiesOf("Atoms|Icon", module)
     {
       info: {
         summary:
-          "Use this slot if passing icon SVG path is not enough. **Note** that need to provide also alt attribute or arial-label."
+          "Use this slot if passing icon SVG icon is not enough. **Note** that need to provide also alt attribute or arial-label."
       }
     }
   )

--- a/packages/vue/src/components/molecules/SfAlert/SfAlert.html
+++ b/packages/vue/src/components/molecules/SfAlert/SfAlert.html
@@ -2,7 +2,7 @@
     <!--@slot Custom alert icon. Slot content will replace default icon <img> tag.-->
     <slot name="icon" :icon="icon">
         <img :src="iconSrc" class="sf-alert__icon" v-if="hasIconSrc">
-        <sf-icon path="notify" size="xs" :class="`sf-alert--${type}`" color="black" v-else/>
+        <sf-icon icon="notify" size="xs" :class="`sf-alert--${type}`" color="black" v-else/>
     </slot>
     <!--@slot Custom message . Slot content will replace default message <span> tag.-->
     <slot name="message" v-bind="{ message }">

--- a/packages/vue/src/components/molecules/SfCharacteristic/SfCharacteristic.html
+++ b/packages/vue/src/components/molecules/SfCharacteristic/SfCharacteristic.html
@@ -2,7 +2,7 @@
   <!--@slot Icon. Slot content will replace SfIcon atom component-->
   <slot name="icon" v-bind="{color, size, iconPath}">
     <div class="sf-characteristic__icon">
-      <SfIcon :color="color" :size="size" :path="iconPath" />
+      <SfIcon :color="color" :size="size" :icon="iconPath" />
     </div>
   </slot>
   <!--@slot Characteristic text. Slot content will replace default title and description text-->

--- a/packages/vue/src/components/molecules/SfCounter/SfCounter.html
+++ b/packages/vue/src/components/molecules/SfCounter/SfCounter.html
@@ -4,7 +4,7 @@
     class="sf-counter__control sf-counter__control--down"
     @click="decrease">
     <slot name="down">
-      <sf-icon path="chevron_left" size="23px"/>
+      <sf-icon icon="chevron_left" size="23px"/>
     </slot>
   </div>
 
@@ -30,7 +30,7 @@
     aria-label="Increase"
     @click="increase">
     <slot name="up">
-      <sf-icon path="chevron_right" size="23px"/>
+      <sf-icon icon="chevron_right" size="23px"/>
     </slot>
   </div>
 </div>

--- a/packages/vue/src/components/molecules/SfMenuItem/SfMenuItem.html
+++ b/packages/vue/src/components/molecules/SfMenuItem/SfMenuItem.html
@@ -4,7 +4,7 @@
 		<span class="sf-menu-item__label">{{ label }}</span>
 		<div class="sf-menu-item__right">
 			<span class="sf-menu-item__count">{{ count }}</span>
-			<sf-icon :path="mobileNavIcon" v-if="mobileNavIcon" class="sf-menu-item__mobile-nav-icon" size="14px"/>
+			<sf-icon :icon="mobileNavIcon" v-if="mobileNavIcon" class="sf-menu-item__mobile-nav-icon" size="14px"/>
 		</div>
 	</slot>
 </div>

--- a/packages/vue/src/components/molecules/SfModal/SfModal.html
+++ b/packages/vue/src/components/molecules/SfModal/SfModal.html
@@ -11,7 +11,7 @@
       <button class="sf-modal__cross" @click="close" v-if="cross">
         <!--@slot Use this slot to place content inside the close button.-->
         <slot name="close">
-          <SfIcon path="cross" size="15px" color="gray-secondary"/>
+          <SfIcon icon="cross" size="15px" color="gray-secondary"/>
         </slot>
       </button>
       <div class="sf-modal__content">

--- a/packages/vue/src/components/molecules/SfPagination/SfPagination.html
+++ b/packages/vue/src/components/molecules/SfPagination/SfPagination.html
@@ -7,7 +7,7 @@
         @click="setCurrentPage(currentPage - 1)">
         <!-- @slot Custom markup for previous page icon -->
         <slot name="prev">
-          <sf-icon path="chevron_left" size="14px"/>
+          <sf-icon icon="chevron_left" size="14px"/>
         </slot>
       </a>
     </li>
@@ -58,7 +58,7 @@
         @click="setCurrentPage(currentPage + 1)">
         <!-- @slot Custom markup for next page icon -->
         <slot name="next">
-          <sf-icon path="chevron_right" size="14px"/>
+          <sf-icon icon="chevron_right" size="14px"/>
         </slot>
       </a>
     </li>

--- a/packages/vue/src/components/molecules/SfProductCard/SfProductCard.html
+++ b/packages/vue/src/components/molecules/SfProductCard/SfProductCard.html
@@ -5,7 +5,7 @@
     @click="toggleOnWishlist"  
     :class="wishlistIconClasses">
     <slot name="wishlist-icon">
-      <sf-icon :path="currentWishlistIcon" color="black" size="sm" data-test="sf-wishlist-icon"/>
+      <sf-icon :icon="currentWishlistIcon" color="black" size="sm" data-test="sf-wishlist-icon"/>
     </slot>
   </button>
   <slot name="image">

--- a/packages/vue/src/components/organisms/SfBottomNavigation/SfBottomNavigation.stories.js
+++ b/packages/vue/src/components/organisms/SfBottomNavigation/SfBottomNavigation.stories.js
@@ -27,20 +27,20 @@ storiesOf("Molecules|BottomNavigation", module)
       template: `<SfBottomNavigation
       >
         <SfBottomNavigationItem>
-          <SfIcon path="home" size="20px"/>
+          <SfIcon icon="home" size="20px"/>
         </SfBottomNavigationItem>
         <SfBottomNavigationItem>
-          <SfIcon path="menu" size="20px" style="width: 25px" />
+          <SfIcon icon="menu" size="20px" style="width: 25px" />
         </SfBottomNavigationItem>
         <SfBottomNavigationItem>
-          <SfIcon path="heart" size="20px"/>
+          <SfIcon icon="heart" size="20px"/>
         </SfBottomNavigationItem>
         <SfBottomNavigationItem>
-          <SfIcon path="profile" size="20px"/>
+          <SfIcon icon="profile" size="20px"/>
         </SfBottomNavigationItem>
         <SfBottomNavigationItem>
           <SfCircleIcon class="sf-bottom-navigation__floating-icon sf-circle-icon--big">
-            <SfIcon path="add_to_cart" size="20px" color="white" style="margin-right: 4px;"/>
+            <SfIcon icon="add_to_cart" size="20px" color="white" style="margin-right: 4px;"/>
           </SfCircleIcon>
         </SfBottomNavigationItem>
       </SfBottomNavigation>`

--- a/packages/vue/src/components/organisms/SfSidebar/SfSidebar.html
+++ b/packages/vue/src/components/organisms/SfSidebar/SfSidebar.html
@@ -7,7 +7,7 @@
   <transition :name="'slide-' + position">
     <aside v-if="visible" class="sf-sidebar__aside">
       <SfCircleIcon v-if="button" class="sf-sidebar__button" @click="$emit('close')">
-        <sf-icon path="cross" color="white" size="14px"/>
+        <sf-icon icon="cross" color="white" size="14px"/>
       </SfCircleIcon>
       <div class="sf-sidebar__content">
         <slot />

--- a/packages/vue/src/components/organisms/SfStoreLocator/SfStoreLocator.html
+++ b/packages/vue/src/components/organisms/SfStoreLocator/SfStoreLocator.html
@@ -14,14 +14,14 @@
         <l-control-zoom position="topleft" />
         <l-control position="topleft" class="leaflet-bar leaflet-control leaflet-control-zoom-in sf-store-locator__map-wrapper-map-my-location-btn">
           <a title="center on user position" role="button" aria-label="center on user position" href="#" @click.prevent="locateUser">
-            <sf-icon path="home" />
+            <sf-icon icon="home" />
           </a>
         </l-control>
         <l-marker v-for="(store, index) in stores" :lat-lng="store.latlng" :key="index" v-bind="markerOptions">
           <l-icon :icon-size="markerIconSize" :icon-anchor="markerIconAnchor">
             <!-- @slot Use this slot to change the icon of the stores, remember to update `markerIconSize` and `markerIconAnchor` accordingly-->
               <slot name="marker-icon" >
-                <sf-icon :aria-label="`${store.name} located at ${store.address}`" path="marker" />
+                <sf-icon :aria-label="`${store.name} located at ${store.address}`" icon="marker" />
               </slot>
           </l-icon>
         </l-marker>

--- a/packages/vue/src/components/organisms/SfStoreLocator/_internal/SfStore.html
+++ b/packages/vue/src/components/organisms/SfStoreLocator/_internal/SfStore.html
@@ -17,11 +17,11 @@
         {{ address }}
       </div>
       <div class="sf-store__item-info-phone" v-if="phone">
-        <sf-icon path="phone" size="13px" color="green-primary" />
+        <sf-icon icon="phone" size="13px" color="green-primary" />
         <span tabindex="0">{{ phone }}</span>
       </div>
       <div class="sf-store__item-info-email" v-if="email">
-        <sf-icon path="mail" size="13px" color="green-primary" />
+        <sf-icon icon="mail" size="13px" color="green-primary" />
         <span tabindex="0">{{ email }}</span>
       </div>
       <sf-divider class="sf-store__mobile-divider" />

--- a/yarn.lock
+++ b/yarn.lock
@@ -11329,7 +11329,7 @@ mime@1.6.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/mime/-/mime-1.6.0.tgz#32cd9e5c64553bd58d19a568af452acff04981b1"
 
-mime@^2.0.3, mime@^2.3.1:
+mime@^2.0.3, mime@^2.3.1, mime@^2.4.2:
   version "2.4.4"
   resolved "https://registry.yarnpkg.com/mime/-/mime-2.4.4.tgz#bd7b91135fc6b01cde3e9bae33d659b63d8857e5"
 
@@ -13531,7 +13531,7 @@ randomfill@^1.0.3:
     randombytes "^2.0.5"
     safe-buffer "^5.1.0"
 
-range-parser@^1.0.3, range-parser@~1.2.1:
+range-parser@^1.0.3, range-parser@^1.2.1, range-parser@~1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/range-parser/-/range-parser-1.2.1.tgz#3cf37023d199e1c24d1a55b84800c2f3e6468031"
 
@@ -16067,6 +16067,13 @@ vue-docgen-api@^3.11.4:
     vue "^2.6.9"
     vue-template-compiler "^2.6.10"
 
+vue-drag-drop@^1.1.4:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/vue-drag-drop/-/vue-drag-drop-1.1.4.tgz#6e94aeb10304b91d651614b7307d0b90f0227e89"
+  integrity sha512-zrpvKcD5LPVbht7cJ7ZBY0poS8GDLibRck18Zx0polkoSSpTPNMAv/m/b98xtZ3I1jdWGyiPybfPgKFFkygjhQ==
+  dependencies:
+    core-js "^2.5.3"
+
 vue-eslint-parser@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/vue-eslint-parser/-/vue-eslint-parser-2.0.3.tgz#c268c96c6d94cfe3d938a5f7593959b0ca3360d1"
@@ -16324,7 +16331,7 @@ webpack-chain@^4.11.0, webpack-chain@^4.6.0:
     deepmerge "^1.5.2"
     javascript-stringify "^1.6.0"
 
-webpack-dev-middleware@3.6.0, webpack-dev-middleware@^3.0.0, webpack-dev-middleware@^3.7.0:
+webpack-dev-middleware@3.6.0, webpack-dev-middleware@^3.0.0:
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/webpack-dev-middleware/-/webpack-dev-middleware-3.6.0.tgz#71f1b04e52ff8d442757af2be3a658237d53a3e5"
   dependencies:


### PR DESCRIPTION
# Related issue
[#293 ](https://github.com/DivanteLtd/storefront-ui/issues/293)

# Scope of work
Rename `path` to `icon` for a better convention

# Screenshots of visual changes

# Checklist

- [x] I followed [composition rules](https://docs.storefrontui.io/component-rules.html) for my component
- [x] I tested the component in most common device sizes (can be tested in Storybook [from viewport addon in top menu](https://github.com/storybooks/storybook/tree/master/addons/viewport))
