### PR TITLE
Fade in/out effect added to SfAccordion component

### DIFF
--- a/packages/vue/src/components/organisms/SfAccordion/SfAccordion.js
+++ b/packages/vue/src/components/organisms/SfAccordion/SfAccordion.js
@@ -33,6 +33,13 @@ export default {
     showChevron: {
       type: Boolean,
       default: true
+    },
+    /**
+     * Overlay transition effect
+     */
+    transition: {
+      type: String,
+      default: "fade"
     }
   },
 

--- a/packages/vue/src/components/organisms/SfAccordion/SfAccordion.vue
+++ b/packages/vue/src/components/organisms/SfAccordion/SfAccordion.vue
@@ -1,5 +1,6 @@
 <script src="./SfAccordion.js"></script>
 <template lang="html" src="./SfAccordion.html"></template>
 <style lang="scss">
+@import "../../../utilities/transitions/transitions.scss";
 @import "~@storefront-ui/shared/styles/components/SfAccordion.scss";
 </style>

--- a/packages/vue/src/components/organisms/SfAccordion/_internal/SfAccordionItem.html
+++ b/packages/vue/src/components/organisms/SfAccordion/_internal/SfAccordionItem.html
@@ -15,19 +15,21 @@
       alt="Toggle this section"
     />
   </div>
-  <div class="sf-accordion-item__content-wrapper" v-if="isOpen">
-    <!-- @slot -->
-    <slot v-bind="{items: contentItems, handler: onContentItemClick}">
-      <div class="sf-accordion-item__content">
-        <div
-          v-for="item of contentItems"
-          :key="item.id"
-          @click="onContentItemClick(item.id)"
-          :class="{'sf-accordion-item__content--active': item.id === selected}"
-        >
-          {{ item.text }}
+  <transition :name="$parent.transition">
+    <div class="sf-accordion-item__content-wrapper" v-if="isOpen">
+      <!-- @slot -->
+      <slot v-bind="{items: contentItems, handler: onContentItemClick}">
+        <div class="sf-accordion-item__content">
+          <div
+            v-for="item of contentItems"
+            :key="item.id"
+            @click="onContentItemClick(item.id)"
+            :class="{'sf-accordion-item__content--active': item.id === selected}"
+          >
+            {{ item.text }}
+          </div>
         </div>
-      </div>
-    </slot>
-  </div>
+      </slot>
+    </div>
+  </transition>
 </div>


### PR DESCRIPTION
# Related issue
https://github.com/DivanteLtd/storefront-ui/issues/280

# Scope of work
Fade in/out effect added to SfAccordion component

# Screenshots of visual changes

# Checklist

- [x] I followed [composition rules](https://docs.storefrontui.io/component-rules.html) for my component
- [x] I tested the component in most common device sizes (can be tested in Storybook [from viewport addon in top menu](https://github.com/storybooks/storybook/tree/master/addons/viewport))
