### PR TITLE
Animate progress bar in steps component

### DIFF
--- a/packages/shared/styles/components/SfSteps.scss
+++ b/packages/shared/styles/components/SfSteps.scss
@@ -1,5 +1,4 @@
-@import "../variables";
-
+@import '../variables';
 
 $steps__active-line-height-mobile: 0.1875rem;
 $steps__active-line-height-desktop: 0.125rem;
@@ -12,25 +11,9 @@ $steps__step-font-color: $c-gray-secondary;
 $steps__step-padding: 1.25rem 0;
 $steps__step-text-transform: uppercase;
 
-
-%sf-store-active-line {
-  position: absolute;
-  content: "";
-  display: block;
-  height: $steps__active-line-height-mobile;
-  width: 100%;
-  bottom: -$steps__active-line-height-mobile /2;
-  left: 0;
-  background-color: $steps__active-line-color;
-
-  @media screen and (min-width: $desktop-min) {
-    height: $steps__active-line-height-desktop;
-    bottom: -$steps__active-line-height-desktop /2;
-  }
-}
-
 .sf-steps {
   &__header {
+    position: relative;
     width: 100%;
     display: flex;
     flex-flow: row nowrap;
@@ -48,55 +31,14 @@ $steps__step-text-transform: uppercase;
       flex: 1;
       cursor: pointer;
 
-      &:after {
-        @extend %sf-store-active-line;
-        width: 0%;
-      }
-
-      &:last-of-type {
-        &.sf-steps__header-step-current {
-          span:after {
-            opacity: 0;
-          }
-          &:after {
-            width: 100%;
-          }
-        }
-      }
-
       span {
         position: relative;
-        text-align: right;
+        text-align: center;
         display: block;
-        width: 50%;
-        transform: translate(25%);
-        &:after {
-          @extend %sf-store-active-line;
-          opacity: 0;
-          width: calc(100% + 25%);
-          bottom: -(1.25rem + ($steps__active-line-height-mobile / 2));
-          left: -25%;
-
-          @media screen and (min-width: $desktop-min) {
-            bottom: -(1.25rem + ($steps__active-line-height-desktop / 2));
-          }
-        }
-      }
-
-      &-done {
-        &:after {
-          width: 100%;
-        }
       }
 
       &-current {
         color: $c-dark-primary;
-
-        span {
-          &:after {
-            opacity: 1;
-          }
-        }
       }
 
       &-disabled {
@@ -104,6 +46,24 @@ $steps__step-text-transform: uppercase;
       }
     }
   }
+
+  &__progress {
+    position: absolute;
+    content: '';
+    display: block;
+    height: $steps__active-line-height-mobile;
+    bottom: -$steps__active-line-height-mobile / 2;
+    left: 0;
+    background-color: $steps__active-line-color;
+    transform-origin: 0 50%;
+    transition: transform 150ms ease-in-out;
+
+    @media screen and (min-width: $desktop-min) {
+      height: $steps__active-line-height-desktop;
+      bottom: -$steps__active-line-height-desktop / 2;
+    }
+  }
+
   &__content {
     padding: 2.5rem 0 0 0;
 

--- a/packages/vue/src/components/molecules/SfSteps/SfSteps.html
+++ b/packages/vue/src/components/molecules/SfSteps/SfSteps.html
@@ -10,6 +10,10 @@
         <span>{{ step.step }}</span>
       </div>
     </slot>
+    <div
+      class="sf-steps__progress"
+      :style="{ width: progressWidth, transform: `scaleX(${progress})` }">
+    </div>
   </div>
   <div class="sf-steps__content">
     <slot></slot>

--- a/packages/vue/src/components/molecules/SfSteps/SfSteps.js
+++ b/packages/vue/src/components/molecules/SfSteps/SfSteps.js
@@ -57,6 +57,12 @@ export default {
         }));
       }
       return [];
+    },
+    progress() {
+      return this.active + 1;
+    },
+    progressWidth() {
+      return `${100 / this.steps.length}%`;
     }
   },
   methods: {


### PR DESCRIPTION
# Related issue
#335

# Scope of work
I refactored the way the progress bar used to work so it simplified the CSS code quite a bit, I also made sure to animate the `transform` property to keep the transition performant.

# Screenshots of visual changes
![motion](https://user-images.githubusercontent.com/661330/66256412-74ef0980-e785-11e9-89d8-b68a09f60f4a.gif)

# Checklist

- [x] I followed [composition rules](https://docs.storefrontui.io/component-rules.html) for my component
- [x] I tested the component in most common device sizes (can be tested in Storybook [from viewport addon in top menu](https://github.com/storybooks/storybook/tree/master/addons/viewport))
