### PR TITLE
#452 Bugfix: Storybook "filter" displays color even if "color" is "null"

### DIFF
--- a/packages/vue/src/components/molecules/SfFilter/SfFilter.js
+++ b/packages/vue/src/components/molecules/SfFilter/SfFilter.js
@@ -11,7 +11,7 @@ export default {
     },
     color: {
       type: String,
-      defult: ""
+      default: ""
     },
     selected: {
       type: Boolean,

--- a/packages/vue/src/components/molecules/SfFilter/SfFilter.stories.js
+++ b/packages/vue/src/components/molecules/SfFilter/SfFilter.stories.js
@@ -36,7 +36,7 @@ export default storiesOf("Molecules|Filter", module)
           default: text("count (prop)", "30")
         },
         color: {
-          default: select("color (prop)", ["red", "null"], "red")
+          default: select("color (prop)", ["", "red", "blue"], "red")
         },
         selected: {
           default: boolean("selected (prop)", true)


### PR DESCRIPTION
# Related issue
#452 [BUG] Storybook "filter" displays color even if "color" is "null"

# Scope of work
This fixes #452.
Selecting `null` as the color prop in the _SfFilter_ story didn't result in the color not being rendered as it tried to render a color named "null" which doesn't exist, so it stayed the last one (red). Also, I added another color (blue).
And there was a code typo for the color prop ("default" was misspelled).

# Checklist
- [X] I followed [composition rules](https://docs.storefrontui.io/contributing/coding-guidelines.html#component-rules) for my component
- [X] I tested the component in most common device sizes (can be tested in Storybook [from viewport addon in top menu](https://github.com/storybooks/storybook/tree/master/addons/viewport))
