### PR TITLE
Fix uglyCommentsRegex in storysource

### DIFF
--- a/packages/vue/config/storybook/webpack.config.js
+++ b/packages/vue/config/storybook/webpack.config.js
@@ -7,7 +7,7 @@ module.exports = async ({ config }) => {
       {
         loader: require.resolve("@storybook/addon-storysource/loader"),
         options: {
-          uglyCommentsRegex: [/^eslint-.*/]
+          uglyCommentsRegex: [/^eslint-.*/, /^noinspection.*/]
         }
       }
     ],

--- a/packages/vue/config/storybook/webpack.config.js
+++ b/packages/vue/config/storybook/webpack.config.js
@@ -5,10 +5,7 @@ module.exports = async ({ config }) => {
     test: /\.stories\.js?$/,
     loaders: [
       {
-        loader: require.resolve("@storybook/addon-storysource/loader"),
-        options: {
-          uglyCommentsRegex: [/^eslint-.*/, /^noinspection.*/]
-        }
+        loader: require.resolve("@storybook/addon-storysource/loader")
       }
     ],
     enforce: "pre"


### PR DESCRIPTION
It doesn't work with one single entry, so I added another one (`noinspection` is a WebStorm-specific comment which works similar to `eslint-disable`).

Looks like a bug in storysource.

--- 

edit: doesn't work with 2 options on CI either. I'll remove the `options` part completely. 🤷🏻‍♂️

# Related issue
#482, commit 63d2d51.