### PR TITLE
Refactor/SfAccordion

### DIFF
--- a/packages/shared/styles/components/SfAccordion.scss
+++ b/packages/shared/styles/components/SfAccordion.scss
@@ -12,7 +12,7 @@ $accordion__title-color--active: $c-dark-primary !default;
 $accordion__title-color--hover: $c-dark-primary !default;
 $accordion__title-font-size: $font-size-big-mobile !default;
 $accordion__title-font-size-desktop: $font-size-big-desktop !default;
-$accordion__content-padding-y: $spacer-big !default;
+$accordion__content-padding-y: 3 * $spacer-big !default;
 
 @mixin for-desktop {
   @media screen and (min-width: $desktop-min) {
@@ -30,7 +30,7 @@ $accordion__content-padding-y: $spacer-big !default;
     display: flex;
     justify-content: space-between;
     align-items: center;
-    padding: calc(#{$accordion__title-padding-y} - 5px) 0;
+    padding: calc(#{$accordion__title-padding-y / 2} - 5px) 0;
     color: $c-dark-primary;
     cursor: pointer;
     font-size: $accordion__title-font-size;
@@ -40,6 +40,6 @@ $accordion__content-padding-y: $spacer-big !default;
     }
   }
   &__content {
-    padding: $accordion__content-padding-y 0;
+    padding: ($accordion__content-padding-y / 2) 0;
   }
 }

--- a/packages/shared/styles/components/SfAccordion.scss
+++ b/packages/shared/styles/components/SfAccordion.scss
@@ -6,13 +6,13 @@ $accordion-font-size: $font-size-regular-mobile !default;
 $accordion-font-size-desktop: $font-size-regular-desktop !default;
 $accordion-font-weight: $body-font-weight-secondary !default;
 $accordion-line-height: 1.6 !default;
-$accordion__title-padding-y: $spacer-big !default;
+$accordion__title-padding-y: 0.625rem !default;
 $accordion__title-color: $c-gray-secondary !default;
 $accordion__title-color--active: $c-dark-primary !default;
 $accordion__title-color--hover: $c-dark-primary !default;
 $accordion__title-font-size: $font-size-big-mobile !default;
 $accordion__title-font-size-desktop: $font-size-big-desktop !default;
-$accordion__content-padding-y: 3 * $spacer-big !default;
+$accordion__content-padding-y: 1.875rem !default;
 
 @mixin for-desktop {
   @media screen and (min-width: $desktop-min) {
@@ -30,7 +30,7 @@ $accordion__content-padding-y: 3 * $spacer-big !default;
     display: flex;
     justify-content: space-between;
     align-items: center;
-    padding: calc(#{$accordion__title-padding-y / 2} - 5px) 0;
+    padding: $accordion__title-padding-y 0;
     color: $c-dark-primary;
     cursor: pointer;
     font-size: $accordion__title-font-size;
@@ -39,7 +39,7 @@ $accordion__content-padding-y: 3 * $spacer-big !default;
     }
   }
   &__content {
-    padding: ($accordion__content-padding-y / 2) 0;
+    padding: $accordion__content-padding-y 0;
   }
   &__chevron {
     display: none;

--- a/packages/shared/styles/components/SfAccordion.scss
+++ b/packages/shared/styles/components/SfAccordion.scss
@@ -35,7 +35,6 @@ $accordion__content-padding-y: 3 * $spacer-big !default;
     cursor: pointer;
     font-size: $accordion__title-font-size;
     @include for-desktop {
-      padding: $accordion__title-padding-y 0;
       font-size: $accordion__title-font-size-desktop;
     }
   }

--- a/packages/shared/styles/components/SfAccordion.scss
+++ b/packages/shared/styles/components/SfAccordion.scss
@@ -1,49 +1,47 @@
-@import '../variables';
+@import "../variables";
 
-$accordion-item__header-padding: 0.5rem 0 !default;
-$accordion-item__header-font-size: $font-size-big-desktop !default;
-$accordion-item__header-bg-color: $c-light-primary !default;
-$accordion-item__header-bg-color--active: #ffffff !default;
-$accordion-item__header-font-weight: 900 !default;
-$accordion-item__header-text-transform: uppercase !default;
-$accordion-item__header-display: flex !default;
-$accordion-item__header-justify-content: space-between !default;
-$accordion-item__content-color: $c-dark-primary !default;
-$accordion-item__content-font-size: $font-size-regular-desktop !default;
-$accordion-item__content-padding: 0.5rem 0 !default;
-$accordion-item__content-padding--first: 1.5rem 0 0.5rem !default;
-$accordion-item__content-padding--last: 0.5rem 0 1.5rem !default;
+$accordion-border-color: $c-light-primary !default;
+$accordion-font-family: $body-font-family-secondary !default;
+$accordion-font-size: $font-size-regular-mobile !default;
+$accordion-font-size-desktop: $font-size-regular-desktop !default;
+$accordion-font-weight: $body-font-weight-secondary !default;
+$accordion-line-height: 1.6 !default;
+$accordion__title-padding-y: $spacer-big !default;
+$accordion__title-color: $c-gray-secondary !default;
+$accordion__title-color--active: $c-dark-primary !default;
+$accordion__title-color--hover: $c-dark-primary !default;
+$accordion__title-font-size: $font-size-big-mobile !default;
+$accordion__title-font-size-desktop: $font-size-big-desktop !default;
+$accordion__content-padding-y: 3 * $spacer-big !default;
+
+@mixin for-desktop{
+  @media screen and (min-width: $desktop-min){
+    @content;
+  }
+}
 
 .sf-accordion {
-  &-item__header-wrapper {
+  $this: &;
+  font-family: $accordion-font-family;
+  font-size: $accordion-font-size;
+  font-weight: $accordion-font-weight;
+  line-height: $accordion-line-height;
+  &__header{
     display: flex;
     justify-content: space-between;
     align-items: center;
+    padding: calc(#{$accordion__title-padding-y} - 5px) 0;
+    border-bottom: 1px solid $accordion-border-color;
+    color: $c-dark-primary;
     cursor: pointer;
-  }
-  &-item__header {
-    padding: $accordion-item__header-padding;
-    font-size: $accordion-item__header-font-size;
-    font-weight: 400;
-  }
-  &-item__header-icon--up {
-    transform: rotate(180deg);
-  }
-  &-item__content {
-    color: $accordion-item__content-color;
-    font-size: $accordion-item__content-font-size;
-    cursor: pointer;
-    > * {
-      padding: $accordion-item__content-padding;
-      &:first-child {
-        padding: $accordion-item__content-padding--first;
-      }
-      &:last-child {
-        padding: $accordion-item__content-padding--last;
-      }
+    transition: border-color 150ms ease-in-out, color 150ms ease-in-out;
+    font-size: $accordion__title-font-size;
+    @include for-desktop{
+      padding: $accordion__title-padding-y 0;
+      font-size: $accordion__title-font-size-desktop;
     }
-  }
-  &-item__content--active {
-    font-weight: 900;
+    &--open{
+      border-color: transparent;
+    }
   }
 }

--- a/packages/shared/styles/components/SfAccordion.scss
+++ b/packages/shared/styles/components/SfAccordion.scss
@@ -12,36 +12,34 @@ $accordion__title-color--active: $c-dark-primary !default;
 $accordion__title-color--hover: $c-dark-primary !default;
 $accordion__title-font-size: $font-size-big-mobile !default;
 $accordion__title-font-size-desktop: $font-size-big-desktop !default;
-$accordion__content-padding-y: 3 * $spacer-big !default;
+$accordion__content-padding-y: $spacer-big !default;
 
-@mixin for-desktop{
-  @media screen and (min-width: $desktop-min){
+@mixin for-desktop {
+  @media screen and (min-width: $desktop-min) {
     @content;
   }
 }
 
-.sf-accordion {
+.sf-accordion-item {
   $this: &;
   font-family: $accordion-font-family;
   font-size: $accordion-font-size;
   font-weight: $accordion-font-weight;
   line-height: $accordion-line-height;
-  &__header{
+  &__header {
     display: flex;
     justify-content: space-between;
     align-items: center;
     padding: calc(#{$accordion__title-padding-y} - 5px) 0;
-    border-bottom: 1px solid $accordion-border-color;
     color: $c-dark-primary;
     cursor: pointer;
-    transition: border-color 150ms ease-in-out, color 150ms ease-in-out;
     font-size: $accordion__title-font-size;
-    @include for-desktop{
+    @include for-desktop {
       padding: $accordion__title-padding-y 0;
       font-size: $accordion__title-font-size-desktop;
     }
-    &--open{
-      border-color: transparent;
-    }
+  }
+  &__content {
+    padding: $accordion__content-padding-y 0;
   }
 }

--- a/packages/shared/styles/components/SfAccordion.scss
+++ b/packages/shared/styles/components/SfAccordion.scss
@@ -42,4 +42,16 @@ $accordion__content-padding-y: 3 * $spacer-big !default;
   &__content {
     padding: ($accordion__content-padding-y / 2) 0;
   }
+  &__chevron {
+    display: none;
+  }
+}
+
+.sf-accordion {
+  $this: &;
+  &--has-chevron {
+    #{$this}-item__chevron {
+      display: block;
+    }
+  }
 }

--- a/packages/shared/styles/components/SfAccordion.scss
+++ b/packages/shared/styles/components/SfAccordion.scss
@@ -1,15 +1,11 @@
 @import "../variables";
 
-$accordion-border-color: $c-light-primary !default;
 $accordion-font-family: $body-font-family-secondary !default;
 $accordion-font-size: $font-size-regular-mobile !default;
 $accordion-font-size-desktop: $font-size-regular-desktop !default;
 $accordion-font-weight: $body-font-weight-secondary !default;
 $accordion-line-height: 1.6 !default;
 $accordion__title-padding-y: 0.625rem !default;
-$accordion__title-color: $c-gray-secondary !default;
-$accordion__title-color--active: $c-dark-primary !default;
-$accordion__title-color--hover: $c-dark-primary !default;
 $accordion__title-font-size: $font-size-big-mobile !default;
 $accordion__title-font-size-desktop: $font-size-big-desktop !default;
 $accordion__content-padding-y: 1.875rem !default;
@@ -26,6 +22,9 @@ $accordion__content-padding-y: 1.875rem !default;
   font-size: $accordion-font-size;
   font-weight: $accordion-font-weight;
   line-height: $accordion-line-height;
+  @include for-desktop {
+    font-size: $accordion-font-size-desktop;
+  }
   &__header {
     display: flex;
     justify-content: space-between;

--- a/packages/shared/styles/components/SfList.scss
+++ b/packages/shared/styles/components/SfList.scss
@@ -1,21 +1,14 @@
-@import '../variables';
+@import "../variables";
 
 .sf-list {
   list-style-type: none;
   padding-left: 0;
+  margin: 0;
   .sf-list__item {
     font-size: $font-size-big-mobile;
+    padding: $spacer 0;
     @media (min-width: $desktop-min) {
       font-size: $font-size-small-desktop;
     }
-  }
-  .sf-list__item-content {
-    display: flex;
-    flex-wrap: wrap;
-    justify-content: space-between;
-    align-items: center;
-    padding: $spacer 0;
-    font-size: $font-size-big-mobile;
-    font-family: $body-font-family-secondary;
   }
 }

--- a/packages/shared/styles/components/SfTabs.scss
+++ b/packages/shared/styles/components/SfTabs.scss
@@ -27,6 +27,7 @@ $tabs__content-padding-y: 3 * $spacer-big !default;
   flex-wrap: wrap;
   font-family: $tabs-font-family;
   font-size: $tabs-font-size;
+  font-weight: $tabs-font-weight;
   line-height: $tabs-line-height;
   @include for-desktop{
     font-size: $tabs-font-size-desktop;

--- a/packages/vue/src/components/organisms/SfAccordion/SfAccordion.html
+++ b/packages/vue/src/components/organisms/SfAccordion/SfAccordion.html
@@ -1,4 +1,4 @@
 <div class="sf-accordion">
   <!--@slot default slot to setup SfAccordionItem elements -->
-  <slot v-bind="{ selected }"/>
+  <slot />
 </div>

--- a/packages/vue/src/components/organisms/SfAccordion/SfAccordion.html
+++ b/packages/vue/src/components/organisms/SfAccordion/SfAccordion.html
@@ -1,4 +1,4 @@
-<div class="sf-accordion">
+<div class="sf-accordion" :class="{'sf-accordion--has-chevron': showChevron}">
   <!--@slot default slot to setup SfAccordionItem elements -->
   <slot />
 </div>

--- a/packages/vue/src/components/organisms/SfAccordion/SfAccordion.js
+++ b/packages/vue/src/components/organisms/SfAccordion/SfAccordion.js
@@ -26,6 +26,10 @@ export default {
     transition: {
       type: String,
       default: "fade"
+    },
+    showChevron: {
+      type: Boolean,
+      default: true
     }
   },
   methods: {

--- a/packages/vue/src/components/organisms/SfAccordion/SfAccordion.js
+++ b/packages/vue/src/components/organisms/SfAccordion/SfAccordion.js
@@ -5,21 +5,7 @@ Vue.component("SfAccordionItem", SfAccordionItem);
 
 export default {
   name: "SfAccordion",
-
-  data() {
-    return {
-      selected: ""
-    };
-  },
-
   props: {
-    /**
-     * Allows to open multiple accordion items if set to "true"
-     */
-    multiple: {
-      type: Boolean,
-      default: false
-    },
     /**
      * Opens the first accordion item if set to "true"
      */
@@ -28,11 +14,11 @@ export default {
       default: false
     },
     /**
-     * Toggles chevron icon in accordion item header
+     * Allows to open multiple accordion items if set to "true"
      */
-    showChevron: {
+    multiple: {
       type: Boolean,
-      default: true
+      default: false
     },
     /**
      * Overlay transition effect
@@ -42,9 +28,8 @@ export default {
       default: "fade"
     }
   },
-
   methods: {
-    toggle(slotId) {
+    toggleHandler(slotId) {
       if (!this.multiple) {
         this.$children.forEach(child => {
           child._uid === slotId
@@ -59,12 +44,8 @@ export default {
       }
     }
   },
-
   mounted: function() {
-    this.$on("toggle", this.toggle);
-    this.$on("click", id => {
-      this.selected = id;
-    });
+    this.$on("toggle", this.toggleHandler);
     if (this.$children.length) {
       this.$children[0].isOpen = this.firstOpen;
     }

--- a/packages/vue/src/components/organisms/SfAccordion/SfAccordion.stories.js
+++ b/packages/vue/src/components/organisms/SfAccordion/SfAccordion.stories.js
@@ -10,7 +10,44 @@ import SfMenuItem from "../../molecules/SfMenuItem/SfMenuItem.vue";
 // use this to document scss vars
 const scssTableConfig = {
   tableHeadConfig: ["NAME", "DEFAULT", "DESCRIPTION"],
-  tableBodyConfig: []
+  tableBodyConfig: [
+    [
+      "$accordion-font-family",
+      "$body-font-family-secondary",
+      "font family for accordion"
+    ],
+    [
+      "$accordion-font-size",
+      "$font-size-regular-mobile",
+      "font size for accordion"
+    ],
+    [
+      "$accordion-font-size-desktop",
+      "$font-size-regular-desktop",
+      "font size for accordion on desktop"
+    ],
+    [
+      "$accordion-font-weight",
+      "$body-font-weight-secondary",
+      "font weight for accordion"
+    ],
+    ["$accordion-line-height: 1.6", "line height for accordion"],
+    ["$accordion__title-padding-y: 0.625rem", "padding y for accordion title"],
+    [
+      "$accordion__title-font-size",
+      "$font-size-big-mobile",
+      "font size for accordion title"
+    ],
+    [
+      "$accordion__title-font-size-desktop",
+      "$font-size-big-desktop",
+      "font size for accordion title on desktop"
+    ],
+    [
+      "$accordion__content-padding-y: 1.875rem",
+      "padding y for accordion content"
+    ]
+  ]
 };
 
 storiesOf("Organisms|Accordion", module)
@@ -64,7 +101,7 @@ storiesOf("Organisms|Accordion", module)
         }
       },
       components: { SfAccordion, SfList, SfMenuItem },
-      template: `<div :style="{width: '300px'}">
+      template: `<div :style="{width: '300px', padding: '1rem'}">
         <SfAccordion :multiple="multiple" :firstOpen="firstOpen" :showChevron="showChevron" :transition="transition">
           <SfAccordionItem v-for="(accordion, i) of accordions" :header="accordion.header" :key="i">
             <SfList>

--- a/packages/vue/src/components/organisms/SfAccordion/SfAccordion.stories.js
+++ b/packages/vue/src/components/organisms/SfAccordion/SfAccordion.stories.js
@@ -72,7 +72,7 @@ storiesOf("Organisms|Accordion", module)
           default: boolean("multiple", false)
         },
         firstOpen: {
-          default: boolean("firstOpen", false)
+          default: boolean("firstOpen", true)
         },
         showChevron: {
           default: boolean("showChevron", true)
@@ -83,7 +83,7 @@ storiesOf("Organisms|Accordion", module)
       },
       components: { SfAccordion },
       template: `
-      <div style="width: 300px; padding: 1rem;">
+      <div style="w">
         <SfAccordion
           :items="items"
           :multiple="multiple"

--- a/packages/vue/src/components/organisms/SfAccordion/SfAccordion.stories.js
+++ b/packages/vue/src/components/organisms/SfAccordion/SfAccordion.stories.js
@@ -1,6 +1,6 @@
 // /* eslint-disable import/no-extraneous-dependencies */
 import { storiesOf } from "@storybook/vue";
-import { withKnobs, boolean, text} from "@storybook/addon-knobs";
+import { withKnobs, boolean, text } from "@storybook/addon-knobs";
 import { generateStorybookTable } from "@/helpers";
 
 import SfAccordion from "./SfAccordion.vue";

--- a/packages/vue/src/components/organisms/SfAccordion/SfAccordion.stories.js
+++ b/packages/vue/src/components/organisms/SfAccordion/SfAccordion.stories.js
@@ -68,7 +68,7 @@ storiesOf("Organisms|Accordion", module)
         <SfAccordion :multiple="multiple" :firstOpen="firstOpen" :showChevron="showChevron" :transition="transition">
           <SfAccordionItem v-for="(accordion, i) of accordions" :header="accordion.header" :key="i">
             <SfList>
-              <SfListItem v-for="(item, j) of accordion.items" :key="j" style="margin: .25rem 0">
+              <SfListItem v-for="(item, j) of accordion.items" :key="j">
                 <SfMenuItem :label="item.label" :count="item.count"/>
               </SfListItem>
             </SfList>

--- a/packages/vue/src/components/organisms/SfAccordion/SfAccordion.stories.js
+++ b/packages/vue/src/components/organisms/SfAccordion/SfAccordion.stories.js
@@ -1,34 +1,16 @@
 // /* eslint-disable import/no-extraneous-dependencies */
 import { storiesOf } from "@storybook/vue";
-import {
-  withKnobs,
-  boolean,
-  select,
-  number,
-  text
-} from "@storybook/addon-knobs";
+import { withKnobs, boolean, text} from "@storybook/addon-knobs";
 import { generateStorybookTable } from "@/helpers";
 
 import SfAccordion from "./SfAccordion.vue";
+import SfList from "../SfList/SfList.vue";
+import SfMenuItem from "../../molecules/SfMenuItem/SfMenuItem.vue";
 
 // use this to document scss vars
 const scssTableConfig = {
   tableHeadConfig: ["NAME", "DEFAULT", "DESCRIPTION"],
-  tableBodyConfig: [
-    ["$sf-accordion-item__header-padding", "0.5rem 0", ""],
-    ["$accordion-header-font-size", "18px", ""],
-    ["$sf-accordion-item__header-bg-color", "$c-light-primary", ""],
-    ["$sf-accordion-item__header-bg-color--active", "#ffffff", ""],
-    ["$sf-accordion-item__header-font-weight", "900", ""],
-    ["$sf-accordion-item__header-text-transform", "uppercase", ""],
-    ["$sf-accordion-item__header-display", "flex", ""],
-    ["$sf-accordion-item__header-justify-content", "space-between", ""],
-    ["$sf-accordion-item__content-color", "$c-dark-primary", ""],
-    ["$sf-accordion-item__content-font-size", "14px", ""],
-    ["$sf-accordion-item__content-padding", "0.5rem 0", ""],
-    ["$sf-accordion-item__content-padding--first", "1.5rem 0 0.5rem", ""],
-    ["$sf-accordion-item__content-padding--last", "0.5rem 0 1.5rem", ""]
-  ]
+  tableBodyConfig: []
 };
 
 storiesOf("Organisms|Accordion", module)
@@ -38,312 +20,31 @@ storiesOf("Organisms|Accordion", module)
     () => ({
       data: () => {
         return {
-          items: [
+          accordions: [
             {
               header: "About Us",
-              content: [
-                { id: "about_1", text: "About us (Magento CMS)" },
-                { id: "about_2", text: "Store locator" }
+              items: [
+                { label: "About us (Magento CMS)", count: "280" },
+                { label: "Store locator", count: "34" }
               ]
             },
             {
               header: "Departaments",
-              content: [
-                { id: "dep_1", text: "Women fashion" },
-                { id: "dep_2", text: "Men fashion" },
-                { id: "dep_3", text: "Kidswear" },
-                { id: "dep_4", text: "Home" },
-                { id: "dep_5", text: "Dogswear" }
+              items: [
+                { label: "Women fashion", count: "2" },
+                { label: "Men fashion", count: "56" },
+                { label: "Kidswear", count: "16" },
+                { label: "Home", count: "166" },
+                { label: "Dogswear", count: "24" }
               ]
             },
             {
               header: "Help",
-              content: [
-                { id: "help_1", text: "Customer service" },
-                { id: "help_2", text: "Size guide" },
-                { id: "help_3", text: "Contact us" }
+              items: [
+                { label: "Customer service", count: "54" },
+                { label: "Size guide", count: "4" },
+                { label: "Contact us", count: "76" }
               ]
-            }
-          ]
-        };
-      },
-      props: {
-        multiple: {
-          default: boolean("multiple", false)
-        },
-        firstOpen: {
-          default: boolean("firstOpen", true)
-        },
-        showChevron: {
-          default: boolean("showChevron", true)
-        },
-        transition: {
-          default: text("transition", "fade")
-        }
-      },
-      components: { SfAccordion },
-      template: `
-      <div style="w">
-        <SfAccordion
-          :items="items"
-          :multiple="multiple"
-          :firstOpen="firstOpen"
-          :showChevron="showChevron"
-          :transition="transition"
-        >
-          <template v-slot="{ selected }">
-            <SfAccordionItem
-              v-for="(item, i) of items"
-              :key="i"
-              :header="item.header"
-              :contentItems="item.content"
-              :selected="selected"
-            />
-          </template>
-        </SfAccordion>
-      </div>`
-    }),
-    {
-      info: {
-        summary: `<p><code>SfAccordion</code> can be used by providing an array of <code>items</code>
-        as props. Then the user can take advantage of the predefined styles.
-        <br><br>
-        <code>items</code> must be an array of objects in format as follows:
-<pre>
-<code>{
-    header: String,
-    content: [
-      { id: String, text: String },
-      { id: String, text: String },
-      (...)
-    ]
-  }
-</code>
-</pre>
-        </p>
-       <h2>Usage</h2>
-       <pre><code>import { SfAccordion } from "@storefront-ui/vue"</code></pre>
-       ${generateStorybookTable(scssTableConfig, "SCSS variables")}
-       `
-      }
-    }
-  )
-
-  .add(
-    "[slot] default",
-    () => ({
-      data() {
-        return {
-          contentStyle:
-            "padding: 1rem 2rem; color: #fff; font-size: 16px; cursor: pointer; background: #5ECE7B;",
-          headerOne: "About Us",
-          contentItemsOne: [
-            { id: "about_1", text: "About us (Magento CMS)" },
-            { id: "about_2", text: "Store locator" }
-          ],
-          headerTwo: "Departaments",
-          contentItemsTwo: [
-            { id: "dep_1", text: "Women fashion" },
-            { id: "dep_2", text: "Men fashion" },
-            { id: "dep_3", text: "Kidswear" },
-            { id: "dep_4", text: "Home" },
-            { id: "dep_5", text: "Dogswear" }
-          ],
-          headerThree: "Help",
-          contentItemsThree: [
-            { id: "help_1", text: "Customer service" },
-            { id: "help_2", text: "Size guide" },
-            { id: "help_3", text: "Contact us" }
-          ]
-        };
-      },
-      props: {
-        multiple: {
-          default: boolean("multiple", false)
-        },
-        firstOpen: {
-          default: boolean("firstOpen", false)
-        },
-        showChevron: {
-          default: boolean("showChevron", true)
-        },
-        transition: {
-          default: text("transition", "fade")
-        }
-      },
-      components: { SfAccordion },
-      template: `
-      <div style="width: 300px; padding: 1rem;">
-        <SfAccordion 
-        :multiple="multiple" 
-        :firstOpen="firstOpen"
-        :transition="transition">
-          <template v-slot="{ selected }">
-            <transition :name="transition">
-              <SfAccordionItem :selected="selected" :header="headerOne">
-                <template>
-                  <div v-for="item of contentItemsOne" :style="contentStyle">
-                    {{item.text}}
-                  </div>
-                </template>
-              </SfAccordionItem>
-            </transition>
-            <transition :name="transition">
-              <SfAccordionItem :selected="selected" :header="headerTwo">
-                <template>
-                  <div v-for="item of contentItemsTwo" :style="contentStyle">
-                    {{item.text}}
-                  </div>
-                </template>
-              </SfAccordionItem>
-            </transition>
-            <transition :name="transition">
-              <SfAccordionItem :selected="selected" :header="headerThree">
-                <template>
-                  <div v-for="item of contentItemsThree" :style="contentStyle">
-                    {{item.text}}
-                  </div>
-                </template>
-              </SfAccordionItem>
-            </transition>
-          </template>
-        </SfAccordion>
-      </div>`
-    }),
-    {
-      info: {
-        summary: `
-        <p>Custom styling can be achieved by using <code>default</code> slot inside <code>SfAccordion</code>.</p>
-        <p>To use custom styling for content items populate <code>default</code> slot inside <code>SfAccordionItem</code> tag.</p>
-       <h2>Usage</h2>
-       <pre><code>import { SfAccordion } from "@storefront-ui/vue"</code></pre>
-       ${generateStorybookTable(scssTableConfig, "SCSS variables")}
-       `
-      }
-    }
-  )
-
-  .add(
-    "[slot] header",
-    () => ({
-      data() {
-        return {
-          headerStyle: `padding: 1rem;
-            background-color: #efebe9;
-            cursor: pointer;
-            display: flex;
-            justify-content: space-between;
-            width: 100%`,
-          headerOne: "About Us",
-          contentItemsOne: [
-            { id: "about_1", text: "About us (Magento CMS)" },
-            { id: "about_2", text: "Store locator" }
-          ],
-          headerTwo: "Departaments",
-          contentItemsTwo: [
-            { id: "dep_1", text: "Women fashion" },
-            { id: "dep_2", text: "Men fashion" },
-            { id: "dep_3", text: "Kidswear" },
-            { id: "dep_4", text: "Home" },
-            { id: "dep_5", text: "Dogswear" }
-          ],
-          headerThree: "Help",
-          contentItemsThree: [
-            { id: "help_1", text: "Customer service" },
-            { id: "help_2", text: "Size guide" },
-            { id: "help_3", text: "Contact us" }
-          ]
-        };
-      },
-      props: {
-        multiple: {
-          default: boolean("multiple", false)
-        },
-        firstOpen: {
-          default: boolean("firstOpen", false)
-        },
-        showChevron: {
-          default: boolean("showChevron", false)
-        },
-        transition: {
-          default: text("transition", "fade")
-        }
-      },
-      components: { SfAccordion },
-      template: `
-      <div style="width: 300px;">
-        <SfAccordion
-          :multiple="multiple"
-          :firstOpen="firstOpen"
-          :showChevron="showChevron"
-          :transition="transition">
-          <template v-slot="{selected}">
-            <transition :name="transition">
-              <SfAccordionItem :selected="selected" :contentItems="contentItemsOne">
-                <template v-slot:header="{isOpen}">
-                  <div :style="headerStyle">
-                    <div>{{ headerOne }}</div>
-                    <img v-if="isOpen" style="width: 16px; height: 16px;" src="assets/storybook/times.svg" alt="">
-                    <img v-else style="width: 16px; height: 16px;" src="assets/storybook/plus.svg" alt="">
-                  </div>
-                </template>
-              </SfAccordionItem>
-            </transition>
-            <transition :name="transition">
-              <SfAccordionItem :selected="selected" :contentItems="contentItemsTwo">
-                <template v-slot:header="{isOpen}">
-                  <div :style="headerStyle">
-                    <div>{{ headerTwo }}</div>
-                    <img v-if="isOpen" style="width: 16px; height: 16px;" src="assets/storybook/times.svg" alt="">
-                    <img v-else style="width: 16px; height: 16px;" src="assets/storybook/plus.svg" alt="">
-                  </div>
-                </template>
-              </SfAccordionItem>
-            </transition>
-            <transition :name="transition">
-              <SfAccordionItem :selected="selected" :contentItems="contentItemsThree">
-                <template v-slot:header="{isOpen}">
-                  <div :style="headerStyle">
-                    <div>{{ headerThree }}</div>
-                    <img v-if="isOpen" style="width: 16px; height: 16px;" src="assets/storybook/times.svg" alt="">
-                    <img v-else style="width: 16px; height: 16px;" src="assets/storybook/plus.svg" alt="">
-                  </div>
-                </template>
-              </SfAccordionItem>
-            </transition>
-          </template>
-        </SfAccordion>
-      </div>`
-    }),
-    {
-      info: {
-        summary: `
-        <p>Custom styling can be achieved by using <code>default</code> slot inside <code>SfAccordion</code>.</p>
-        <p>To use custom styling for header populate <code>#header</code> slot inside <code>SfAccordionItem</code> tag and set <code>showChevron</code> to false in <code>SfAccordion</code> tag.<br><br>
-        To use custom styling for opened and closed header states use classes:<br><br>
-        <code>sf-accordion-item__header-slot--close</code><br><br>
-        <code>sf-accordion-item__header-slot--open</code><br><br>
-       <h2>Usage</h2>
-       <pre><code>import { SfAccordion } from "@storefront-ui/vue"</code></pre>
-       ${generateStorybookTable(scssTableConfig, "SCSS variables")}
-       `
-      }
-    }
-  )
-
-  .add(
-    "[event] click",
-    () => ({
-      data: () => {
-        return {
-          items: [
-            {
-              header: "First header",
-              content: [{ id: "first_id", text: "Click me!" }]
-            },
-            {
-              header: "Second header",
-              content: [{ id: "second_id", text: "Click me!" }]
             }
           ]
         };
@@ -362,45 +63,24 @@ storiesOf("Organisms|Accordion", module)
           default: text("transition", "fade")
         }
       },
-      methods: {
-        storyMethod(id) {
-          alert("You have clicked item with id: " + id);
-        }
-      },
-      components: { SfAccordion },
-      template: `
-      <div style="width: 300px; padding: 1rem;">
-        <SfAccordion
-          :multiple="multiple"
-          :firstOpen="firstOpen"
-          :showChevron="showChevron"
-          :transition="transition"
-          @click="storyMethod"
-        >
-          <template v-slot="{ selected }">
-            <transition :name="transition">
-              <SfAccordionItem
-                v-for="(item, i) of items"
-                :key="i"
-                :header="item.header"
-                :contentItems="item.content"
-                :selected="selected"
-              />
-            </transition>
-          </template>
+      components: { SfAccordion, SfList, SfMenuItem },
+      template: `<div :style="{width: '300px'}">
+        <SfAccordion :multiple="multiple" :firstOpen="firstOpen" :showChevron="showChevron" :transition="transition">
+          <SfAccordionItem v-for="(accordion, i) of accordions" :header="accordion.header" :key="i">
+            <SfList>
+              <SfListItem v-for="(item, j) of accordion.items" :key="j" style="margin: .25rem 0">
+                <SfMenuItem :label="item.label" :count="item.count"/>
+              </SfListItem>
+            </SfList>
+          </SfAccordionItem>
         </SfAccordion>
       </div>`
     }),
     {
       info: {
-        summary: `
-        <p>If user populate content through <code>items</code> array in <code>SfAccordion</code>
-        or through <code>contentItems</code> array in <code>SfAccordionItem</code>,
-        he can bind <code>v-on:click</code>.
-        This function gets one argument - the id of clicked content item.</p>
-       <h2>Usage</h2>
-       <pre><code>import { SfAccordion } from "@storefront-ui/vue"</code></pre>
-       `
+        summary: `<h2>Usage</h2>
+        <pre><code>import { SfAccordion } from "@storefront-ui/vue"</code></pre>
+        ${generateStorybookTable(scssTableConfig, "SCSS variables")}`
       }
     }
   );

--- a/packages/vue/src/components/organisms/SfAccordion/_internal/SfAccordionItem.html
+++ b/packages/vue/src/components/organisms/SfAccordion/_internal/SfAccordionItem.html
@@ -1,25 +1,24 @@
-<Fragment>
-  <div @click="" class="sf-accordion__header">
-    {{ header }}
-    <div class="sf-accordion__chevron">
-      <SfChevron :class="{'sf-chevron--top': isOpen}" />
+<div class="sf-accordion-item">
+  <!-- @slot -->
+  <slot
+    name="header"
+    v-bind="{header, isOpen, accordionClick, showChevron: $parent.showChevron}"
+  >
+    <div
+      @click="accordionClick"
+      :class="{'sf-accordion-item__header--open': isOpen}"
+      class="sf-accordion-item__header"
+    >
+      {{ header }}
+      <div v-if="$parent.showChevron" class="sf-accordion-item__chevron">
+        <SfChevron :class="{'sf-chevron--top': isOpen}" />
+      </div>
     </div>
-  </div>
+  </slot>
   <transition :name="$parent.transition">
-    <div class="sf-accordion-item__content-wrapper" v-if="isOpen">
+    <div v-if="isOpen" class="sf-accordion-item__content">
       <!-- @slot -->
-      <slot v-bind="{items: contentItems, handler: onContentItemClick}">
-        <div class="sf-accordion-item__content">
-          <div
-            v-for="item of contentItems"
-            :key="item.id"
-            @click="onContentItemClick(item.id)"
-            :class="{'sf-accordion-item__content--active': item.id === selected}"
-          >
-            {{ item.text }}
-          </div>
-        </div>
-      </slot>
+      <slot />
     </div>
   </transition>
-</Fragment>
+</div>

--- a/packages/vue/src/components/organisms/SfAccordion/_internal/SfAccordionItem.html
+++ b/packages/vue/src/components/organisms/SfAccordion/_internal/SfAccordionItem.html
@@ -1,14 +1,7 @@
-<div>
-  <div
-    @click="onHeaderClick"
-    class="sf-accordion-item__header-wrapper"
-    :class="isOpen ? 'sf-accordion-item__header-wrapper--open' : 'sf-accordion-item__header-wrapper--close'"
-  >
-    <!-- @slot -->
-    <slot name="header" v-bind="{isOpen, header}">
-      <div class="sf-accordion-item__header">{{ header }}</div>
-    </slot>
-    <div v-if="$parent.showChevron" class="sf-accordion-item__chevron">
+<Fragment>
+  <div @click="" class="sf-accordion__header">
+    {{ header }}
+    <div class="sf-accordion__chevron">
       <SfChevron :class="{'sf-chevron--top': isOpen}" />
     </div>
   </div>
@@ -29,4 +22,4 @@
       </slot>
     </div>
   </transition>
-</div>
+</Fragment>

--- a/packages/vue/src/components/organisms/SfAccordion/_internal/SfAccordionItem.js
+++ b/packages/vue/src/components/organisms/SfAccordion/_internal/SfAccordionItem.js
@@ -1,3 +1,4 @@
+import {Fragment} from "vue-fragment";
 import SfChevron from "../../../atoms/SfChevron/SfChevron.vue";
 export default {
   name: "SfAccordionItem",
@@ -21,7 +22,8 @@ export default {
     }
   },
   components: {
-    SfChevron
+    SfChevron,
+    Fragment
   },
   mounted() {
     this.$parent.$emit("accordion-item-ready");

--- a/packages/vue/src/components/organisms/SfAccordion/_internal/SfAccordionItem.js
+++ b/packages/vue/src/components/organisms/SfAccordion/_internal/SfAccordionItem.js
@@ -1,39 +1,23 @@
-import {Fragment} from "vue-fragment";
 import SfChevron from "../../../atoms/SfChevron/SfChevron.vue";
 export default {
   name: "SfAccordionItem",
-  data() {
-    return {
-      isOpen: false
-    };
+  components: {
+    SfChevron
   },
   props: {
     header: {
       type: String,
       default: ""
-    },
-    selected: {
-      type: String,
-      default: ""
-    },
-    contentItems: {
-      type: Array,
-      default: () => []
     }
   },
-  components: {
-    SfChevron,
-    Fragment
-  },
-  mounted() {
-    this.$parent.$emit("accordion-item-ready");
+  data() {
+    return {
+      isOpen: false
+    };
   },
   methods: {
-    onHeaderClick() {
+    accordionClick() {
       this.$parent.$emit("toggle", this._uid);
-    },
-    onContentItemClick(id) {
-      this.$parent.$emit("click", id);
     }
   }
 };

--- a/packages/vue/src/examples/pages/category/Category.vue
+++ b/packages/vue/src/examples/pages/category/Category.vue
@@ -96,36 +96,23 @@
     <div class="main section">
       <div class="sidebar desktop-only">
         <SfAccordion :firstOpen="true" :showChevron="false">
-          <template v-slot="{ selected }">
-            <SfAccordionItem
-              v-for="(accordion, i) in sidebarAccordion"
-              :key="i"
-              :header="accordion.header"
-            >
-              <template v-slot="{ handler }">
-                <SfList>
-                  <SfListItem v-for="(item, j) in accordion.items" :key="j">
-                    <div
-                      @click="
-                        () => {
-                          handler(item.label);
-                        }
-                      "
-                    >
-                      <SfMenuItem
-                        class="menu-item"
-                        :class="{
-                          'menu-item--active': selected === item.label
-                        }"
-                        :label="item.label"
-                        :count="item.count"
-                      />
-                    </div>
-                  </SfListItem>
-                </SfList>
-              </template>
-            </SfAccordionItem>
-          </template>
+          <SfAccordionItem
+            v-for="(accordion, i) in sidebarAccordion"
+            :key="i"
+            :header="accordion.header"
+          >
+            <template>
+              <SfList>
+                <SfListItem
+                  v-for="(item, j) in accordion.items"
+                  :key="j"
+                  class="list-item"
+                >
+                  <SfMenuItem :label="item.label" :count="item.count" />
+                </SfListItem>
+              </SfList>
+            </template>
+          </SfAccordionItem>
         </SfAccordion>
       </div>
       <div class="products">
@@ -625,14 +612,8 @@ export default {
     font-size: inherit;
   }
 }
-.menu-item {
+.list-item {
   padding: $spacer-small 0;
-  &--active,
-  &:hover {
-    font-weight: 500;
-    text-decoration: underline;
-    cursor: pointer;
-  }
 }
 .bottom-navigation-circle {
   opacity: 1;

--- a/packages/vue/src/examples/pages/category/Category.vue
+++ b/packages/vue/src/examples/pages/category/Category.vue
@@ -103,11 +103,7 @@
           >
             <template>
               <SfList>
-                <SfListItem
-                  v-for="(item, j) in accordion.items"
-                  :key="j"
-                  class="list-item"
-                >
+                <SfListItem v-for="(item, j) in accordion.items" :key="j">
                   <SfMenuItem :label="item.label" :count="item.count" />
                 </SfListItem>
               </SfList>
@@ -611,9 +607,6 @@ export default {
     padding: 10px;
     font-size: inherit;
   }
-}
-.list-item {
-  padding: $spacer-small 0;
 }
 .bottom-navigation-circle {
   opacity: 1;


### PR DESCRIPTION
# Related issue
<!-- paste a link to related issue -->

# Scope of work
<!-- describe what you did -->
- SfAccordionItem removed props `selected`, `contentItems` for do simplest component API
- removed SfAccordionItem slot falback (v-for on contentItems)
- fixed just Basic story, used MenuItem and removed others stories
# Screenshots of visual changes
sftabs:mobile
![Zrzut ekranu 2019-10-4 o 15 21 06](https://user-images.githubusercontent.com/12138170/66210695-b6ff4900-e6ba-11e9-8f93-9f0e8b7412a7.png)
sfaccorion
![Zrzut ekranu 2019-10-4 o 15 21 33](https://user-images.githubusercontent.com/12138170/66210696-b797df80-e6ba-11e9-8049-a7ec2864697c.png)

# Checklist

- [x] I followed [composition rules](https://docs.storefrontui.io/component-rules.html) for my component
- [x] I tested the component in most common device sizes (can be tested in Storybook [from viewport addon in top menu](https://github.com/storybooks/storybook/tree/master/addons/viewport))
