### PR TITLE
fix:  transition group on shipping details view

### DIFF
--- a/packages/vue/src/examples/pages/my-account/_internal/ShippingDetails.vue
+++ b/packages/vue/src/examples/pages/my-account/_internal/ShippingDetails.vue
@@ -95,46 +95,44 @@
           ...) This way you won't have to enter the shipping address manually
           with each order.
         </p>
-        <div class="shipping-list">
-          <transition-group name="fade">
-            <div
-              v-for="(shipping, key) in account.shipping"
-              :key="shipping.firstName + shipping.lastName"
-              class="shipping"
-            >
-              <div class="shipping__content">
-                <p class="shipping__address">
-                  <span class="shipping__client-name"
-                    >{{ shipping.firstName }} {{ shipping.lastName }}</span
-                  ><br />
-                  {{ shipping.streetName }} {{ shipping.apartment }}<br />{{
-                    shipping.zipCode
-                  }}
-                  {{ shipping.city }},<br />{{ shipping.country }}
-                </p>
-                <p class="shipping__address">
-                  {{ shipping.phoneNumber }}
-                </p>
-              </div>
-              <div class="shipping__actions">
-                <SfIcon
-                  icon="cross"
-                  color="gray"
-                  size="14px"
-                  role="button"
-                  class="mobile-only"
-                  @click="deleteAddress(key)"
-                />
-                <SfButton @click="changeAddress(key)">Change</SfButton>
-                <SfButton
-                  class="shipping__button-delete desktop-only"
-                  @click="deleteAddress(key)"
-                  >Delete</SfButton
-                >
-              </div>
+        <transition-group tag="div" name="fade" class="shipping-list">
+          <div
+            v-for="(shipping, key) in account.shipping"
+            :key="shipping.firstName + shipping.lastName"
+            class="shipping"
+          >
+            <div class="shipping__content">
+              <p class="shipping__address">
+                <span class="shipping__client-name"
+                  >{{ shipping.firstName }} {{ shipping.lastName }}</span
+                ><br />
+                {{ shipping.streetName }} {{ shipping.apartment }}<br />{{
+                  shipping.zipCode
+                }}
+                {{ shipping.city }},<br />{{ shipping.country }}
+              </p>
+              <p class="shipping__address">
+                {{ shipping.phoneNumber }}
+              </p>
             </div>
-          </transition-group>
-        </div>
+            <div class="shipping__actions">
+              <SfIcon
+                icon="cross"
+                color="gray"
+                size="14px"
+                role="button"
+                class="mobile-only"
+                @click="deleteAddress(key)"
+              />
+              <SfButton @click="changeAddress(key)">Change</SfButton>
+              <SfButton
+                class="shipping__button-delete desktop-only"
+                @click="deleteAddress(key)"
+                >Delete</SfButton
+              >
+            </div>
+          </div>
+        </transition-group>
         <SfButton class="action-button" @click="changeAddress(-1)"
           >Add new address</SfButton
         >

--- a/packages/vue/src/examples/pages/my-account/_internal/ShippingDetails.vue
+++ b/packages/vue/src/examples/pages/my-account/_internal/ShippingDetails.vue
@@ -99,7 +99,7 @@
           <transition-group name="fade">
             <div
               v-for="(shipping, key) in account.shipping"
-              :key="key"
+              :key="shipping.firstName + shipping.lastName"
               class="shipping"
             >
               <div class="shipping__content">


### PR DESCRIPTION
# Related issue
<!-- paste a link to related issue -->

# Scope of work
<!-- describe what you did -->
fix transition group key linter warning
# Screenshots of visual changes

# Checklist

- [x] I followed [composition rules](https://docs.storefrontui.io/contributing/coding-guidelines.html#component-rules) for my component
- [x] I tested the component in most common device sizes (can be tested in Storybook [from viewport addon in top menu](https://github.com/storybooks/storybook/tree/master/addons/viewport))
