### PR TITLE
#370 auto docs css modifiers

### DIFF
--- a/packages/shared/styles/components/SfAccordion.scss
+++ b/packages/shared/styles/components/SfAccordion.scss
@@ -27,6 +27,7 @@ $accordion-item__content-padding--last: 0.5rem 0 1.5rem !default;
     font-weight: 400;
   }
   &-item__header-icon--up {
+    /* @no-docs */
     transform: rotate(180deg);
   }
   &-item__content {

--- a/packages/vue/scripts/create-vue-components-docs.js
+++ b/packages/vue/scripts/create-vue-components-docs.js
@@ -292,7 +292,7 @@ function extractCssModifiers(contentScssFile) {
   const uniqueModifiers = new Map();
   for (let i = 0; i < lines.length; ++i) {
     const line = lines[i];
-    const regExp = /(\w+--[^\s,:]+)/g;
+    const regExp = /(\S+--[^\s,:]+)/g;
     let partialReResult;
     let lastModifierFound;
     // as multiple modifiers may be on one line, we have to make this (stateful) reg exp. search

--- a/packages/vue/scripts/create-vue-components-docs.js
+++ b/packages/vue/scripts/create-vue-components-docs.js
@@ -311,7 +311,12 @@ function extractCssModifiers(contentScssFile) {
       if (!lines[j].endsWith("{")) {
         continue;
       }
-      // opening-brace found; if the line after it doesn't contain a @modifier annotation, break
+      // opening-brace found; but if the line after it contains a @no-docs annotation, remove it again from the found modifiers
+      if (lines[j + 1].trim().includes("@no-docs")) {
+        uniqueModifiers.delete(lastModifierFound);
+        break;
+      }
+      // if it doesn't contain a @modifier annotation, keep it in the found modifiers, but break (don't look for description)
       if (!lines[j + 1].trim().includes("@modifier")) {
         break;
       }


### PR DESCRIPTION
# Related issue
#370 [Docs][Automation] Fix CSS modifier parsing and add possibility to ignore modifiers

# Scope of work
- Fix CSS modifiers sometimes only being partially extracted.
- Add possibility to ignore CSS modifiers by using the no-docs annotation instead of the modifier annotation.

# Checklist
- [x] ~~I followed [composition rules](https://docs.storefrontui.io/component-rules.html) for my component~~ (doesn't apply)
- [x] I tested the component in most common device sizes (can be tested in Storybook [from viewport addon in top menu](https://github.com/storybooks/storybook/tree/master/addons/viewport))
