### PR TITLE
fix: css specificity for show password button

### DIFF
--- a/packages/shared/styles/components/SfInput.scss
+++ b/packages/shared/styles/components/SfInput.scss
@@ -121,7 +121,7 @@ $input__password-icon-width: 1.4rem !default;
     font-family: $input__error-message-font-family;
     font-size: $input__error-message-font-size;
   }
-  &__password-button {
+  &__password-button.sf-button {
     position: absolute;
     right: $spacer-big;
     padding: 0;


### PR DESCRIPTION
# Related issue
<!-- paste a link to related issue -->

# Scope of work
<!-- describe what you did -->

# Screenshots of visual changes

# Checklist

- [ ] I followed [composition rules](https://docs.storefrontui.io/contributing/coding-guidelines.html#component-rules) for my component
- [ ] I tested the component in most common device sizes (can be tested in Storybook [from viewport addon in top menu](https://github.com/storybooks/storybook/tree/master/addons/viewport))
