### PR TITLE
fix(organisms): the second click SfTab title on desktop hide content

### DIFF
--- a/packages/vue/src/components/organisms/SfTabs/_internal/SfTab.js
+++ b/packages/vue/src/components/organisms/SfTabs/_internal/SfTab.js
@@ -7,7 +7,8 @@ export default {
   name: "SfTab",
   data() {
     return {
-      isActive: false
+      isActive: false,
+      desktopMin: 1024
     };
   },
   components: {
@@ -25,6 +26,11 @@ export default {
   },
   methods: {
     tabClick() {
+      const width = Math.max(
+        document.documentElement.clientWidth,
+        window.innerWidth
+      );
+      if (this.isActive && width > this.desktopMin) return;
       this.$parent.$emit("toggle", this._uid);
     }
   }


### PR DESCRIPTION
# Related issue
<!-- paste a link to related issue -->
Closes #601
# Scope of work
<!-- describe what you did -->
just check document width before run click script  
[[before changes]](https://storybook.storefrontui.io/?path=/story/organisms-tabs--common)
[[after changes]](https://deploy-preview-602--storefrontui-storybook.netlify.com/?path=/story/organisms-tabs--common)
# Screenshots of visual changes

# Checklist

- [x] I followed [composition rules](https://docs.storefrontui.io/contributing/coding-guidelines.html#component-rules) for my component
- [x] I tested the component in most common device sizes (can be tested in Storybook [from viewport addon in top menu](https://github.com/storybooks/storybook/tree/master/addons/viewport))
