### PR TITLE
Re-add missing Playground.vue generation

### DIFF
--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -17,6 +17,7 @@
     "docs:vuecomponents": "node scripts/create-vue-components-docs.js",
     "docs:dev": "$npm_execpath docs:vuecomponents && vuepress dev docs",
     "docs:build": "$npm_execpath docs:vuecomponents && vuepress build docs",
+    "postinstall": "node scripts/postinstall.js",
     "version": "node scripts/version.js"
   },
   "dependencies": {

--- a/packages/vue/scripts/postinstall.js
+++ b/packages/vue/scripts/postinstall.js
@@ -1,0 +1,31 @@
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+
+const isDependency = __dirname.includes("node_modules");
+
+function runPostInstall() {
+  createPlaygroundVue();
+}
+
+function createPlaygroundVue() {
+  const playgroundPath = path.resolve(__dirname, "..", "src/Playground.vue");
+  if (!fs.existsSync(playgroundPath) && !isDependency) {
+    fs.writeFileSync(playgroundPath, getPlaygroundContent());
+  }
+}
+
+function getPlaygroundContent() {
+  return `<template>
+  <div id="playground"></div>
+</template>
+
+<script>
+// Use this component to play with other components
+export default {};
+</script>
+`;
+}
+
+runPostInstall();


### PR DESCRIPTION
In commit a976c5b7 the generation of Playground.vue on postinstall got
accidentally removed. This re-adds it.