### PR TITLE
[DOCS] add minimum css-loader version to the docs

### DIFF
--- a/packages/vue/docs/getting-started.md
+++ b/packages/vue/docs/getting-started.md
@@ -4,7 +4,7 @@
 For best extendability and performance we ship Storefront UI as (unpackaged) source code which requires **webpack** in your project to use the library.
 
 Storefront UI is working out of the box with **Nuxt** and **Vue CLI 2 & 3**!
-In order to use it in custom projects you need the following webpack loaders: `css-loader`, `scss-loader`, `sass-loader`, `vue-loader`
+In order to use it in custom projects you need the following webpack loaders: `css-loader@>1.0.1`, `scss-loader`, `sass-loader`, `vue-loader`
 :::
 
 Storefront UI is installed as a dependency to your project:


### PR DESCRIPTION
# Related issue
N/A

# Scope of work
Specify min css-loader version (otherwise scss will not load images properly from assets directory) 

# Screenshots of visual changes
N/A

# Checklist

- [x] I followed [composition rules](https://docs.storefrontui.io/contributing/coding-guidelines.html#component-rules) for my component
- [x] I tested the component in most common device sizes (can be tested in Storybook [from viewport addon in top menu](https://github.com/storybooks/storybook/tree/master/addons/viewport))
