### PR TITLE
#437 Fix lozad adding new IMG tags if a multi-size src is provided

### DIFF
--- a/packages/vue/src/components/atoms/SfImage/SfImage.js
+++ b/packages/vue/src/components/atoms/SfImage/SfImage.js
@@ -64,20 +64,43 @@ export default {
   methods: {
     hoverHandler(state) {
       this.overlay = state;
+    },
+
+    initLozad: function() {
+      const vm = this;
+      this.$nextTick(() => {
+        const observer = lozad(vm.$refs.imgLazy, {
+          loaded: function() {
+            vm.loaded = true;
+          }
+        });
+        observer.observe();
+      });
     }
   },
 
   mounted() {
     if (this.lazy !== false) {
-      const vm = this;
-      const observer = lozad(vm.$refs.imgLazy, {
-        loaded: function() {
-          vm.loaded = true;
-        }
-      });
-      observer.observe();
+      this.initLozad();
     } else {
       this.loaded = true;
+    }
+  },
+
+  watch: {
+    lazy: function(newValue, oldValue) {
+      // init lozad if lazy loading was previously disabled
+      if (!oldValue && newValue) {
+        this.initLozad();
+      }
+      // if lazy loading was previously enabled, remove lozad classes and
+      // remove spurious img tag added by lozad if src is a multi-size object
+      if (oldValue && !newValue) {
+        this.$refs.imgLazy.removeAttribute("data-loaded");
+        if (this.$refs.imgLazy.tagName === "PICTURE") {
+          this.$refs.imgLazy.querySelector("img").remove();
+        }
+      }
     }
   }
 };


### PR DESCRIPTION
# Related issue
#437 SfImage `lazy` set to false shows another image on bottom

# Scope of work
This fixes #437.

By design, lozad is supposed to be added _once_ to an element. But as we
allow to change the "lazy" attribute dynamically for our SfImages, this
triggers strange behavior: The reference to the IMG element which lozad
inserts after loading isn't fully removed from the DOM and another one
is then added to the picture tag, resulting in two images.

The fix consists of removing the spurious IMG tag when the "lazy"
attribute changes from true to false.
Also, when the attribute changes from false to true, the initialization
if lozad is retriggered.