### PR TITLE
Fix #330 - Fix links to contributor guide, label system and Nico's location

### DIFF
--- a/packages/vue/docs/assets/members.json
+++ b/packages/vue/docs/assets/members.json
@@ -60,7 +60,12 @@
 }, {
     "name": "Nicolò Maria Mezzopera",
     "role": "Maintainer",
-    "location": "Sofia, Hungary",
+    "work": {
+        "title": "Senior Frontend Engineer",
+        "org": "Gitlab",
+        "orgUrl": "https://gitlab.com/"
+    },
+    "location": "Budapest, Hungary",
     "languages": ["it", "en"],
     "socials": {
         "github": "DonNicoJs",

--- a/packages/vue/docs/contributing/become-a-contributor.md
+++ b/packages/vue/docs/contributing/become-a-contributor.md
@@ -55,7 +55,7 @@ We have a lot of features that need good helping hand, as always. However, there
 Then you'll be ready to [pick your first issue](https://github.com/DivanteLtd/storefront-ui/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22) and contribute to [StorefrontUI](https://github.com/DivanteLtd/storefront-ui) core respository.
 
 ::: tip DON'T KNOW WHICH ISSUE TO SELECT?
-We **have our issues labelled** to make it easier in selecting an issue to work with. You can also check about [our labels system](github-guidelines#_3-select-a-github-issue) for more information.
+We **have our issues labelled** to make it easier in selecting an issue to work with. You can also check about [our labels system](github-guidelines.md#_3-select-a-github-issue) for more information.
 :::
 
 ### Report bug or request a feature

--- a/packages/vue/docs/introduction.md
+++ b/packages/vue/docs/introduction.md
@@ -89,5 +89,5 @@ If you'd like to support us and join the team please write to me:
 ## Useful links
 
 - [StorefrontUI Github](https://github.com/Divanteltd/storefront-ui)
-- [Contribution guide](contributing/getting-started.md)
+- [Contribution guide](contributing/become-a-contributor.md)
 - [Storybook docs](https://storybook.js.org/docs/basics/introduction/)


### PR DESCRIPTION
# Related issue
#330 

# Scope of work
1. Fix broken links (label system in `become-a-contributor.md`, to contributor guide in `introduction.md`
2. Update Nico's job title and location

# Screenshots of visual changes
N/A
# Checklist

- [x] I followed [composition rules](https://docs.storefrontui.io/component-rules.html) for my component
- [x] I tested the component in most common device sizes (can be tested in Storybook [from viewport addon in top menu](https://github.com/storybooks/storybook/tree/master/addons/viewport))
