### PR TITLE
Add aria-label to SFArrow

### DIFF
--- a/packages/vue/src/components/atoms/SfArrow/SfArrow.html
+++ b/packages/vue/src/components/atoms/SfArrow/SfArrow.html
@@ -1,5 +1,5 @@
 <div class="sf-arrow">
-  <button v-on="$listeners" class="sf-arrow__button" type="button">
+  <button v-on="$listeners" class="sf-arrow__button" type="button" aria-label="Arrow">
     <!--@slot Use this slot to replace arrow icon-->
     <slot>
       <svg class="sf-arrow__icon"viewBox="0 0 24 12" fill="none" xmlns="http://www.w3.org/2000/svg">


### PR DESCRIPTION
# Related issue
[A11y] Fix accesibility issues for SfArrow #341

# Scope of work
Adds aria-label to button in SFArrow to fix accessibility issue

# Screenshots of visual changes

![image](https://user-images.githubusercontent.com/25033813/66325899-08dfe300-e8f6-11e9-9da8-5ee81eb2c646.png)

# Checklist

- [X] I followed [composition rules](https://docs.storefrontui.io/contributing/coding-guidelines.html#component-rules) for my component
- [X] I tested the component in most common device sizes (can be tested in Storybook [from viewport addon in top menu](https://github.com/storybooks/storybook/tree/master/addons/viewport))
