### PR TITLE
fix: add to cart disable style

### DIFF
--- a/packages/shared/styles/components/SfAddToCart.scss
+++ b/packages/shared/styles/components/SfAddToCart.scss
@@ -12,10 +12,6 @@ $add-to-cart__select-quantity-max-width: 5.625rem !default;
   display: flex;
   &__button {
     flex: 1;
-    &:disabled {
-      background-color: $c-primary-variant;
-      cursor: default;
-    }
     @include for-desktop {
       order: 1;
     }


### PR DESCRIPTION
# Related issue
<!-- paste a link to related issue -->

# Scope of work
remove override to fix disable button color

# Checklist

- [x] I followed [composition rules](https://docs.storefrontui.io/contributing/coding-guidelines.html#component-rules) for my component
- [x] I tested the component in most common device sizes (can be tested in Storybook [from viewport addon in top menu](https://github.com/storybooks/storybook/tree/master/addons/viewport))
