### PR TITLE
Moved glide.js init to nextTick function

### DIFF
--- a/packages/vue/src/components/molecules/SfGallery/SfGallery.js
+++ b/packages/vue/src/components/molecules/SfGallery/SfGallery.js
@@ -55,14 +55,17 @@ export default {
   },
 
   mounted() {
-    // handle slider with swipe and transitions with Glide.js
-    // https://glidejs.com/docs/
-    const glide = new Glide(this.$refs.glide, this.sliderOptions);
-    glide.on("run", () => {
-      this.go(glide.index);
+    this.$nextTick(() => {
+      // handle slider with swipe and transitions with Glide.js
+      // https://glidejs.com/docs/
+      const glide = new Glide(this.$refs.glide, this.sliderOptions);
+      glide.on("run", () => {
+        this.go(glide.index);
+      });
+      glide.mount();
+      this.glide = glide;
     });
-    glide.mount();
-    this.glide = glide;
+
     // handle lazy load for big images with lozad
     // https://apoorv.pro/lozad.js/
     const observer = lozad(".sf-gallery__big-image");

--- a/packages/vue/src/components/organisms/SfCarousel/SfCarousel.js
+++ b/packages/vue/src/components/organisms/SfCarousel/SfCarousel.js
@@ -67,44 +67,46 @@ export default {
     }
   },
   mounted: function() {
-    const glide = new Glide(this.$refs.glide, this.mergedOptions);
-    glide.mount();
+    this.$nextTick(() => {
+      const glide = new Glide(this.$refs.glide, this.mergedOptions);
+      glide.mount();
+      glide.on("run.before", move => {
+        const { slidePerPage, rewind, type } = this.mergedOptions;
 
-    glide.on("run.before", move => {
-      const { slidePerPage, rewind, type } = this.mergedOptions;
+        if (!slidePerPage) return;
 
-      if (!slidePerPage) return;
+        const { perView } = glide.settings;
+        if (!perView > 1) return;
 
-      const { perView } = glide.settings;
-      if (!perView > 1) return;
+        const size = this.$slots.default.filter(slot => slot.tag).length;
+        const { direction } = move;
+        let page, newIndex;
 
-      const size = this.$slots.default.filter(slot => slot.tag).length;
-      const { direction } = move;
-      let page, newIndex;
-
-      switch (direction) {
-        case ">":
-        case "<":
-          page = Math.ceil(glide.index / perView);
-          newIndex = page * perView + (direction === ">" ? perView : -perView);
-          if (newIndex >= size) {
-            if (type === "slider" && !rewind) {
-              newIndex = glide.index;
-            } else {
-              newIndex = 0;
+        switch (direction) {
+          case ">":
+          case "<":
+            page = Math.ceil(glide.index / perView);
+            newIndex =
+              page * perView + (direction === ">" ? perView : -perView);
+            if (newIndex >= size) {
+              if (type === "slider" && !rewind) {
+                newIndex = glide.index;
+              } else {
+                newIndex = 0;
+              }
+            } else if (newIndex < 0 || newIndex + perView > size) {
+              if (type === "slider" && !rewind) {
+                newIndex = glide.index;
+              } else {
+                newIndex = size - perView;
+              }
             }
-          } else if (newIndex < 0 || newIndex + perView > size) {
-            if (type === "slider" && !rewind) {
-              newIndex = glide.index;
-            } else {
-              newIndex = size - perView;
-            }
-          }
 
-          move.direction = "=";
-          move.steps = newIndex;
-      }
+            move.direction = "=";
+            move.steps = newIndex;
+        }
+      });
+      this.glide = glide;
     });
-    this.glide = glide;
   }
 };

--- a/packages/vue/src/components/organisms/SfHero/SfHero.js
+++ b/packages/vue/src/components/organisms/SfHero/SfHero.js
@@ -79,9 +79,11 @@ export default {
 
   mounted() {
     if (this.numberOfPages) {
-      const glide = new Glide(this.$refs.glide, this.mergedOptions);
-      glide.mount();
-      this.glide = glide;
+      this.$nextTick(() => {
+        const glide = new Glide(this.$refs.glide, this.mergedOptions);
+        glide.mount();
+        this.glide = glide;
+      });
     }
   }
 };


### PR DESCRIPTION
# Related issue
<!-- paste a link to related issue -->
No issue

# Scope of work
<!-- describe what you did -->
Moved all glide.js initialization function to nextTick. Because on mounted is to fast and glide can't calculate slide size. 

# Screenshots of visual changes
before:
![before](https://user-images.githubusercontent.com/12138170/64618089-e4b8e100-d3df-11e9-95b9-23458cb99a3d.png)

after: 
![after](https://user-images.githubusercontent.com/12138170/64618093-e682a480-d3df-11e9-8e47-b9d17c89ea5e.png)


# Checklist

- [x] I followed [composition rules](https://docs.storefrontui.io/component-rules.html) for my component
- [x] I tested the component in most common device sizes (can be tested in Storybook [from viewport addon in top menu](https://github.com/storybooks/storybook/tree/master/addons/viewport))
