### PR TITLE
bugfix/css specificity for SfCircleIcon. SfHeader

### DIFF
--- a/packages/shared/styles/components/SfCircleIcon.scss
+++ b/packages/shared/styles/components/SfCircleIcon.scss
@@ -8,10 +8,12 @@ $circle-icon__badge-background-color: #FF3535 !default;
   align-items: center;
   justify-content: center;
   box-sizing: border-box;
-  padding: $spacer-big;
   border-radius: 50%;
   transition: box-shadow 0.3s ease, opacity 150ms ease-in-out;
   position: relative;
+  &.sf-button{
+    padding: $spacer-big;
+  }
   &:hover {
     box-shadow: 0 0 0 0.3125rem rgba($circle-icon-background, 0.4);
   }

--- a/packages/shared/styles/components/SfHeader.scss
+++ b/packages/shared/styles/components/SfHeader.scss
@@ -80,26 +80,32 @@ $header-navigation-item-font-weight: 500 !default;
     display: flex;
     align-items: center;
   }
-  &__icon{
+  &__icon {
     $this: &;
-    padding: 10px;
-    background-color: transparent;
-    transition: background-color 0.3s ease;
     margin-left: $spacer-big;
-    .sf-icon{
-      --icon-color: #{$c-text};
-    }
-    &:hover{
-      background-color: $c-light;
-      box-shadow: none;
-      .sf-icon{
+    &.sf-circle-icon {
+      background-color: transparent;
+      transition: background-color 0.3s ease;
+      &:hover {
+        background-color: $c-light;
+        box-shadow: none;
+      }
+      &.sf-button {
+        padding: 10px;
+      }
+      & .sf-icon {
         --icon-color: #{$c-text};
+        &:hover {
+          --icon-color: #{$c-text};
+        }
       }
     }
-    &--is-active{
-      background-color: $c-primary;
-      .sf-icon{
-        --icon-color: #{$c-white};
+    &--is-active {
+      &.sf-circle-icon {
+        background-color: $c-primary;
+        & .sf-icon {
+          --icon-color: #{$c-white};
+        }
       }
     }
   }

--- a/packages/shared/styles/components/SfHeader.scss
+++ b/packages/shared/styles/components/SfHeader.scss
@@ -94,6 +94,7 @@ $header-navigation-item-font-weight: 500 !default;
         padding: 10px;
       }
       & .sf-icon {
+        --icon-size: 1.25rem;
         --icon-color: #{$c-text};
         &:hover {
           --icon-color: #{$c-text};


### PR DESCRIPTION
# Related issue
<!-- paste a link to related issue -->
#531 
# Scope of work
<!-- describe what you did -->
Fix css specificy for nested components:
- SfButton in SfCircleIcon
- SfCircleIcon in SfHeader

# Screenshots of visual changes
compare server and client
![_](https://user-images.githubusercontent.com/12138170/70911943-32fb0300-2013-11ea-9e74-44832c2b70b9.gif)
# Checklist

- [x] I followed [composition rules](https://docs.storefrontui.io/contributing/coding-guidelines.html#component-rules) for my component
- [x] I tested the component in most common device sizes (can be tested in Storybook [from viewport addon in top menu](https://github.com/storybooks/storybook/tree/master/addons/viewport))
