### PR TITLE
#365 Fix for Auto-Docs-Generation doesn't retrieve SCSS details anymore

### DIFF
--- a/packages/vue/docs/.vuepress/config.js
+++ b/packages/vue/docs/.vuepress/config.js
@@ -41,6 +41,7 @@ module.exports = {
           ["/components/Checkbox", "Checkbox"],
           ["/components/Chevron", "Chevron"],
           ["/components/CircleIcon", "Circle Icon"],
+          ["/components/CollectedProduct", "Collected Product"],
           ["/components/Counter", "Counter"],
           ["/components/Divider", "Divider"],
           ["/components/Filter", "Filter"],

--- a/packages/vue/docs/.vuepress/enhanceApp.js
+++ b/packages/vue/docs/.vuepress/enhanceApp.js
@@ -17,6 +17,7 @@ import SfCharacteristic from "../../src/components/molecules/SfCharacteristic/Sf
 import SfCheckbox from "../../src/components/atoms/SfCheckbox/SfCheckbox.vue"
 import SfChevron from "../../src/components/atoms/SfChevron/SfChevron.vue"
 import SfCircleIcon from "../../src/components/atoms/SfCircleIcon/SfCircleIcon.vue"
+import SfCollectedProduct from "../../src/components/organisms/SfCollectedProduct/SfCollectedProduct.vue"
 import SfCounter from "../../src/components/molecules/SfCounter/SfCounter.vue"
 import SfDivider from "../../src/components/atoms/SfDivider/SfDivider.vue"
 import SfFilter from "../../src/components/molecules/SfFilter/SfFilter.vue"
@@ -79,6 +80,7 @@ export default ({
   Vue.component("SfCheckbox", SfCheckbox);
   Vue.component("SfChevron", SfChevron);
   Vue.component("SfCircleIcon", SfCircleIcon);
+  Vue.component("SfCollectedProduct", SfCollectedProduct);
   Vue.component("SfCounter", SfCounter);
   Vue.component("SfDivider", SfDivider);
   Vue.component("SfFilter", SfFilter);

--- a/packages/vue/scripts/create-vue-components-docs.js
+++ b/packages/vue/scripts/create-vue-components-docs.js
@@ -125,15 +125,16 @@ function getComponentInfoFromPath(pathComponentVue) {
   const componentDirname = path.dirname(pathComponentVue);
   const componentFilename = path.basename(pathComponentVue);
   const componentName = componentFilename.replace(/Sf(.+)\.vue$/, "$1");
+  const sfComponentName = "Sf" + componentName;
   const atomicType = componentDirname.replace(/\/.*/, "");
   const storybookLink = `${atomicType}-${componentName}--basic`.toLowerCase();
 
   return {
     componentName,
-    sfComponentName: "Sf" + componentName,
+    sfComponentName,
     pathComponentHtml: pathComponentVue.replace(/(.+)\.vue$/, "$1.html"),
     pathComponentJs: pathComponentVue.replace(/(.+)\.vue$/, "$1.js"),
-    pathComponentScss: pathComponentVue.replace(/(.+)\.vue$/, "$1.scss"),
+    pathComponentScss: sfComponentName + ".scss",
     pathComponentMd: pathComponentVue.replace(/(.+)\.vue$/, "$1.md"),
     pathInternalComponents: path.join(componentDirname, "_internal"),
     storybookLink


### PR DESCRIPTION
# Related issue
#365 Auto-Docs-Generation doesn't retrieve SCSS details anymore

# Scope of work
This fixes #365.
- Fix for issue
- SfCollectedProduct added to VuePress config

# Checklist
- [x] ~~I followed [composition rules](https://docs.storefrontui.io/component-rules.html) for my component~~
- [x] I tested the component in most common device sizes (can be tested in Storybook [from viewport addon in top menu](https://github.com/storybooks/storybook/tree/master/addons/viewport))
