### PR TITLE
fix: prevent glide mount for empty container

### DIFF
--- a/packages/vue/src/components/molecules/SfGallery/SfGallery.vue
+++ b/packages/vue/src/components/molecules/SfGallery/SfGallery.vue
@@ -153,6 +153,7 @@ export default {
     this.$nextTick(() => {
       // handle slider with swipe and transitions with Glide.js
       // https://glidejs.com/docs/
+      if (this.images.length < 1) return;
       const glide = new Glide(this.$refs.glide, this.sliderOptions);
       glide.on("run", () => {
         this.go(glide.index);

--- a/packages/vue/src/components/molecules/SfGallery/SfGallery.vue
+++ b/packages/vue/src/components/molecules/SfGallery/SfGallery.vue
@@ -181,6 +181,7 @@ export default {
       return "";
     },
     go(index) {
+      if (!this.glide) return;
       this.activeIndex = index;
       /**
        * Event for current image change (`v-model`)

--- a/packages/vue/src/components/organisms/SfCarousel/SfCarousel.spec.js
+++ b/packages/vue/src/components/organisms/SfCarousel/SfCarousel.spec.js
@@ -1,0 +1,8 @@
+import { shallowMount } from "@vue/test-utils";
+import SfCarousel from "./SfCarousel.vue";
+describe("SfCarousel.vue", () => {
+  it("renders a component", () => {
+    const component = shallowMount(SfCarousel);
+    expect(component.contains(".sf-carousel")).toBe(true);
+  });
+});

--- a/packages/vue/src/components/organisms/SfCarousel/SfCarousel.vue
+++ b/packages/vue/src/components/organisms/SfCarousel/SfCarousel.vue
@@ -84,6 +84,7 @@ export default {
   },
   mounted: function() {
     this.$nextTick(() => {
+      if (!this.$slots.default) return;
       const glide = new Glide(this.$refs.glide, this.mergedOptions);
       glide.mount();
       glide.on("run.before", move => {

--- a/packages/vue/src/components/organisms/SfCarousel/SfCarousel.vue
+++ b/packages/vue/src/components/organisms/SfCarousel/SfCarousel.vue
@@ -123,6 +123,7 @@ export default {
   },
   methods: {
     go(direct) {
+      if (!this.glide) return;
       switch (direct) {
         case "prev":
           this.glide.go("<");

--- a/packages/vue/src/components/organisms/SfGroupedProduct/SfGroupedProduct.vue
+++ b/packages/vue/src/components/organisms/SfGroupedProduct/SfGroupedProduct.vue
@@ -56,6 +56,7 @@ export default {
   },
   mounted() {
     this.$nextTick(() => {
+      if (!this.$slots.default) return;
       const glide = new Glide(this.$refs.glide, this.glideSettings);
       glide.mount();
       glide.on("run.before", move => {

--- a/packages/vue/src/components/organisms/SfHero/SfHero.vue
+++ b/packages/vue/src/components/organisms/SfHero/SfHero.vue
@@ -96,6 +96,7 @@ export default {
   mounted() {
     if (this.numberOfPages) {
       this.$nextTick(() => {
+        if (!this.$slots.default) return;
         const glide = new Glide(this.$refs.glide, this.mergedOptions);
         glide.mount();
         this.glide = glide;

--- a/packages/vue/src/components/organisms/SfHero/SfHero.vue
+++ b/packages/vue/src/components/organisms/SfHero/SfHero.vue
@@ -105,6 +105,7 @@ export default {
   },
   methods: {
     go(direct) {
+      if (!this.glide) return;
       switch (direct) {
         case "prev":
           this.glide.go("<");


### PR DESCRIPTION
# Related issue
<!-- paste a link to related issue -->

# Scope of work
<!-- describe what you did -->
glide.js must have child nodes to work
# Screenshots of visual changes

# Checklist

- [x] I followed [composition rules](https://docs.storefrontui.io/contributing/coding-guidelines.html#component-rules) for my component
- [x] I tested the component in most common device sizes (can be tested in Storybook [from viewport addon in top menu](https://github.com/storybooks/storybook/tree/master/addons/viewport))
