### PR TITLE
fix: move bodyLock to nextTick

### DIFF
--- a/packages/vue/src/components/molecules/SfGallery/SfGallery.vue
+++ b/packages/vue/src/components/molecules/SfGallery/SfGallery.vue
@@ -46,18 +46,18 @@
     <div class="sf-gallery__thumbs">
       <slot name="thumbs" v-bind="{ images, active: activeIndex, go }">
         <div
-            v-for="(image, index) in images"
-            :key="'img-' + index"
-            class="sf-gallery__item"
-            :class="{ 'sf-gallery__item--selected': index === activeIndex }"
-            @click="go(index)"
+          v-for="(image, index) in images"
+          :key="'img-' + index"
+          class="sf-gallery__item"
+          :class="{ 'sf-gallery__item--selected': index === activeIndex }"
+          @click="go(index)"
         >
           <SfImage
-              class="sf-gallery__thumb"
-              :src="image.mobile.url"
-              :width="imageWidth"
-              :height="imageHeight"
-              alt=""
+            class="sf-gallery__thumb"
+            :src="image.mobile.url"
+            :width="imageWidth"
+            :height="imageHeight"
+            alt=""
           />
         </div>
       </slot>

--- a/packages/vue/src/components/molecules/SfModal/SfModal.vue
+++ b/packages/vue/src/components/molecules/SfModal/SfModal.vue
@@ -97,7 +97,9 @@ export default {
       handler: function(value) {
         if (typeof window === "undefined") return;
         if (value) {
-          disableBodyScroll(this.$refs.content);
+          this.$nextTick(() => {
+            disableBodyScroll(this.$refs.content);
+          });
           document.addEventListener("keydown", this.keydownHandler);
         } else {
           clearAllBodyScrollLocks();

--- a/packages/vue/src/components/organisms/SfSidebar/SfSidebar.vue
+++ b/packages/vue/src/components/organisms/SfSidebar/SfSidebar.vue
@@ -90,7 +90,9 @@ export default {
       handler(value) {
         if (typeof window === "undefined") return;
         if (value) {
-          disableBodyScroll(this.$refs.content);
+          this.$nextTick(() => {
+            disableBodyScroll(this.$refs.content);
+          });
           document.addEventListener("keydown", this.keydownHandler);
         } else {
           clearAllBodyScrollLocks();


### PR DESCRIPTION
# Related issue
<!-- paste a link to related issue -->

# Scope of work
<!-- describe what you did -->
when you use body-scroll-lock without $nextTick you have undefined on refs, then you should use next tick to fix it 
# Screenshots of visual changes

# Checklist

- [x] I followed [composition rules](https://docs.storefrontui.io/contributing/coding-guidelines.html#component-rules) for my component
- [x] I tested the component in most common device sizes (can be tested in Storybook [from viewport addon in top menu](https://github.com/storybooks/storybook/tree/master/addons/viewport))
