### PR TITLE
fix: z-index in SfSelect dropdown

### DIFF
--- a/packages/shared/styles/components/SfSelect.scss
+++ b/packages/shared/styles/components/SfSelect.scss
@@ -90,6 +90,7 @@ $select__cancel-color: #a3a5ad !default;
     left: 0;
     right: 0;
     bottom: 0;
+    z-index: 1;
     box-sizing: border-box;
     background-color: #fff;
     @media screen and (min-width: $desktop-min) {

--- a/packages/vue/src/components/molecules/SfSelect/SfSelect.vue
+++ b/packages/vue/src/components/molecules/SfSelect/SfSelect.vue
@@ -26,11 +26,7 @@
           {{ label }}
         </div>
       </slot>
-      <SfOverlay
-        :visible="open"
-        class="sf-select__overlay"
-        @click="open = false"
-      />
+      <SfOverlay :visible="open" class="sf-select__overlay" />
       <transition name="sf-select">
         <div v-show="open" class="sf-select__dropdown">
           <!--  sf-select__option -->


### PR DESCRIPTION
# Related issue
<!-- paste a link to related issue -->

# Scope of work
<!-- describe what you did -->
fix z-index 💚 in SfSelect dropdown
# Screenshots of visual changes

# Checklist

- [ ] I followed [composition rules](https://docs.storefrontui.io/contributing/coding-guidelines.html#component-rules) for my component
- [ ] I tested the component in most common device sizes (can be tested in Storybook [from viewport addon in top menu](https://github.com/storybooks/storybook/tree/master/addons/viewport))
