### PR TITLE
chore(SfGallery): sticky thumbs on horizontally

### DIFF
--- a/packages/shared/styles/components/SfCollectedProduct.scss
+++ b/packages/shared/styles/components/SfCollectedProduct.scss
@@ -1,0 +1,59 @@
+@import "../variables";
+
+$collected-card-hover-box-shadow: 0px 4px 35px rgba(168, 172, 176, 0.19) !default;
+$sf-circle-icon-background-primary: $c-gray-primary;
+$sf-circle-icon-background-secondary: $c-gray-secondary;
+.sf-collected-product {
+  @media (max-width: $mobile-max) {
+    margin-right: 25px;
+  }
+  max-width: 100%;
+  position: relative;
+  transition: 0.3s all;
+  .sf-collected-product__remove {
+    @media (max-width: $mobile-max) {
+      visibility: visible;
+    }
+    position: absolute;
+    right: -25px;
+    top: 10px;
+    visibility: hidden;
+  }
+  &__container {
+    display: flex;
+    .sf-collected-product__image {
+      max-width: 100%;
+      display: flex;
+      position: relative;
+      flex-direction: column;
+      padding: 10px;
+      align-items: flex-end;
+      justify-content: end;
+      img {
+        max-width: 100%;
+      }
+      .sf-counter {
+        position: absolute;
+        right: 1rem;
+        bottom: 1rem;
+      }
+    }
+    .sf-collected-product__contents {
+      width: 100%;
+      display: flex;
+      flex-direction: column;
+      justify-content: space-between;
+      .sf-collected-product__title {
+        margin-top: 0.5rem;
+        margin-bottom: 0.25rem;
+        display: flex;
+        font-weight: 300;
+      }
+    }
+  }
+  &:hover {
+    box-shadow: $collected-card-hover-box-shadow;
+    transition: 0.3s all;
+    z-index: 2;
+  }
+}

--- a/packages/shared/styles/components/SfGallery.scss
+++ b/packages/shared/styles/components/SfGallery.scss
@@ -1,4 +1,4 @@
-@import '../variables';
+@import "../variables";
 @import "~@glidejs/glide/src/assets/sass/glide.core";
 
 $gallery-flex-direction: row !default;
@@ -16,19 +16,24 @@ $gallery__stage-width: 400px !default;
   display: flex;
   flex-direction: $gallery-flex-direction;
   position: relative;
+  @media (max-width: $mobile-max) {
+    justify-content: center;
+  }
   &__thumbs {
     width: $gallery__nav-width;
     padding: 0;
     margin: $gallery__nav-margin;
+    overflow-y: auto;
     @media (max-width: $mobile-max) {
       z-index: 2;
       position: absolute;
       width: auto;
       margin: 0;
       padding: 0;
-      left: $spacer-medium;
-      top: 50%;
-      transform: translateY(-50%);
+      top: 100%;
+      display: inline-flex;
+      bottom: 0;
+      overflow: inherit;
     }
   }
   &__item {
@@ -53,6 +58,9 @@ $gallery__stage-width: 400px !default;
         width: $gallery__item-mobile-size;
         background: $c-gray-secondary;
         border-radius: 50%;
+        @media (max-width: $mobile-max) {
+          margin: 0 5px;
+        }
       }
       &--selected::before {
         background: $c-accent-primary;
@@ -62,6 +70,7 @@ $gallery__stage-width: 400px !default;
   &__stage {
     width: $gallery__stage-width;
     max-width: 100%;
+    overflow: hidden;
   }
   &__thumb {
     display: block;

--- a/packages/vue/src/components/molecules/SfCollectedProduct/SfCollectedProduct.html
+++ b/packages/vue/src/components/molecules/SfCollectedProduct/SfCollectedProduct.html
@@ -1,0 +1,36 @@
+<div class="sf-collected-product">
+  <!-- @slot -->
+  <slot name="remove">
+    <SfCircleIcon colorIcon="white" sizeIcon="50%" class="sf-collected-product__remove">
+      <SfIcon icon="cross" size="15px" color="white" />
+    </SfCircleIcon>
+  </slot>
+  <div class="sf-collected-product__container">
+    <slot name="image" v-bind="{image, title}">
+      <div class="sf-collected-product__image">
+        <img :src="image" :alt="title">
+        <!-- @slot -->
+        <SfCounter />
+      </div>
+    </slot>
+    <div class="sf-collected-product__contents">
+      <div>
+        <!-- @slot -->
+        <slot name="title" v-bind="{title}">
+          <span class="sf-collected-product__title">
+            {{ title }}
+          </span>
+        </slot>
+        <!-- @slot -->
+        <slot name="price" v-bind="{ specialPrice, regularPrice }">
+          <SfPrice class="sf-collected-product__price" v-if="regularPrice" :regular="regularPrice"
+            :special="specialPrice" />
+        </slot>
+      </div>
+      <!-- @slot -->
+      <slot name="configuration"></slot>
+      <!-- @slot -->
+      <slot name="actions"></slot>
+    </div>
+  </div>
+</div>

--- a/packages/vue/src/components/molecules/SfCollectedProduct/SfCollectedProduct.js
+++ b/packages/vue/src/components/molecules/SfCollectedProduct/SfCollectedProduct.js
@@ -1,0 +1,44 @@
+import SfPrice from "../../atoms/SfPrice/SfPrice.vue";
+import SfIcon from "../../atoms/SfIcon/SfIcon.vue";
+import SfCircleIcon from "../../atoms/SfCircleIcon/SfCircleIcon.vue";
+import SfCounter from "../../molecules/SfCounter/SfCounter.vue";
+export default {
+  name: "SfCollectedProduct",
+  props: {
+    /**
+     * Product image
+     * It should be an url of the product
+     */
+    image: {
+      type: String,
+      default: "assets/storybook/product_thumb.png"
+    },
+    /**
+     * Product title
+     */
+    title: {
+      type: String,
+      required: true
+    },
+    /**
+     * Product regular price
+     */
+    regularPrice: {
+      type: [Number, String],
+      default: null
+    },
+    /**
+     * Product special price
+     */
+    specialPrice: {
+      type: [Number, String],
+      default: null
+    }
+  },
+  components: {
+    SfIcon,
+    SfCircleIcon,
+    SfPrice,
+    SfCounter
+  }
+};

--- a/packages/vue/src/components/molecules/SfCollectedProduct/SfCollectedProduct.spec.ts
+++ b/packages/vue/src/components/molecules/SfCollectedProduct/SfCollectedProduct.spec.ts
@@ -1,0 +1,9 @@
+import { shallowMount } from "@vue/test-utils";
+import SfCollectedProduct from "@/components/molecules/SfCollectedProduct.vue";
+
+describe("SfCollectedProduct.vue", () => {
+  it("renders a component", () => {
+    const component = shallowMount(SfCollectedProduct);
+    expect(component.contains(".sf-sf-collected-product")).toBe(true);
+  });
+});

--- a/packages/vue/src/components/molecules/SfCollectedProduct/SfCollectedProduct.stories.js
+++ b/packages/vue/src/components/molecules/SfCollectedProduct/SfCollectedProduct.stories.js
@@ -1,0 +1,67 @@
+// /* eslint-disable import/no-extraneous-dependencies */
+import { storiesOf } from "@storybook/vue";
+import { withKnobs, text } from "@storybook/addon-knobs";
+import { generateStorybookTable } from "@/helpers";
+
+import SfCollectedProduct from "./SfCollectedProduct.vue";
+// use this to document scss vars
+const scssTableConfig = {
+  tableHeadConfig: ["NAME", "DEFAULT", "DESCRIPTION"],
+  tableBodyConfig: [
+    [
+      "$collected-product-card-box-shadow",
+      "0px 4px 35px rgba(168, 172, 176, 0.19)",
+      "Shadow effect on collected product"
+    ]
+  ]
+};
+
+const data = () => {
+  return {
+    image:
+      "https://ecom-ptqgjveg.nyc3.digitaloceanspaces.com/@1550858949523-frontal-macbook-pro-apple-13-intel-core-i5-128gb-mpxq2bz-a.jpg",
+    title: "Product name",
+    regularPrice: 12.99,
+    specialPrice: 1.99
+  };
+};
+
+storiesOf("Molecules|CollectedProduct", module)
+  .addDecorator(withKnobs)
+  .add(
+    "Props",
+    () => ({
+      props: {
+        image: {
+          default: text("image (prop)", "assets/storybook/product_thumb.png")
+        },
+        title: {
+          default: text("title (prop)", "Product name")
+        },
+        regularPrice: {
+          default: text("regularPrice (prop)", "$10,99")
+        },
+        specialPrice: {
+          default: text("specialPrice (prop)", "$5,99")
+        }
+      },
+      data,
+      components: { SfCollectedProduct },
+      template: `    <SfCollectedProduct
+      :image="image"
+      :title="title"
+      :specialPrice="specialPrice"
+      :regularPrice="regularPrice"/>`
+    }),
+    {
+      info: {
+        summary: `
+        <p>Component for rendering Collected Product.</p>
+        <h2> Usage </h2>
+        <pre><code>import { SfCollectedProduct } from "@storefront-ui/vue"</code></pre>
+        ${generateStorybookTable(scssTableConfig, "SCSS Variables")}`
+      }
+    }
+  )
+  .add("[slot] configuration")
+  .add("[slot] actions");

--- a/packages/vue/src/components/molecules/SfCollectedProduct/SfCollectedProduct.vue
+++ b/packages/vue/src/components/molecules/SfCollectedProduct/SfCollectedProduct.vue
@@ -1,0 +1,5 @@
+<script src="./SfCollectedProduct.js"></script>
+<template lang="html" src="./SfCollectedProduct.html"></template>
+<style lang="scss">
+@import "~@storefront-ui/shared/styles/components/SfCollectedProduct.scss";
+</style>


### PR DESCRIPTION
# Scope of work
thumbs from gallery stuck horizontally on mobile to prevent  the user gets confused when browsing gallery
# Screenshots of visual changes
![Captura de tela de 2019-08-27 13-23-20](https://user-images.githubusercontent.com/14341511/63792683-6e42bc00-c8d4-11e9-8a53-0fbb062a848b.png)

to

![Captura de tela de 2019-08-27 13-17-43](https://user-images.githubusercontent.com/14341511/63792708-80245f00-c8d4-11e9-8509-be6fb3c1f75b.png)


# Checklist
- [x] I followed [composition rules](https://docs.storefrontui.io/component-rules.html) for my component
- [x] I tested the component in most common device sizes (can be tested in Storybook [from viewport addon in top menu](https://github.com/storybooks/storybook/tree/master/addons/viewport))
