### PR TITLE
#581 Create Mobile observer

### DIFF
--- a/packages/vue/src/components/molecules/SfBanner/SfBanner.vue
+++ b/packages/vue/src/components/molecules/SfBanner/SfBanner.vue
@@ -30,6 +30,11 @@
 </template>
 <script>
 import SfButton from "../../atoms/SfButton/SfButton.vue";
+import {
+  mapMobileObserver,
+  unMapMobileObserver
+} from "../../../utilities/mobile-observer";
+
 export default {
   name: "SfBanner",
   components: {
@@ -70,13 +75,8 @@ export default {
       default: ""
     }
   },
-  data() {
-    return {
-      desktopMin: 1024,
-      isMobile: false
-    };
-  },
   computed: {
+    ...mapMobileObserver(),
     style() {
       const image = this.image;
       const background = this.background;
@@ -91,23 +91,8 @@ export default {
       };
     }
   },
-  mounted() {
-    this.isMobile =
-      Math.max(document.documentElement.clientWidth, window.innerWidth) <
-      this.desktopMin;
-    window
-      .matchMedia(`(max-width: ${this.desktopMin}px)`)
-      .addListener(this.isMobileHandler);
-  },
   beforeDestroy() {
-    window
-      .matchMedia(`(max-width: ${this.desktopMin}px)`)
-      .removeListener(this.isMobileHandler);
-  },
-  methods: {
-    isMobileHandler(e) {
-      this.isMobile = e.matches;
-    }
+    unMapMobileObserver();
   }
 };
 </script>

--- a/packages/vue/src/components/molecules/SfSlidingSection/SfSlidingSection.vue
+++ b/packages/vue/src/components/molecules/SfSlidingSection/SfSlidingSection.vue
@@ -23,6 +23,11 @@
 </template>
 <script>
 import SfIcon from "../../atoms/SfIcon/SfIcon.vue";
+import {
+  mapMobileObserver,
+  unMapMobileObserver
+} from "../../../utilities/mobile-observer";
+
 export default {
   name: "SfSlidingSection",
   components: {
@@ -31,12 +36,13 @@ export default {
   data() {
     return {
       isActive: false,
-      isMobile: false,
       hasScrollLock: false,
-      desktopMin: 1024,
       hammer: undefined,
       hasStaticHeight: false
     };
+  },
+  computed: {
+    ...mapMobileObserver()
   },
   watch: {
     isMobile(mobile) {
@@ -81,24 +87,16 @@ export default {
       this.hammer = new Hammer(document, {
         enable: false
       }).on("pan", this.touchHandler);
-      this.isMobileHandler();
-      window.addEventListener("resize", this.isMobileHandler, {
-        passive: true
-      });
     });
   },
   beforeDestroy() {
     this.scrollUnlock();
+    unMapMobileObserver();
     this.hammer.destroy();
   },
   methods: {
     touchPreventDefault(e) {
       e.preventDefault();
-    },
-    isMobileHandler() {
-      this.isMobile =
-        Math.max(document.documentElement.clientWidth, window.innerWidth) <
-        this.desktopMin;
     },
     scrollLock() {
       window.scrollTo(0, 0);

--- a/packages/vue/src/components/organisms/SfContentPages/SfContentPages.vue
+++ b/packages/vue/src/components/organisms/SfContentPages/SfContentPages.vue
@@ -62,6 +62,11 @@ import SfList from "../SfList/SfList.vue";
 import SfMenuItem from "../../molecules/SfMenuItem/SfMenuItem.vue";
 import SfIcon from "../../atoms/SfIcon/SfIcon.vue";
 import SfBar from "../../molecules/SfBar/SfBar.vue";
+import {
+  mapMobileObserver,
+  unMapMobileObserver
+} from "../../../utilities/mobile-observer";
+
 export default {
   name: "SfContentPages",
   components: {
@@ -88,12 +93,11 @@ export default {
   },
   data() {
     return {
-      items: [],
-      isMobile: false,
-      desktopMin: 1024
+      items: []
     };
   },
   computed: {
+    ...mapMobileObserver(),
     categories() {
       const items = [];
       const orphans = { items: [] };
@@ -136,14 +140,8 @@ export default {
       this.$emit("click:change", this.categories[0].items[0].title);
     }
   },
-  mounted() {
-    this.isMobileHandler();
-    window.addEventListener("resize", this.isMobileHandler, { passive: true });
-  },
   beforeDestroy() {
-    window.removeEventListener("resize", this.isMobileHandler, {
-      passive: true
-    });
+    unMapMobileObserver();
   },
   methods: {
     updatePage(title) {
@@ -154,13 +152,6 @@ export default {
        * @type String
        */
       this.$emit("click:change", title);
-    },
-    isMobileHandler() {
-      if (typeof window === "undefined" || typeof document === "undefined")
-        return;
-      this.isMobile =
-        Math.max(document.documentElement.clientWidth, window.innerWidth) <
-        this.desktopMin;
     }
   }
 };

--- a/packages/vue/src/components/organisms/SfFooter/SfFooter.vue
+++ b/packages/vue/src/components/organisms/SfFooter/SfFooter.vue
@@ -6,6 +6,11 @@
 <script>
 import Vue from "vue";
 import SfFooterColumn from "./_internal/SfFooterColumn.vue";
+import {
+  mapMobileObserver,
+  unMapMobileObserver
+} from "../../../utilities/mobile-observer";
+
 Vue.component("SfFooterColumn", SfFooterColumn);
 export default {
   name: "SfFooter",
@@ -22,12 +27,11 @@ export default {
   data() {
     return {
       open: [],
-      items: [],
-      desktopMin: 1024,
-      isMobile: false
+      items: []
     };
   },
   computed: {
+    ...mapMobileObserver(),
     style() {
       return { "--col-width": `${100 / this.column}%` };
     }
@@ -42,18 +46,8 @@ export default {
       immediate: true
     }
   },
-  mounted() {
-    this.isMobile =
-      Math.max(document.documentElement.clientWidth, window.innerWidth) <
-      this.desktopMin;
-    window
-      .matchMedia(`(max-width: ${this.desktopMin}px)`)
-      .addListener(this.isMobileHandler);
-  },
   beforeDestroy() {
-    window
-      .matchMedia(`(max-width: ${this.desktopMin}px)`)
-      .removeListener(this.isMobileHandler);
+    unMapMobileObserver();
   },
   methods: {
     toggle(payload) {
@@ -66,9 +60,6 @@ export default {
         this.open.push(payload);
       }
       this.$emit("change", this.open);
-    },
-    isMobileHandler(e) {
-      this.isMobile = e.matches;
     }
   }
 };

--- a/packages/vue/src/components/organisms/SfMegaMenu/SfMegaMenu.vue
+++ b/packages/vue/src/components/organisms/SfMegaMenu/SfMegaMenu.vue
@@ -46,6 +46,11 @@ Vue.component("SfMegaMenuColumn", SfMegaMenuColumn);
 import SfList from "../SfList/SfList.vue";
 import SfMenuItem from "../../molecules/SfMenuItem/SfMenuItem.vue";
 import SfBar from "../../molecules/SfBar/SfBar.vue";
+import {
+  mapMobileObserver,
+  unMapMobileObserver
+} from "../../../utilities/mobile-observer";
+
 export default {
   name: "SfMegaMenu",
   components: {
@@ -66,12 +71,11 @@ export default {
   data() {
     return {
       active: [],
-      items: [],
-      isMobile: false,
-      desktopMin: 1024
+      items: []
     };
   },
   computed: {
+    ...mapMobileObserver(),
     isActive() {
       return this.active.length > 0;
     }
@@ -106,18 +110,8 @@ export default {
       immediate: true
     }
   },
-  mounted() {
-    this.isMobile =
-      Math.max(document.documentElement.clientWidth, window.innerWidth) <
-      this.desktopMin;
-    window
-      .matchMedia(`(max-width: ${this.desktopMin}px)`)
-      .addListener(this.isMobileHandler);
-  },
   beforeDestroy() {
-    window
-      .matchMedia(`(max-width: ${this.desktopMin}px)`)
-      .removeListener(this.isMobileHandler);
+    unMapMobileObserver();
   },
   methods: {
     updateItems(title) {
@@ -127,9 +121,6 @@ export default {
     change(payload) {
       this.active = payload ? [payload] : [];
       this.$emit("change", payload ? payload : "");
-    },
-    isMobileHandler(e) {
-      this.isMobile = e.matches;
     }
   }
 };

--- a/packages/vue/src/utilities/mobile-observer.js
+++ b/packages/vue/src/utilities/mobile-observer.js
@@ -53,12 +53,12 @@ export const mapMobileObserver = () => {
         return observer.isMobile;
       }
     },
-    clients: {
+    mobileObserverClients: {
       get() {
         return observer.clients;
       }
     },
-    isInitialized: {
+    mobileObserverIsInitialized: {
       get() {
         return observer.isInitialized;
       }

--- a/packages/vue/src/utilities/mobile-observer.js
+++ b/packages/vue/src/utilities/mobile-observer.js
@@ -47,20 +47,20 @@ export const mapMobileObserver = () => {
   return {
     isMobile: {
       get() {
-        if (!observer.isInitialized) {
+        if (observer && !observer.isInitialized) {
           setupListener();
         }
-        return observer.isMobile;
+        return observer ? observer.isMobile : false;
       }
     },
     mobileObserverClients: {
       get() {
-        return observer.clients;
+        return observer ? observer.clients : 0;
       }
     },
     mobileObserverIsInitialized: {
       get() {
-        return observer.isInitialized;
+        return observer ? observer.isInitialized : false;
       }
     }
   };

--- a/packages/vue/src/utilities/mobile-observer.js
+++ b/packages/vue/src/utilities/mobile-observer.js
@@ -67,9 +67,13 @@ export const mapMobileObserver = () => {
 };
 
 export const unMapMobileObserver = () => {
-  observer.clients -= 1;
-  if (observer.clients === 0) {
-    observer = null;
+  if (observer) {
+    observer.clients -= 1;
+    if (observer.clients === 0) {
+      observer = null;
+      tearDownListener();
+    }
+  } else {
     tearDownListener();
   }
 };

--- a/packages/vue/src/utilities/mobile-observer.js
+++ b/packages/vue/src/utilities/mobile-observer.js
@@ -1,0 +1,75 @@
+import Vue from "vue";
+
+let observer;
+const desktopMin = 1024;
+
+export const onMediaMatch = e => {
+  observer.isMobile = e.matches;
+};
+
+export const setupListener = () => {
+  if (
+    typeof window === "undefined" ||
+    typeof document === "undefined" ||
+    !window.matchMedia
+  ) {
+    return;
+  }
+  observer.isMobile =
+    Math.max(document.documentElement.clientWidth, window.innerWidth) <
+    desktopMin;
+  window.matchMedia(`(max-width: ${desktopMin}px)`).addListener(onMediaMatch);
+  observer.isInitialized = true;
+};
+
+export const tearDownListener = () => {
+  if (
+    typeof window !== "undefined" &&
+    typeof document !== "undefined" &&
+    window.matchMedia
+  ) {
+    window
+      .matchMedia(`(max-width: ${desktopMin}px)`)
+      .removeListener(onMediaMatch);
+  }
+};
+
+export const mapMobileObserver = () => {
+  if (!observer) {
+    observer = Vue.observable({
+      isMobile: false,
+      clients: 0,
+      isInitialized: false
+    });
+  }
+  observer.clients += 1;
+
+  return {
+    isMobile: {
+      get() {
+        if (!observer.isInitialized) {
+          setupListener();
+        }
+        return observer.isMobile;
+      }
+    },
+    clients: {
+      get() {
+        return observer.clients;
+      }
+    },
+    isInitialized: {
+      get() {
+        return observer.isInitialized;
+      }
+    }
+  };
+};
+
+export const unMapMobileObserver = () => {
+  observer.clients -= 1;
+  if (observer.clients === 0) {
+    observer = null;
+    tearDownListener();
+  }
+};

--- a/packages/vue/src/utilities/mobile-observer.spec.js
+++ b/packages/vue/src/utilities/mobile-observer.spec.js
@@ -1,4 +1,8 @@
-import { mapMobileObserver, unMapMobileObserver } from "./mobile-observer";
+import {
+  mapMobileObserver,
+  unMapMobileObserver,
+  onMediaMatch
+} from "./mobile-observer";
 
 describe("mobile observr", () => {
   let addListener;
@@ -18,6 +22,7 @@ describe("mobile observr", () => {
 
   describe("matchMedia exists", () => {
     let instance;
+
     beforeEach(() => {
       addListener = jest.fn();
       removeListener = jest.fn();
@@ -26,22 +31,64 @@ describe("mobile observr", () => {
         removeListener
       });
       instance = mapMobileObserver();
-      instance.isMobile.get();
     });
 
     afterEach(() => {
       unMapMobileObserver();
     });
 
-    it("mapMobileObserver initialize", () => {
-      expect(instance.mobileObserverIsInitialized.get()).toBe(true);
+    describe("mapMobileObserver", () => {
+      it("returns isMobile", () => {
+        expect(instance.isMobile).toBeDefined();
+      });
+
+      it("increase the clients count", () => {
+        expect(instance.mobileObserverClients.get()).toBe(1);
+        mapMobileObserver();
+        expect(instance.mobileObserverClients.get()).toBe(2);
+        unMapMobileObserver();
+      });
+
+      describe("calling get on isMobile", () => {
+        beforeEach(() => {
+          window.matchMedia.mockClear();
+          addListener.mockClear();
+          instance.isMobile.get();
+        });
+
+        it("initialize", () => {
+          expect(instance.mobileObserverIsInitialized.get()).toBe(true);
+        });
+
+        it("calls matchMedia and addListeners", () => {
+          expect(window.matchMedia).toHaveBeenCalledWith("(max-width: 1024px)");
+          expect(addListener).toHaveBeenCalledWith(onMediaMatch);
+        });
+
+        it("multiple calls on get do not attach multiple listeners", () => {
+          instance.isMobile.get();
+          expect(window.matchMedia).toHaveBeenCalledTimes(1);
+          expect(addListener).toHaveBeenCalledTimes(1);
+        });
+      });
     });
 
-    it("increase the clients count", () => {
-      expect(instance.mobileObserverClients.get()).toBe(1);
-      mapMobileObserver();
-      expect(instance.mobileObserverClients.get()).toBe(2);
-      unMapMobileObserver();
+    describe("unMapMobileObserver", () => {
+      describe("if observer is defined", () => {
+        it("decrement client by one", () => {
+          // we are adding one more from the one registered in the beforeEAch
+          mapMobileObserver();
+          unMapMobileObserver();
+          expect(instance.mobileObserverClients.get()).toBe(1);
+        });
+
+        it("if clients reach 0", () => {
+          unMapMobileObserver();
+          expect(instance.isMobile.get()).toEqual(false);
+          expect(window.matchMedia).toHaveBeenCalledWith("(max-width: 1024px)");
+          expect(removeListener).toHaveBeenCalledWith(onMediaMatch);
+        });
+      });
     });
   });
 });

--- a/packages/vue/src/utilities/mobile-observer.spec.js
+++ b/packages/vue/src/utilities/mobile-observer.spec.js
@@ -1,0 +1,47 @@
+import { mapMobileObserver, unMapMobileObserver } from "./mobile-observer";
+
+describe("mobile observr", () => {
+  let addListener;
+  let removeListener;
+
+  it("has a map and unmap function", () => {
+    expect(mapMobileObserver).toBeInstanceOf(Function);
+    expect(unMapMobileObserver).toBeInstanceOf(Function);
+  });
+
+  it("if window.matchMedia is not defined it does not initialize", () => {
+    const result = mapMobileObserver();
+    result.isMobile.get();
+    expect(result.isInitialized.get()).toBe(false);
+    unMapMobileObserver();
+  });
+
+  describe("matchMedia exists", () => {
+    let instance;
+    beforeEach(() => {
+      addListener = jest.fn();
+      removeListener = jest.fn();
+      window.matchMedia = jest.fn().mockReturnValue({
+        addListener,
+        removeListener
+      });
+      instance = mapMobileObserver();
+      instance.isMobile.get();
+    });
+
+    afterEach(() => {
+      unMapMobileObserver();
+    });
+
+    it("mapMobileObserver initialize", () => {
+      expect(instance.isInitialized.get()).toBe(true);
+    });
+
+    it("increase the clients count", () => {
+      expect(instance.clients.get()).toBe(1);
+      mapMobileObserver();
+      expect(instance.clients.get()).toBe(2);
+      unMapMobileObserver();
+    });
+  });
+});

--- a/packages/vue/src/utilities/mobile-observer.spec.js
+++ b/packages/vue/src/utilities/mobile-observer.spec.js
@@ -12,7 +12,7 @@ describe("mobile observr", () => {
   it("if window.matchMedia is not defined it does not initialize", () => {
     const result = mapMobileObserver();
     result.isMobile.get();
-    expect(result.isInitialized.get()).toBe(false);
+    expect(result.mobileObserverIsInitialized.get()).toBe(false);
     unMapMobileObserver();
   });
 
@@ -34,13 +34,13 @@ describe("mobile observr", () => {
     });
 
     it("mapMobileObserver initialize", () => {
-      expect(instance.isInitialized.get()).toBe(true);
+      expect(instance.mobileObserverIsInitialized.get()).toBe(true);
     });
 
     it("increase the clients count", () => {
-      expect(instance.clients.get()).toBe(1);
+      expect(instance.mobileObserverClients.get()).toBe(1);
       mapMobileObserver();
-      expect(instance.clients.get()).toBe(2);
+      expect(instance.mobileObserverClients.get()).toBe(2);
       unMapMobileObserver();
     });
   });

--- a/packages/vue/src/utilities/mobile-observer.spec.js
+++ b/packages/vue/src/utilities/mobile-observer.spec.js
@@ -4,7 +4,7 @@ import {
   onMediaMatch
 } from "./mobile-observer";
 
-describe("mobile observr", () => {
+describe("mobile observer", () => {
   let addListener;
   let removeListener;
 


### PR DESCRIPTION
# Related issue
Fixes #581 

# Scope of work
This PR adds a new utility called mobile observer with the following features:

- adds one single event listener on window.matchMedia
- return a computed property isMobile that is reactive
- has a destroy function to clean up if no component is using it anymore

The new utility is bound to all the component that were implementing the isMobile behaviour.

The utility can be used in a similar fashion as the well know vuex helpers `mapComputed or mapState`

```javascript
computed : {
...mapMobileObserver()
}
```
this way the components receive a new computed property called `isMobile`

The utility keeps track of the amount of 'clients' that is serving and if the last one is destroyed it removes the event listeners and perform a basic cleanup.

The utility is compatible with SSR, and it tries to check if the `window` object is available every-time the `isMobile` property is accessed

The PR is [WIP] because I am finishing the tests

# Screenshots of visual changes
No visual changes :)

# Checklist

- [x] I followed [composition rules](https://docs.storefrontui.io/contributing/coding-guidelines.html#component-rules) for my component
- [x] I tested the component in most common device sizes (can be tested in Storybook [from viewport addon in top menu](https://github.com/storybooks/storybook/tree/master/addons/viewport))
