### PR TITLE
Fix false positives in CSS modifiers on Vue components docs generation

### DIFF
--- a/packages/vue/scripts/create-vue-components-docs.js
+++ b/packages/vue/scripts/create-vue-components-docs.js
@@ -297,6 +297,10 @@ function extractCssModifiers(contentScssFile) {
     let lastModifierFound;
     // as multiple modifiers may be on one line, we have to make this (stateful) reg exp. search
     while ((partialReResult = regExp.exec(line)) !== null) {
+      // skip CSS vars which the simple regexp catches accidentally
+      if (partialReResult[0].includes("var(")) {
+        continue;
+      }
       if (!uniqueModifiers.has(partialReResult[0])) {
         uniqueModifiers.set(partialReResult[0], null);
         lastModifierFound = partialReResult[0];


### PR DESCRIPTION
This fix accounts for false positives in auto-generated components docs when a SCSS files contains CSS variables. Those look like BEM modifiers but are now explicitly excluded.
(Instead of making the reg exp. more complicated I decided to use a dedicated check for that.)