### PR TITLE
fix(style): chevron position in multiline header

### DIFF
--- a/packages/shared/styles/components/SfAccordion.scss
+++ b/packages/shared/styles/components/SfAccordion.scss
@@ -9,6 +9,7 @@ $accordion__title-padding-y: 0.625rem !default;
 $accordion__title-font-size: $font-size-big-mobile !default;
 $accordion__title-font-size-desktop: $font-size-big-desktop !default;
 $accordion__content-padding-y: 1.875rem !default;
+$accordion-item__chevron-size: 1.25rem !default;
 
 @mixin for-desktop {
   @media screen and (min-width: $desktop-min) {
@@ -28,7 +29,6 @@ $accordion__content-padding-y: 1.875rem !default;
   &__header {
     display: flex;
     justify-content: space-between;
-    align-items: center;
     padding: $accordion__title-padding-y 0;
     color: $c-dark;
     cursor: pointer;
@@ -44,12 +44,12 @@ $accordion__content-padding-y: 1.875rem !default;
     display: none;
   }
 }
-
 .sf-accordion {
   $this: &;
   &--has-chevron {
     #{$this}-item__chevron {
       display: block;
+      margin-top:  (-$accordion-font-size + $accordion-item__chevron-size) / 2;
     }
   }
 }

--- a/packages/shared/styles/components/SfTabs.scss
+++ b/packages/shared/styles/components/SfTabs.scss
@@ -13,6 +13,7 @@ $tabs__title-color--hover: $c-dark !default;
 $tabs__title-font-size: $font-size-big-mobile !default;
 $tabs__title-font-size-desktop: $font-size-big-desktop !default;
 $tabs__content-padding-y: 3 * $spacer-big !default;
+$tabs__chevron-size: 1.25rem !default;
 
 @mixin for-desktop {
   @media screen and (min-width: $desktop-min) {
@@ -36,7 +37,6 @@ $tabs__content-padding-y: 3 * $spacer-big !default;
     display: flex;
     flex-basis: 100%;
     justify-content: space-between;
-    align-items: center;
     padding: calc(#{$tabs__title-padding-y} - 5px) 0;
     border-bottom: 1px solid $tabs-border-color;
     color: $c-dark;
@@ -86,6 +86,7 @@ $tabs__content-padding-y: 3 * $spacer-big !default;
     }
   }
   &__chevron {
+    margin-top:  (-$tabs-font-size + $tabs__chevron-size) / 2;
     @include for-desktop {
       display: none;
     }


### PR DESCRIPTION
# Related issue
<!-- paste a link to related issue -->
Closes: #524 
Closes: #558
# Scope of work
<!-- describe what you did -->
Move to top chevron in components for multiline header

# Screenshots of visual changes
[after]
![Zrzut ekranu 2020-01-6 o 12 25 21](https://user-images.githubusercontent.com/12138170/71815662-78de4080-3080-11ea-8a30-6a765e4ba630.png)
[before]
![Zrzut ekranu 2020-01-6 o 12 32 32](https://user-images.githubusercontent.com/12138170/71815713-a9be7580-3080-11ea-9671-02dca62a20f0.png)

# Checklist

- [x] I followed [composition rules](https://docs.storefrontui.io/contributing/coding-guidelines.html#component-rules) for my component
- [x] I tested the component in most common device sizes (can be tested in Storybook [from viewport addon in top menu](https://github.com/storybooks/storybook/tree/master/addons/viewport))
