### PR TITLE
#385 Fix precommit lint

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,16 +18,20 @@
     "url": "https://github.com/DivanteLtd/storefront-ui/issues"
   },
   "homepage": "https://github.com/DivanteLtd/storefront-ui#readme",
-  "dependencies": {
-    "lerna": "^3.16.4"
-  },
   "workspaces": [
     "packages/*"
   ],
   "devDependencies": {
     "file-save": "^0.2.0",
     "glob": "^7.1.4",
+    "husky": "^3.0.9",
+    "lerna": "^3.16.4",
     "prompts": "^2.1.0",
     "uppercamelcase": "^3.0.0"
+  },
+  "husky": {
+    "hooks": {
+      "pre-commit": "lerna run --concurrency 1 --stream precommit"
+    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "root",
-  "private": "true",
+  "private": true,
   "version": "0.0.0",
   "description": "",
   "main": "index.js",

--- a/packages/shared/.lintstagedrc.yml
+++ b/packages/shared/.lintstagedrc.yml
@@ -1,0 +1,3 @@
+"*.{js,html,scss}":
+  - eslint --fix
+  - git add

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -3,8 +3,15 @@
   "version": "0.3.1",
   "description": "",
   "main": "index.js",
+  "scripts": {
+    "precommit": "lint-staged"
+  },
   "author": "Filip Rakowski",
   "license": "ISC",
+  "devDependencies": {
+    "eslint": "^5.16.0",
+    "lint-staged": "^9.4.2"
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -14,6 +14,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "gitHead": "85b200d4981615ee7dc0682a7ad2d26fc0de2866"
+  }
 }

--- a/packages/vue/.lintstagedrc.yml
+++ b/packages/vue/.lintstagedrc.yml
@@ -1,0 +1,3 @@
+"*.{js,vue,html,scss}":
+  - vue-cli-service lint
+  - git add

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -18,6 +18,7 @@
     "docs:dev": "yarpm docs:vuecomponents && vuepress dev docs",
     "docs:build": "yarpm docs:vuecomponents && vuepress build docs",
     "create-index-files": "node scripts/create-index-files.js",
+    "precommit": "lint-staged",
     "postinstall": "node scripts/postinstall.js",
     "version": "node scripts/version.js",
     "postpublish": "node scripts/postpublish.js"
@@ -72,7 +73,7 @@
     "eslint-plugin-vue": "^5.2.3",
     "html-loader": "^0.5.5",
     "jest": "^24.9.0",
-    "lint-staged": "^8.2.1",
+    "lint-staged": "^9.4.2",
     "markdown-loader": "^5.0.0",
     "node-sass": "^4.12.0",
     "sass-loader": "^7.1.0",
@@ -87,15 +88,6 @@
     "vue": "^2.6.x"
   },
   "main": "./index.js",
-  "lint-staged": {
-    "*.{js,vue,html,scss}": [
-      "vue-cli-service lint",
-      "git add"
-    ]
-  },
-  "gitHooks": {
-    "pre-commit": "lint-staged"
-  },
   "publishConfig": {
     "access": "public"
   },

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -90,6 +90,5 @@
   "main": "./index.js",
   "publishConfig": {
     "access": "public"
-  },
-  "gitHead": "85b200d4981615ee7dc0682a7ad2d26fc0de2866"
+  }
 }


### PR DESCRIPTION
# Related issue
#396 [Bug] Auto-lint on precommit not working anymore

# Scope of work
- install `lint-staged` and (underlying) `husky` as recommended for multi-package monorepo
- setup precommit hooks in both packages (_vue_ and _shared_)
- use `vue-cli-service lint` for _vue_ and `eslint --fix` for _shared_
- move lerna to devDeps
- minor clean-ups in _package.json_s