### PR TITLE
feature/SfBar

### DIFF
--- a/packages/shared/styles/components/SfBar.scss
+++ b/packages/shared/styles/components/SfBar.scss
@@ -1,0 +1,12 @@
+@import '../variables';
+
+// $component__block-property: value;
+
+// .sf-bar {
+//   &__element {
+
+//   }
+//   &--modifier {
+
+//   }
+// }

--- a/packages/shared/styles/components/SfBar.scss
+++ b/packages/shared/styles/components/SfBar.scss
@@ -1,12 +1,26 @@
-@import '../variables';
+@import "../variables";
 
-// $component__block-property: value;
+$bar-height: 3.125rem !default;
+$bar-padding: 0 $spacer-big !default;
+$bar-background-color: $c-light !default;
+$bar-font-family: $body-font-family-secondary !default;
+$bar-font-size: $font-size-big-mobile !default;
+$bar-font-weight: 500 !default;
+$bar__icon-width: 0.875rem;
 
-// .sf-bar {
-//   &__element {
-
-//   }
-//   &--modifier {
-
-//   }
-// }
+.sf-bar {
+  box-sizing: border-box;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  height: $bar-height;
+  padding: $bar-padding;
+  background-color: $bar-background-color;
+  font-family: $bar-font-family;
+  font-size: $bar-font-size;
+  font-weight: $bar-font-weight;
+  line-height: 1.6;
+  &__icon{
+    width: $bar__icon-width;
+  }
+}

--- a/packages/vue/config/storybook/webpack.config.js
+++ b/packages/vue/config/storybook/webpack.config.js
@@ -6,9 +6,6 @@ module.exports = async ({ config }) => {
     loaders: [
       {
         loader: require.resolve("@storybook/addon-storysource/loader"),
-        options: {
-          uglyCommentsRegex: [/^eslint-.*/]
-        }
       }
     ],
     enforce: "pre"

--- a/packages/vue/docs/.vuepress/config.js
+++ b/packages/vue/docs/.vuepress/config.js
@@ -31,6 +31,7 @@ module.exports = {
           ["/components/Badge", "Badge"],
           ["/components/Banner", "Banner"],
           ["/components/BannerGrid", "Banner Grid"],
+          ["/components/Bar", "Bar"],
           ["/components/BottomNavigation", "Bottom Navigation"],
           ["/components/Breadcrumbs", "Breadcrumbs"],
           ["/components/Bullets", "Bullets"],

--- a/packages/vue/docs/.vuepress/enhanceApp.js
+++ b/packages/vue/docs/.vuepress/enhanceApp.js
@@ -7,6 +7,7 @@ import SfArrow from "../../src/components/atoms/SfArrow/SfArrow.vue"
 import SfBadge from "../../src/components/atoms/SfBadge/SfBadge.vue"
 import SfBanner from "../../src/components/molecules/SfBanner/SfBanner.vue"
 import SfBannerGrid from "../../src/components/organisms/SfBannerGrid/SfBannerGrid.vue"
+import SfBar from "../../src/components/molecules/SfBar/SfBar.vue"
 import SfBottomNavigation from "../../src/components/organisms/SfBottomNavigation/SfBottomNavigation.vue"
 import SfBreadcrumbs from "../../src/components/atoms/SfBreadcrumbs/SfBreadcrumbs.vue"
 import SfBullets from "../../src/components/atoms/SfBullets/SfBullets.vue"
@@ -73,6 +74,7 @@ export default ({
   Vue.component("SfBadge", SfBadge);
   Vue.component("SfBanner", SfBanner);
   Vue.component("SfBannerGrid", SfBannerGrid);
+  Vue.component("SfBar", SfBar);
   Vue.component("SfBottomNavigation", SfBottomNavigation);
   Vue.component("SfBreadcrumbs", SfBreadcrumbs);
   Vue.component("SfBullets", SfBullets);

--- a/packages/vue/src/components/molecules/SfBar/SfBar.html
+++ b/packages/vue/src/components/molecules/SfBar/SfBar.html
@@ -1,1 +1,15 @@
-<div class="sf-bar"></div>
+<div class="sf-bar">
+  <slot name="back">
+    <div class="sf-bar__icon">
+      <SfIcon v-if="back" @click="$emit('click:back')" icon="chevron_left" size="14px" role="button" aria-label="back"/>
+    </div>
+  </slot>
+  <slot name="title" v-bind="{title}">
+    <div class="sf-bar__title">{{title}}</div>
+  </slot>
+  <slot name="close">
+    <div class="sf-bar__icon">
+      <SfIcon v-if="close" @click="$emit('click:close')" icon="cross" size="14px" role="button" aria-label="close"/>
+    </div>
+  </slot>
+</div>

--- a/packages/vue/src/components/molecules/SfBar/SfBar.html
+++ b/packages/vue/src/components/molecules/SfBar/SfBar.html
@@ -1,0 +1,1 @@
+<div class="sf-bar"></div>

--- a/packages/vue/src/components/molecules/SfBar/SfBar.js
+++ b/packages/vue/src/components/molecules/SfBar/SfBar.js
@@ -1,3 +1,21 @@
+import SfIcon from "../../atoms/SfIcon/SfIcon.vue";
 export default {
-  name: "SfBar"
+  name: "SfBar",
+  components: {
+    SfIcon
+  },
+  props: {
+    title: {
+      type: String,
+      default: ""
+    },
+    back: {
+      type: Boolean,
+      default: false
+    },
+    close: {
+      type: Boolean,
+      default: false
+    }
+  }
 };

--- a/packages/vue/src/components/molecules/SfBar/SfBar.js
+++ b/packages/vue/src/components/molecules/SfBar/SfBar.js
@@ -1,0 +1,3 @@
+export default {
+  name: "SfBar"
+};

--- a/packages/vue/src/components/molecules/SfBar/SfBar.md
+++ b/packages/vue/src/components/molecules/SfBar/SfBar.md
@@ -1,0 +1,33 @@
+# component-description
+Bar component for mobile components.
+
+# common-usage
+<br>
+
+
+```html 
+<template>
+  <SfBar 
+    :title="title"
+    :back="true"
+    @click:back=""
+    :close="false"
+    @click:close=""
+   />
+</template>
+
+<script>
+import { SfBar } from '@storefront-ui/vue'
+
+export default {
+  components: {
+    SfBar
+  }, 
+  data(){
+    return {
+       title: "Dresses"
+    }
+  }
+}
+</script>
+```

--- a/packages/vue/src/components/molecules/SfBar/SfBar.spec.js
+++ b/packages/vue/src/components/molecules/SfBar/SfBar.spec.js
@@ -1,5 +1,5 @@
 import { shallowMount } from "@vue/test-utils";
-import SfBar from "@/components/molecules/SfBar.vue";
+import SfBar from "@/components/molecules/SfBar/SfBar.vue";
 
 describe("SfBar.vue", () => {
   it("renders a component", () => {

--- a/packages/vue/src/components/molecules/SfBar/SfBar.spec.js
+++ b/packages/vue/src/components/molecules/SfBar/SfBar.spec.js
@@ -1,0 +1,9 @@
+import { shallowMount } from "@vue/test-utils";
+import SfBar from "@/components/molecules/SfBar.vue";
+
+describe("SfBar.vue", () => {
+  it("renders a component", () => {
+    const component = shallowMount(SfBar);
+    expect(component.contains(".sf-bar")).toBe(true);
+  });
+});

--- a/packages/vue/src/components/molecules/SfBar/SfBar.stories.js
+++ b/packages/vue/src/components/molecules/SfBar/SfBar.stories.js
@@ -1,0 +1,34 @@
+/* eslint-disable import/no-extraneous-dependencies */
+import { storiesOf } from "@storybook/vue";
+import {
+  withKnobs,
+  text,
+  optionsKnob as options
+} from "@storybook/addon-knobs";
+
+import SfBar from "./SfBar.vue";
+
+storiesOf("Molecules|Bar", module)
+  .addDecorator(withKnobs)
+  .add("[slot] default", () => ({
+    props: {
+      customClass: {
+        default: options(
+          "CSS modifier",
+          {
+            "sf-bar--modifier":
+              "sf-bar--modifier"
+          },
+          "",
+          { display: "multi-select" }
+        )
+      }
+    },
+    editableProp: {
+      default: text("propname (prop)", "propvalue")
+    },
+    components: { SfBar },
+    template: `<SfBar
+      :class="customClass" />`
+  }));
+

--- a/packages/vue/src/components/molecules/SfBar/SfBar.stories.js
+++ b/packages/vue/src/components/molecules/SfBar/SfBar.stories.js
@@ -19,13 +19,11 @@ storiesOf("Molecules|Bar", module)
         default: boolean("close", true, "Props")
       }
     },
-    template: `<div style="margin: -20px">
-      <SfBar
+    template: `<SfBar
         :title="title"
         :back="back"
         :close="close"
-      />
-    </div>`
+      />`
   }))
   .add("[slot] back", () => ({
     components: { SfBar },
@@ -40,15 +38,13 @@ storiesOf("Molecules|Bar", module)
         default: boolean("close", true, "Props")
       }
     },
-    template: `<div style="margin: -20px">
-      <SfBar
+    template: `<SfBar
         :title="title"
         :back="back"
         :close="close"
       >
         <template #back>CUSTOM BACK</template>
-      </SfBar>
-    </div>`
+      </SfBar>`
   }))
   .add("[slot] title", () => ({
     components: { SfBar },
@@ -63,15 +59,13 @@ storiesOf("Molecules|Bar", module)
         default: boolean("close", true, "Props")
       }
     },
-    template: `<div style="margin: -20px">
-      <SfBar
+    template: `<SfBar
         :title="title"
         :back="back"
         :close="close"
       >
         <template #title="{title}">CUSTOM TITLE</template>
-      </SfBar>
-    </div>`
+      </SfBar>`
   }))
   .add("[slot] close", () => ({
     components: { SfBar },
@@ -86,13 +80,11 @@ storiesOf("Molecules|Bar", module)
         default: boolean("close", true, "Props")
       }
     },
-    template: `<div style="margin: -20px">
-      <SfBar
+    template: `<SfBar
         :title="title"
         :back="back"
         :close="close"
       >
         <template #close>CUSTOM CLOSE</template>
-      </SfBar>
-    </div>`
+      </SfBar>`
   }))

--- a/packages/vue/src/components/molecules/SfBar/SfBar.stories.js
+++ b/packages/vue/src/components/molecules/SfBar/SfBar.stories.js
@@ -1,34 +1,98 @@
 /* eslint-disable import/no-extraneous-dependencies */
 import { storiesOf } from "@storybook/vue";
-import {
-  withKnobs,
-  text,
-  optionsKnob as options
-} from "@storybook/addon-knobs";
+import { withKnobs, text, boolean } from "@storybook/addon-knobs";
 
 import SfBar from "./SfBar.vue";
 
 storiesOf("Molecules|Bar", module)
   .addDecorator(withKnobs)
-  .add("[slot] default", () => ({
+  .add("Common", () => ({
+    components: { SfBar },
     props: {
-      customClass: {
-        default: options(
-          "CSS modifier",
-          {
-            "sf-bar--modifier":
-              "sf-bar--modifier"
-          },
-          "",
-          { display: "multi-select" }
-        )
+      title: {
+        default: text("title", "Dresses", "Props")
+      },
+      back: {
+        default: boolean("back", true, "Props")
+      },
+      close: {
+        default: boolean("close", true, "Props")
       }
     },
-    editableProp: {
-      default: text("propname (prop)", "propvalue")
-    },
+    template: `<div style="margin: -20px">
+      <SfBar
+        :title="title"
+        :back="back"
+        :close="close"
+      />
+    </div>`
+  }))
+  .add("[slot] back", () => ({
     components: { SfBar },
-    template: `<SfBar
-      :class="customClass" />`
-  }));
-
+    props: {
+      title: {
+        default: text("title", "Dresses", "Props")
+      },
+      back: {
+        default: boolean("back", true, "Props")
+      },
+      close: {
+        default: boolean("close", true, "Props")
+      }
+    },
+    template: `<div style="margin: -20px">
+      <SfBar
+        :title="title"
+        :back="back"
+        :close="close"
+      >
+        <template #back>CUSTOM BACK</template>
+      </SfBar>
+    </div>`
+  }))
+  .add("[slot] title", () => ({
+    components: { SfBar },
+    props: {
+      title: {
+        default: text("title", "Dresses", "Props")
+      },
+      back: {
+        default: boolean("back", true, "Props")
+      },
+      close: {
+        default: boolean("close", true, "Props")
+      }
+    },
+    template: `<div style="margin: -20px">
+      <SfBar
+        :title="title"
+        :back="back"
+        :close="close"
+      >
+        <template #title="{title}">CUSTOM TITLE</template>
+      </SfBar>
+    </div>`
+  }))
+  .add("[slot] close", () => ({
+    components: { SfBar },
+    props: {
+      title: {
+        default: text("title", "Dresses", "Props")
+      },
+      back: {
+        default: boolean("back", true, "Props")
+      },
+      close: {
+        default: boolean("close", true, "Props")
+      }
+    },
+    template: `<div style="margin: -20px">
+      <SfBar
+        :title="title"
+        :back="back"
+        :close="close"
+      >
+        <template #close>CUSTOM CLOSE</template>
+      </SfBar>
+    </div>`
+  }))

--- a/packages/vue/src/components/molecules/SfBar/SfBar.vue
+++ b/packages/vue/src/components/molecules/SfBar/SfBar.vue
@@ -1,0 +1,5 @@
+<script src="./SfBar.js"></script>
+<template lang="html" src="./SfBar.html"></template>
+<style lang="scss">
+@import "~@storefront-ui/shared/styles/components/SfBar.scss";
+</style>


### PR DESCRIPTION
# Related issue
<!-- paste a link to related issue -->
No issue
# Scope of work
<!-- describe what you did -->
Should merge before #472 
Add SfBar component for mobile SfConentPages, SfMegaMenu and more. 
``` html
<SfBar
  class="mobile-only"
  :title="title"
  :back="true"
  :close="false"
  @click:back=""
  @click:close=""
   />
```
# Screenshots of visual changes
![Zrzut ekranu 2019-12-4 o 23 18 51](https://user-images.githubusercontent.com/12138170/70186572-763ca400-16ec-11ea-9b6c-99b68eb87dfd.png)

# Checklist

- [x] I followed [composition rules](https://docs.storefrontui.io/contributing/coding-guidelines.html#component-rules) for my component
- [x] I tested the component in most common device sizes (can be tested in Storybook [from viewport addon in top menu](https://github.com/storybooks/storybook/tree/master/addons/viewport))
