### PR TITLE
Bugfix/Body Scroll Lock

### DIFF
--- a/packages/shared/styles/components/SfSidebar.scss
+++ b/packages/shared/styles/components/SfSidebar.scss
@@ -45,4 +45,7 @@ $sidebar-padding    : 3rem !default;
       display: none
     }
   }
+  &--has-scroll-lock{
+    overflow: hidden;
+  }
 }

--- a/packages/vue/src/components/molecules/SfSlidingSection/SfSlidingSection.js
+++ b/packages/vue/src/components/molecules/SfSlidingSection/SfSlidingSection.js
@@ -49,6 +49,19 @@ export default {
       this.scrollLock();
     }
   },
+  async mounted() {
+    const hammer = await import("hammerjs");
+    const Hammer = hammer.default;
+    this.hammer = new Hammer(document, {
+      enable: false
+    }).on("pan", this.touchHandler);
+    this.isMobileHandler();
+    window.addEventListener("resize", this.isMobileHandler, { passive: true });
+  },
+  beforeDestroy() {
+    this.scrollUnlock();
+    this.hammer.destroy();
+  },
   methods: {
     touchPreventDefault(e) {
       e.preventDefault();
@@ -90,18 +103,5 @@ export default {
     closeHandler() {
       this.isActive = false;
     }
-  },
-  async mounted() {
-    const hammer = await import("hammerjs");
-    const Hammer = hammer.default;
-    this.hammer = new Hammer(document, {
-      enable: false
-    }).on("pan", this.touchHandler);
-    this.isMobileHandler();
-    window.addEventListener("resize", this.isMobileHandler, { passive: true });
-  },
-  beforeDestroy() {
-    this.scrollUnlock();
-    this.hammer.destroy();
   }
 };

--- a/packages/vue/src/components/molecules/SfSlidingSection/SfSlidingSection.js
+++ b/packages/vue/src/components/molecules/SfSlidingSection/SfSlidingSection.js
@@ -17,6 +17,7 @@ export default {
   },
   watch: {
     isMobile(mobile) {
+      if (typeof window === "undefined") return;
       if (!mobile) {
         this.isActive = false;
         this.hasScrollLock = false;
@@ -27,6 +28,7 @@ export default {
       this.hammer.set({ enable: true });
     },
     isActive(active) {
+      if (typeof window === "undefined") return;
       if (!active) {
         this.hasStaticHeight = false;
         if (!this.isMobile) {
@@ -39,6 +41,7 @@ export default {
       this.hasScrollLock = false;
     },
     hasScrollLock(scrollLock) {
+      if (typeof window === "undefined") return;
       if (!scrollLock) {
         this.scrollUnlock();
         return;

--- a/packages/vue/src/components/molecules/SfSlidingSection/SfSlidingSection.js
+++ b/packages/vue/src/components/molecules/SfSlidingSection/SfSlidingSection.js
@@ -98,6 +98,7 @@ export default {
     window.addEventListener("resize", this.isMobileHandler, { passive: true });
   },
   beforeDestroy() {
+    this.scrollUnlock();
     this.hammer.destroy();
   }
 };

--- a/packages/vue/src/components/organisms/SfSidebar/SfSidebar.js
+++ b/packages/vue/src/components/organisms/SfSidebar/SfSidebar.js
@@ -1,8 +1,14 @@
 import SfCircleIcon from "../../atoms/SfCircleIcon/SfCircleIcon.vue";
 import SfIcon from "../../atoms/SfIcon/SfIcon.vue";
 import SfOverlay from "../../atoms/SfOverlay/SfOverlay.vue";
+
 export default {
   name: "SfSidebar",
+  components: {
+    SfCircleIcon,
+    SfIcon,
+    SfOverlay
+  },
   props: {
     button: {
       type: Boolean,
@@ -22,6 +28,24 @@ export default {
       position: "left"
     };
   },
+  computed: {
+    visibleOverlay() {
+      return this.visible && this.overlay;
+    }
+  },
+  watch: {
+    visible: {
+      handler: value => {
+        if (typeof window === "undefined") return;
+        if (value) {
+          document.body.classList.add("sf-sidebar--has-scroll-lock");
+        } else {
+          document.body.classList.remove("sf-sidebar--has-scroll-lock");
+        }
+      },
+      immediate: true
+    }
+  },
   mounted() {
     const keydownHandler = e => {
       if (e.key === "Escape" || e.key === "Esc" || e.keyCode === 27) {
@@ -36,27 +60,7 @@ export default {
       ? "right"
       : "left";
   },
-  watch: {
-    visible: {
-      handler: value => {
-        if (value && typeof window !== "undefined") {
-          document.body.style.setProperty("overflow", "hidden");
-        }
-        if (!value && typeof window !== "undefined") {
-          document.body.style.removeProperty("overflow");
-        }
-      },
-      immediate: true
-    }
-  },
-  computed: {
-    visibleOverlay() {
-      return this.visible && this.overlay;
-    }
-  },
-  components: {
-    SfCircleIcon,
-    SfIcon,
-    SfOverlay
+  beforeDestroy() {
+    document.body.classList.remove("sf-sidebar--has-scroll-lock");
   }
 };


### PR DESCRIPTION
# Related issue
<!-- paste a link to related issue -->

# Scope of work
<!-- describe what you did -->
- added removed scroll lock to `beforeDestroy` for SfSidebar & SfSlidingSection
- prevent SfSlidingSection warchers to error on ssrto 
- changed SfSidebar inline scroll lock to class 
- fixed componen options order (https://vuejs.org/v2/style-guide/#Component-instance-options-order-recommended) 

# Screenshots of visual changes

# Checklist

- [x] I followed [composition rules](https://docs.storefrontui.io/component-rules.html) for my component
- [x] I tested the component in most common device sizes (can be tested in Storybook [from viewport addon in top menu](https://github.com/storybooks/storybook/tree/master/addons/viewport))
