### PR TITLE
feat: mobile header improvements 

### DIFF
--- a/packages/shared/styles/components/SfHeader.scss
+++ b/packages/shared/styles/components/SfHeader.scss
@@ -78,8 +78,10 @@ $header-navigation-item-font-weight: 500 !default;
   }
   &__search {
     @media (max-width: $desktop-min){
-      background-color: $c-white;
+      order: 1;
+      flex: 0 0 100%;
       margin: $spacer 0;
+      background-color: $c-white;
     }
     @media (min-width: $desktop-min) {
       margin: 0 10px 0 auto;

--- a/packages/shared/styles/components/SfHeader.scss
+++ b/packages/shared/styles/components/SfHeader.scss
@@ -1,7 +1,7 @@
 @import "../variables";
 
-$header-padding: 0 $spacer-extra-big!default;
-$header-desktop-padding: $spacer-big $spacer-extra-big!default;
+$header-padding: 0 $spacer-extra-big !default;
+$header-desktop-padding: $spacer-big $spacer-extra-big !default;
 $header__logo-height: 1.5rem !default;
 $header__logo-desktop-height: 2.125 !default;
 $header-background-color: $c-light !default;

--- a/packages/shared/styles/components/SfHeader.scss
+++ b/packages/shared/styles/components/SfHeader.scss
@@ -43,6 +43,7 @@ $header-navigation-item-font-weight: 500 !default;
   }
 }
 .sf-header {
+  $this: &;
   box-sizing: border-box;
   display: flex;
   flex-wrap: wrap;
@@ -55,6 +56,17 @@ $header-navigation-item-font-weight: 500 !default;
     justify-content: flex-start;
     padding: $header-desktop-padding;
     background-color: $header-desktop-background-color;
+  }
+  &--has-mobile-search{
+    #{$this}__search{
+      @media (max-width: $desktop-min){
+        display: flex;
+        order: 1;
+        flex: 0 0 100%;
+        margin: $spacer 0;
+        background-color: $c-white;
+      }
+    }
   }
   &__logo {
     height: $header__logo-height;
@@ -77,13 +89,9 @@ $header-navigation-item-font-weight: 500 !default;
     }
   }
   &__search {
-    @media (max-width: $desktop-min){
-      order: 1;
-      flex: 0 0 100%;
-      margin: $spacer 0;
-      background-color: $c-white;
-    }
+    display: none;
     @media (min-width: $desktop-min) {
+      display: flex;
       margin: 0 10px 0 auto;
     }
   }

--- a/packages/shared/styles/components/SfHeader.scss
+++ b/packages/shared/styles/components/SfHeader.scss
@@ -1,9 +1,9 @@
 @import "../variables";
 
-$header-height: 3.125rem !default;
 $header-padding: 0 $spacer-extra-big!default;
-$header-desktop-padding: 0 $spacer-extra-big!default;
-$header-desktop-height: 5rem !default;
+$header-desktop-padding: $spacer-big $spacer-extra-big!default;
+$header__logo-height: 1.5rem !default;
+$header__logo-desktop-height: 2.125 !default;
 $header-background-color: $c-light !default;
 $header-desktop-background-color: $c-white !default;
 $header-navigation-item-margin-left: 2.5rem !default;
@@ -45,22 +45,24 @@ $header-navigation-item-font-weight: 500 !default;
 .sf-header {
   box-sizing: border-box;
   display: flex;
+  flex-wrap: wrap;
   align-items: center;
   justify-content: center;
-  height: $header-height;
   padding: $header-padding ;
   background-color: $header-background-color;
   @media (min-width: $desktop-min) {
+    flex-wrap: nowrap;
     justify-content: flex-start;
-    height: $header-desktop-height;
-    padding: $header-padding;
+    padding: $header-desktop-padding;
     background-color: $header-desktop-background-color;
   }
   &__logo {
-    height: calc(100% - 1.25rem);
+    height: $header__logo-height;
     width: auto;
+    margin: 10px 0;
     @media (min-width: $desktop-min) {
-      height: calc(100% - 2.5rem);
+      height: 2.125rem;
+      margin: 0;
     }
     img, picture{
       height: 100%;
@@ -75,7 +77,13 @@ $header-navigation-item-font-weight: 500 !default;
     }
   }
   &__search {
-    margin: 0 10px 0 auto;
+    @media (max-width: $desktop-min){
+      background-color: $c-white;
+      margin: $spacer 0;
+    }
+    @media (min-width: $desktop-min) {
+      margin: 0 10px 0 auto;
+    }
   }
   &__icons{
     display: flex;
@@ -112,7 +120,6 @@ $header-navigation-item-font-weight: 500 !default;
     }
   }
   &__navigation,
-  &__search,
   &__icons{
     @media (max-width: $desktop-min) {
       display: none;

--- a/packages/vue/src/components/organisms/SfHeader/SfHeader.html
+++ b/packages/vue/src/components/organisms/SfHeader/SfHeader.html
@@ -50,4 +50,6 @@
       />
     </div>
   </slot>
+  <!--@slot Use this slot to replace default header language selector on mobile -->
+  <slot name="language-selector"></slot>
 </header>

--- a/packages/vue/src/components/organisms/SfHeader/SfHeader.html
+++ b/packages/vue/src/components/organisms/SfHeader/SfHeader.html
@@ -1,4 +1,4 @@
-<header class="sf-header">
+<header class="sf-header" :class="{'sf-header--has-mobile-search': hasMobileSearch}">
   <!--@slot Use this slot to replace logo with text or icon-->
   <slot name="logo" v-bind="{logo, title}">
     <SfImage v-if="logo" :src="logo" :alt="title" class="sf-header__logo"/>
@@ -10,7 +10,7 @@
   </nav>
     <!--@slot Use this slot to replace default search bar-->
   <slot name="search">
-    <SfSearchBar class="sf-header__search" />
+    <SfSearchBar :placeholder="searchPlaceholder" class="sf-header__search" />
   </slot>
   <!--@slot Use this slot to replace default header icons with custom content-->
   <slot name="header-icons" v-bind="{accountIcon, wishlistIcon, cartIcon}">

--- a/packages/vue/src/components/organisms/SfHeader/SfHeader.js
+++ b/packages/vue/src/components/organisms/SfHeader/SfHeader.js
@@ -53,12 +53,29 @@ export default {
       type: [String, Boolean],
       default: "profile"
     },
+    /**
+     * Header activeIcon (accepts account, wishlist and cart)
+     */
     activeIcon: {
       type: String,
       default: "",
       validator(value) {
         return ["", "account", "wishlist", "cart"].includes(value);
       }
+    },
+    /**
+     * Header search on mobile
+     */
+    hasMobileSearch: {
+      type: Boolean,
+      default: false
+    },
+    /**
+     * Header search placeholder
+     */
+    searchPlaceholder:{
+      type: String,
+      default: "Search for items"
     }
   }
 };

--- a/packages/vue/src/components/organisms/SfHeader/SfHeader.stories.js
+++ b/packages/vue/src/components/organisms/SfHeader/SfHeader.stories.js
@@ -1,5 +1,5 @@
 import { storiesOf } from "@storybook/vue";
-import { withKnobs, text, select, object } from "@storybook/addon-knobs";
+import { withKnobs, text, select, object, boolean } from "@storybook/addon-knobs";
 
 import SfHeader from "./SfHeader.vue";
 
@@ -37,6 +37,12 @@ storiesOf("Organisms|Header", module)
           "account",
           "Props"
         )
+      },
+      hasMobileSearch: {
+        default: boolean("hasMobileSearch", false, "Props")
+      },
+      searchPlaceholder: {
+        default: text("searchPlaceholder","Search for items", "Props")
       }
     },
     template: `<SfHeader
@@ -46,7 +52,8 @@ storiesOf("Organisms|Header", module)
       :wishlist-icon="wishlistIcon" 
       :account-icon="accountIcon"
       :active-icon="activeIcon"
-      style="max-width: 1024px; margin: auto"
+      :has-mobile-search="hasMobileSearch"
+      :search-placeholder="searchPlaceholder"
      >
       <template #navigation>
         <SfHeaderNavigationItem>CLOTHES</SfHeaderNavigationItem>
@@ -87,6 +94,12 @@ storiesOf("Organisms|Header", module)
           "account",
           "Props"
         )
+      },
+      hasMobileSearch: {
+        default: boolean("hasMobileSearch", false, "Props")
+      },
+      searchPlaceholder: {
+        default: text("searchPlaceholder","Search for items", "Props")
       }
     },
     template: `<SfHeader
@@ -96,7 +109,8 @@ storiesOf("Organisms|Header", module)
       :wishlist-icon="wishlistIcon" 
       :account-icon="accountIcon"
       :active-icon="activeIcon"
-      style="max-width: 1024px; margin: auto"
+      :has-mobile-search="hasMobileSearch"
+      :search-placeholder="searchPlaceholder"
     >
       <template #logo>
         CUSTOM LOGO 
@@ -135,6 +149,12 @@ storiesOf("Organisms|Header", module)
       },
       activeIcon: {
         default: text("activeIcon", "account", "Props")
+      },
+      hasMobileSearch: {
+        default: boolean("hasMobileSearch", false, "Props")
+      },
+      searchPlaceholder: {
+        default: text("searchPlaceholder","Search for items", "Props")
       }
     },
     template: `<SfHeader
@@ -144,7 +164,8 @@ storiesOf("Organisms|Header", module)
       :wishlist-icon="wishlistIcon" 
       :account-icon="accountIcon"
       :active-icon="activeIcon"
-      style="max-width: 1024px; margin: auto"
+      :has-mobile-search="hasMobileSearch"
+      :search-placeholder="searchPlaceholder"
     >
       <template #navigation>
         CUSTOM NAVIGATION
@@ -178,6 +199,12 @@ storiesOf("Organisms|Header", module)
       },
       activeIcon: {
         default: text("activeIcon", "account", "Props")
+      },
+      hasMobileSearch: {
+        default: boolean("hasMobileSearch", false, "Props")
+      },
+      searchPlaceholder: {
+        default: text("searchPlaceholder","Search for items", "Props")
       }
     },
     template: `<SfHeader
@@ -187,7 +214,8 @@ storiesOf("Organisms|Header", module)
       :wishlist-icon="wishlistIcon" 
       :account-icon="accountIcon"
       :active-icon="activeIcon"
-      style="max-width: 1024px; margin: auto"
+      :has-mobile-search="hasMobileSearch"
+      :search-placeholder="searchPlaceholder"
     >
       <template #navigation>
         <SfHeaderNavigationItem>WOMEN</SfHeaderNavigationItem>
@@ -231,6 +259,12 @@ storiesOf("Organisms|Header", module)
           "account",
           "Props"
         )
+      },
+      hasMobileSearch: {
+        default: boolean("hasMobileSearch", false, "Props")
+      },
+      searchPlaceholder: {
+        default: text("searchPlaceholder","Search for items", "Props")
       }
     },
     template: `<SfHeader
@@ -240,7 +274,8 @@ storiesOf("Organisms|Header", module)
       :wishlist-icon="wishlistIcon" 
       :account-icon="accountIcon"
       :active-icon="activeIcon"
-      style="max-width: 1024px; margin: auto"
+      :has-mobile-search="hasMobileSearch"
+      :search-placeholder="searchPlaceholder"
     >
       <template #navigation>
         <SfHeaderNavigationItem>WOMEN</SfHeaderNavigationItem>

--- a/packages/vue/src/components/organisms/SfHeader/SfHeader.stories.js
+++ b/packages/vue/src/components/organisms/SfHeader/SfHeader.stories.js
@@ -46,7 +46,6 @@ storiesOf("Organisms|Header", module)
       :wishlist-icon="wishlistIcon" 
       :account-icon="accountIcon"
       :active-icon="activeIcon"
-      style="max-width: 1024px; margin: auto"
      >
       <template #navigation>
         <SfHeaderNavigationItem>CLOTHES</SfHeaderNavigationItem>

--- a/packages/vue/src/components/organisms/SfHeader/SfHeader.stories.js
+++ b/packages/vue/src/components/organisms/SfHeader/SfHeader.stories.js
@@ -46,6 +46,7 @@ storiesOf("Organisms|Header", module)
       :wishlist-icon="wishlistIcon" 
       :account-icon="accountIcon"
       :active-icon="activeIcon"
+      style="max-width: 1024px; margin: auto"
      >
       <template #navigation>
         <SfHeaderNavigationItem>CLOTHES</SfHeaderNavigationItem>


### PR DESCRIPTION
# Related issue
<!-- paste a link to related issue -->
Closes #625
# Scope of work
<!-- describe what you did -->
support #622
- [x] add props `has-mobile-search` to enable SfSearch on mobile
- [x] add props `search-placeholder` to set SfSearch placeholder
- [x] just add slot `language-selector` for language selector on mobile
- [x] adjust stories to changes
- [x] adjust styles to changes
# Screenshots of visual changes
[with SfSearch]
![_2](https://user-images.githubusercontent.com/12138170/71890325-501f7f00-3144-11ea-82a8-c843b841031d.png)
[without SfSearch]
![_1](https://user-images.githubusercontent.com/12138170/71890324-501f7f00-3144-11ea-905c-4712a1590c8a.png)

# Checklist

- [x] I followed [composition rules](https://docs.storefrontui.io/contributing/coding-guidelines.html#component-rules) for my component
- [x] I tested the component in most common device sizes (can be tested in Storybook [from viewport addon in top menu](https://github.com/storybooks/storybook/tree/master/addons/viewport))
