### PR TITLE
fix(organisms): unwitting logo image stretch in SfHeader

### DIFF
--- a/packages/shared/styles/components/SfHeader.scss
+++ b/packages/shared/styles/components/SfHeader.scss
@@ -63,6 +63,8 @@ $header-navigation-item-font-weight: 500 !default;
     }
     img, picture{
       height: 100%;
+      width: auto;
+      max-width: unset;
     }
   }
   &__navigation {

--- a/packages/shared/styles/components/SfHeader.scss
+++ b/packages/shared/styles/components/SfHeader.scss
@@ -58,13 +58,12 @@ $header-navigation-item-font-weight: 500 !default;
   }
   &__logo {
     height: calc(100% - 1.25rem);
+    width: auto;
     @media (min-width: $desktop-min) {
       height: calc(100% - 2.5rem);
     }
     img, picture{
       height: 100%;
-      width: auto;
-      max-width: unset;
     }
   }
   &__navigation {


### PR DESCRIPTION
# Related issue
<!-- paste a link to related issue -->
Close #575
# Scope of work
<!-- describe what you did -->
set `width: auto` for `.sf-header__logo.sf-image`

# Screenshots of visual changes

# Checklist

- [x] I followed [composition rules](https://docs.storefrontui.io/contributing/coding-guidelines.html#component-rules) for my component
- [x] I tested the component in most common device sizes (can be tested in Storybook [from viewport addon in top menu](https://github.com/storybooks/storybook/tree/master/addons/viewport))
