### PR TITLE
fix(template): broken sf-carousel__wrapper unclickable space

### DIFF
--- a/packages/vue/src/components/organisms/SfCarousel/SfCarousel.html
+++ b/packages/vue/src/components/organisms/SfCarousel/SfCarousel.html
@@ -1,14 +1,4 @@
 <div class="sf-carousel">
-  <div class="sf-carousel__wrapper">
-    <div class="glide" ref="glide">
-      <div class="glide__track" data-glide-el="track">
-        <ul class="glide__slides sf-carousel__slides">
-          <!--@slot default slot for SfCarouselItem tags -->
-          <slot />
-        </ul>
-      </div>
-    </div>
-  </div>
   <div class="sf-carousel__controls">
     <!--@slot slot for icon moving to the previous item -->
     <slot name="prev" v-bind="{ go: () => go('prev') }">
@@ -28,5 +18,15 @@
         />
       </div>
     </slot>
+  </div>
+  <div class="sf-carousel__wrapper">
+    <div class="glide" ref="glide">
+      <div class="glide__track" data-glide-el="track">
+        <ul class="glide__slides sf-carousel__slides">
+          <!--@slot default slot for SfCarouselItem tags -->
+          <slot />
+        </ul>
+      </div>
+    </div>
   </div>
 </div>

--- a/packages/vue/src/components/organisms/SfCarousel/SfCarousel.html
+++ b/packages/vue/src/components/organisms/SfCarousel/SfCarousel.html
@@ -2,21 +2,19 @@
   <div class="sf-carousel__controls">
     <!--@slot slot for icon moving to the previous item -->
     <slot name="prev" v-bind="{ go: () => go('prev') }">
-      <div @click="go('prev')">
         <SfArrow
           class="sf-arrow--long"
           aria-label="previous"
+          @click="go('prev')"
         />
-      </div>
     </slot>
     <!--@slot slot for icon moving to the next item -->
     <slot name="next" v-bind="{ go: () => go('next') }">
-      <div @click="go('next')">
         <SfArrow
           class="sf-arrow--long sf-arrow--right"
           aria-label="next"
+          @click="go('next')"
         />
-      </div>
     </slot>
   </div>
   <div class="sf-carousel__wrapper">


### PR DESCRIPTION
# Related issue
<!-- paste a link to related issue -->
Closes #539
Mention #548
# Scope of work
<!-- describe what you did -->
Change DOM elements order to solve problem

# Screenshots of visual changes

# Checklist

- [x] I followed [composition rules](https://docs.storefrontui.io/contributing/coding-guidelines.html#component-rules) for my component
- [x] I tested the component in most common device sizes (can be tested in Storybook [from viewport addon in top menu](https://github.com/storybooks/storybook/tree/master/addons/viewport))
