### PR TITLE
refactor: move background css variable to inline styles

### DIFF
--- a/packages/shared/styles/components/SfBanner.scss
+++ b/packages/shared/styles/components/SfBanner.scss
@@ -41,7 +41,7 @@ $banner--slim__title-font-size: $h1-font-size-desktop !default;
   font-weight: $banner-font-weight;
   line-height: $banner-line-height;
   @media (min-width: $desktop-min) {
-    background-image: var(--background-image-desktop);
+    background-image: var(--background-desktop-image);
     min-height: $banner-min-height-desktop;
     padding: $banner-padding-y-desktop $banner-padding-x-desktop
       $banner-padding-y-desktop calc(50% + #{$banner-padding-x-desktop});

--- a/packages/vue/src/components/molecules/SfBanner/SfBanner.stories.js
+++ b/packages/vue/src/components/molecules/SfBanner/SfBanner.stories.js
@@ -44,8 +44,8 @@ storiesOf("Molecules|Banner", module)
         default: object(
           "image",
           {
-            small: "/assets/storybook/SfBanner/Banner1.jpg",
-            normal: "/assets/storybook/SfBanner/Banner1.jpg"
+            mobile: "/assets/storybook/SfBanner/Banner1.jpg",
+            dektop: "/assets/storybook/SfBanner/Banner1.jpg"
           },
           "Props"
         )
@@ -101,8 +101,8 @@ storiesOf("Molecules|Banner", module)
         default: object(
           "image",
           {
-            small: "/assets/storybook/SfBanner/Banner1.jpg",
-            normal: "/assets/storybook/SfBanner/Banner1.jpg"
+            mobile: "/assets/storybook/SfBanner/Banner1.jpg",
+            dektop: "/assets/storybook/SfBanner/Banner1.jpg"
           },
           "Props"
         )
@@ -161,8 +161,8 @@ storiesOf("Molecules|Banner", module)
         default: object(
           "image",
           {
-            small: "/assets/storybook/SfBanner/Banner1.jpg",
-            normal: "/assets/storybook/SfBanner/Banner1.jpg"
+            mobile: "/assets/storybook/SfBanner/Banner1.jpg",
+            dektop: "/assets/storybook/SfBanner/Banner1.jpg"
           },
           "Props"
         )
@@ -221,8 +221,8 @@ storiesOf("Molecules|Banner", module)
         default: object(
           "image",
           {
-            small: "/assets/storybook/SfBanner/Banner1.jpg",
-            normal: "/assets/storybook/SfBanner/Banner1.jpg"
+            mobile: "/assets/storybook/SfBanner/Banner1.jpg",
+            dektop: "/assets/storybook/SfBanner/Banner1.jpg"
           },
           "Props"
         )
@@ -281,8 +281,8 @@ storiesOf("Molecules|Banner", module)
         default: object(
           "image",
           {
-            small: "/assets/storybook/SfBanner/Banner1.jpg",
-            normal: "/assets/storybook/SfBanner/Banner1.jpg"
+            mobile: "/assets/storybook/SfBanner/Banner1.jpg",
+            dektop: "/assets/storybook/SfBanner/Banner1.jpg"
           },
           "Props"
         )

--- a/packages/vue/src/components/molecules/SfBanner/SfBanner.vue
+++ b/packages/vue/src/components/molecules/SfBanner/SfBanner.vue
@@ -1,5 +1,5 @@
 <template>
-  <section class="sf-banner" v-on="isMobile ? $listeners : {}">
+  <section class="sf-banner" :style="style" v-on="isMobile ? $listeners : {}">
     <div class="sf-banner__container">
       <slot name="subtitle" v-bind="{ subtitle }">
         <h2 v-if="subtitle" class="sf-banner__subtitle">
@@ -76,39 +76,19 @@ export default {
       isMobile: false
     };
   },
-  watch: {
-    image: {
-      handler(image) {
-        if (typeof window === "undefined") return;
-        this.$nextTick(() => {
-          if (typeof image === "object") {
-            this.$el.style.setProperty(
-              "--background-image",
-              `url(${image.small})`
-            );
-            this.$el.style.setProperty(
-              "--background-image-desktop",
-              `url(${image.normal})`
-            );
-          } else {
-            this.$el.style.setProperty("--background-image", `url(${image})`);
-            this.$el.style.setProperty(
-              "--background-image-desktop",
-              `url(${image})`
-            );
-          }
-        });
-      },
-      immediate: true
-    },
-    background: {
-      handler(background) {
-        if (typeof window === "undefined") return;
-        this.$nextTick(() => {
-          this.$el.style.setProperty("--background-color", background);
-        });
-      },
-      immediate: true
+  computed: {
+    style() {
+      const image = this.image;
+      const background = this.background;
+      return {
+        "--background-image": image.mobile
+          ? `url(${image.mobile})`
+          : `url(${image})`,
+        "--background-desktop-image": image.desktop
+          ? `url(${image.desktop})`
+          : `url(${image})`,
+        "--background-color": background
+      };
     }
   },
   mounted() {

--- a/packages/vue/src/examples/pages/home/Home.vue
+++ b/packages/vue/src/examples/pages/home/Home.vue
@@ -20,7 +20,10 @@
             title="COCKTAIL PARTY"
             description="Find stunning women's cocktail dresses and party dresses. Stand out in lace and metallic cocktail dresses from all your favorite brands."
             button-text="SHOP NOW"
-            image="/assets/storybook/Home/bannerF.jpg"
+            :image="{
+              mobile: '/assets/storybook/Home/bannerB.jpg',
+              desktop: '/assets/storybook/Home/bannerF.jpg'
+            }"
             class="sf-banner--slim banner-custom"
           />
         </a>
@@ -295,11 +298,6 @@ export default {
 .banner-central {
   @include for-desktop {
     padding-right: 30%;
-  }
-}
-.banner-custom {
-  @media (max-width: $desktop-min) {
-    background-image: url("../../../../public/assets/storybook/Home/bannerB.jpg") !important;
   }
 }
 .banner-application {


### PR DESCRIPTION
# Related issue
<!-- paste a link to related issue -->

# Scope of work
<!-- describe what you did -->
- [x] moved css variable setter to inline styles
- [x] adjust object props name to SfImage mobile and desktop
- [x] upgrade 1 banner on Home page

# Screenshots of visual changes

# Checklist

- [x] I followed [composition rules](https://docs.storefrontui.io/contributing/coding-guidelines.html#component-rules) for my component
- [x] I tested the component in most common device sizes (can be tested in Storybook [from viewport addon in top menu](https://github.com/storybooks/storybook/tree/master/addons/viewport))
