### PR TITLE
chore/refactor-sf-sidebar-behaviour

### DIFF
--- a/packages/shared/styles/components/SfSidebar.scss
+++ b/packages/shared/styles/components/SfSidebar.scss
@@ -1,51 +1,35 @@
-@import '../variables';
+@import "../variables";
 
-$sidebar-background : $c-white !default;
-$sidebar-padding    : 3rem !default;
+$sidebar-background-color: $c-white !default;
 
 .sf-sidebar {
-  &__aside{
+  $this: &;
+  &__aside {
     position: fixed;
     top: 0;
     left: 0;
     z-index: 1;
-    width: 320px;
+    background-color: $sidebar-background-color;
     height: 100%;
-    background: $sidebar-background;
-    box-sizing: border-box;
-    box-shadow: 0px 4px 56px rgba(87, 87, 87, 0.32);
   }
-  &__button {
+  &__circle-icon {
     position: absolute;
-    right: -1.625rem;
-    padding: 10px;
-    top: 3rem;
-  }
-  &__content {
-    overflow-y: scroll;
-    height: 100vh;
-    width: 100%;
-    padding: $sidebar-padding;
-    box-sizing: border-box;
-    &::-webkit-scrollbar{
-      width: 0;
-    }
+    right: 3.25rem / 2 * -1;
+    top: 5.625rem;
+    box-shadow: 0 4px 56px rgba(87, 87, 87, 0.32);
   }
   &--right {
-    .sf-sidebar__aside {
+    #{$this}__aside {
       left: auto;
       right: 0;
     }
-    .sf-sidebar__button {
-      left: -1.625rem;
+    #{$this}__circle-icon {
+      left: 3.25rem / 2 * -1;
     }
   }
   &--mobile-only {
-    &__button {
-      display: none
+    #{$this}__circle-icon {
+      display: none;
     }
-  }
-  &--has-scroll-lock{
-    overflow: hidden;
   }
 }

--- a/packages/shared/styles/components/SfSidebar.scss
+++ b/packages/shared/styles/components/SfSidebar.scss
@@ -32,4 +32,7 @@ $sidebar-background-color: $c-white !default;
       display: none;
     }
   }
+  &--has-scroll-lock {
+    overflow: hidden;
+  }
 }

--- a/packages/vue/src/components/organisms/SfSidebar/SfSidebar.html
+++ b/packages/vue/src/components/organisms/SfSidebar/SfSidebar.html
@@ -1,17 +1,17 @@
 <div class="sf-sidebar">
-  <SfOverlay
-    :visible="visibleOverlay"
-    @click="$emit('close')"
-  >
-  </SfOverlay>
+  <SfOverlay :visible="visibleOverlay" @click="$emit('close')" />
   <transition :name="'slide-' + position">
     <aside v-if="visible" class="sf-sidebar__aside">
-      <SfCircleIcon v-if="button" class="sf-sidebar__button" @click="$emit('close')">
-        <sf-icon icon="cross" color="white" size="14px"/>
-      </SfCircleIcon>
-      <div class="sf-sidebar__content">
-        <slot />
-      </div>
+      <slot name="circle-icon">
+        <SfCircleIcon
+          v-if="button"
+          class="sf-sidebar__circle-icon"
+          @click="$emit('close')"
+        >
+          <SfIcon icon="cross" color="white" size="0.875rem" />
+        </SfCircleIcon>
+      </slot>
+      <slot />
     </aside>
   </transition>
 </div>

--- a/packages/vue/src/components/organisms/SfSidebar/SfSidebar.stories.js
+++ b/packages/vue/src/components/organisms/SfSidebar/SfSidebar.stories.js
@@ -60,7 +60,9 @@ storiesOf("Organisms|Sidebar", module)
           :button="button"
           :class="customClass"
         >
-          Hello World
+          <div style="box-sizing: border-box; padding: 2.5rem; width: 20rem">
+            Hello World
+          </div>
         </SfSidebar>
       </div>`
     }),

--- a/packages/vue/src/examples/pages/category/Category.vue
+++ b/packages/vue/src/examples/pages/category/Category.vue
@@ -147,63 +147,64 @@
     <SfSidebar
       :visible="isFilterSidebarOpen"
       @close="isFilterSidebarOpen = false"
-      class="filters"
     >
-      <h3 class="filters__title">Collection</h3>
-      <SfFilter
-        v-for="filter in filtersOptions.collection"
-        :key="filter.value"
-        :label="filter.label"
-        :count="filter.count"
-        class="filters__item"
-      />
-      <h3 class="filters__title">Color</h3>
-      <SfFilter
-        v-for="filter in filtersOptions.color"
-        :key="filter.value"
-        :value="filter.value"
-        :label="filter.label"
-        :color="filter.color"
-        class="filters__item"
-      />
-      <h3 class="filters__title">Size</h3>
-      <SfFilter
-        v-for="filter in filtersOptions.size"
-        :key="filter.value"
-        :value="filter.value"
-        :label="filter.label"
-        :count="filter.count"
-        class="filters__item"
-      />
-      <h3 class="filters__title">Price</h3>
-      <SfFilter
-        v-for="filter in filtersOptions.price"
-        :key="filter.value"
-        :value="filter.value"
-        :label="filter.label"
-        :count="filter.count"
-        class="filters__item"
-      />
-      <h3 class="filters__title">Material</h3>
-      <SfFilter
-        v-for="filter in filtersOptions.material"
-        :key="filter.value"
-        :value="filter.value"
-        :label="filter.label"
-        :count="filter.count"
-        class="filters__item"
-      />
-      <div class="filters__buttons">
-        <SfButton
-          @click="isFilterSidebarOpen = false"
-          class="sf-button--full-width"
-          >Done</SfButton
-        >
-        <SfButton
-          @click="clearAllFilters"
-          class="sf-button--full-width filters__button-clear"
-          >Clear all</SfButton
-        >
+      <div class="filters">
+        <h3 class="filters__title">Collection</h3>
+        <SfFilter
+          v-for="filter in filtersOptions.collection"
+          :key="filter.value"
+          :label="filter.label"
+          :count="filter.count"
+          class="filters__item"
+        />
+        <h3 class="filters__title">Color</h3>
+        <SfFilter
+          v-for="filter in filtersOptions.color"
+          :key="filter.value"
+          :value="filter.value"
+          :label="filter.label"
+          :color="filter.color"
+          class="filters__item"
+        />
+        <h3 class="filters__title">Size</h3>
+        <SfFilter
+          v-for="filter in filtersOptions.size"
+          :key="filter.value"
+          :value="filter.value"
+          :label="filter.label"
+          :count="filter.count"
+          class="filters__item"
+        />
+        <h3 class="filters__title">Price</h3>
+        <SfFilter
+          v-for="filter in filtersOptions.price"
+          :key="filter.value"
+          :value="filter.value"
+          :label="filter.label"
+          :count="filter.count"
+          class="filters__item"
+        />
+        <h3 class="filters__title">Material</h3>
+        <SfFilter
+          v-for="filter in filtersOptions.material"
+          :key="filter.value"
+          :value="filter.value"
+          :label="filter.label"
+          :count="filter.count"
+          class="filters__item"
+        />
+        <div class="filters__buttons">
+          <SfButton
+            @click="isFilterSidebarOpen = false"
+            class="sf-button--full-width"
+            >Done</SfButton
+          >
+          <SfButton
+            @click="clearAllFilters"
+            class="sf-button--full-width filters__button-clear"
+            >Clear all</SfButton
+          >
+        </div>
       </div>
     </SfSidebar>
   </div>
@@ -589,23 +590,32 @@ export default {
   }
 }
 .filters {
-  position: relative;
-  z-index: 10;
-  &__title:not(:first-child),
-  &__buttons {
-    margin-top: $spacer-big * 3;
+  box-sizing: border-box;
+  width: 20rem;
+  padding: 0 $spacer-big * 3;
+  height: 100%;
+  overflow-y: auto;
+  @include for-desktop {
+    width: 22.875rem;
+  }
+  &::-webkit-scrollbar {
+    width: 0;
   }
   &__title {
+    margin: $spacer-big * 3 0 $spacer-big;
     font-size: $font-size-big-desktop;
-    line-height: 2.23;
-  }
-  &__button-clear {
-    margin-top: 10px;
-    background: $c-light;
-    color: #a3a5ad;
+    line-height: 1.6;
   }
   &__item {
     padding: $spacer-small 0;
+  }
+  &__buttons {
+    margin: $spacer-big * 3 0;
+  }
+  &__button-clear {
+    color: #a3a5ad;
+    margin-top: 10px;
+    background-color: $c-light;
   }
 }
 </style>


### PR DESCRIPTION
# Related issue
<!-- paste a link to related issue -->

# Scope of work
<!-- describe what you did -->
- Change SfSidebar spacing behaviour. 
- Add slot #circle-icon.
- [before] .sf-sidebar__content have responsibility for spacing and sizes
- [now] #default slot content have responsibility for spacing and sizes

[why]
after this changes you have better control for sf-sidebar content
# Screenshots of visual changes
[before]
![_](https://user-images.githubusercontent.com/12138170/68379673-9f4e3100-014e-11ea-8b3d-5afecf68dfad.png)
[now]
![__](https://user-images.githubusercontent.com/12138170/68379674-9f4e3100-014e-11ea-8893-c53ed1c41e64.png)

# Checklist

- [x] I followed [composition rules](https://docs.storefrontui.io/contributing/coding-guidelines.html#component-rules) for my component
- [x] I tested the component in most common device sizes (can be tested in Storybook [from viewport addon in top menu](https://github.com/storybooks/storybook/tree/master/addons/viewport))
