### PR TITLE
refactor: adjust SfFooter to SfHeader and MegaMenu

### DIFF
--- a/packages/shared/styles/components/organisms/SfFooter.scss
+++ b/packages/shared/styles/components/organisms/SfFooter.scss
@@ -1,7 +1,8 @@
 @import "../../variables";
 :root {
+  --footer__container-width: 1240px;
   --footer-desktop-margin: 6.25rem 0;
-  --footer-column__title-padding: var(--spacer-big) var(--spacer-extra-big);
+  --footer-column__title-padding: var(--spacer-big);
   --footer-column__title-background-color: hsl(0%, 0%, 90%);
   --footer-column__title-font-family: var(--body-font-family-secondary);
   --footer-column__title-font-size: var(--font-size-regular);
@@ -30,8 +31,8 @@
   }
 }
 .sf-footer {
-  &__menu-item {
-    padding: var(--spacer-big) var(--spacer-extra-big);
+  & .sf-menu-item {
+    padding: var(--spacer-big);
     font-size: var(--footer__menu-item-font-size);
   }
 }
@@ -46,12 +47,17 @@
     }
   }
   .sf-footer {
-    display: flex;
-    flex-wrap: wrap;
-    justify-content: space-between;
-    margin: var(footer-desktop-margin);
-    &__menu-item {
+    & .sf-menu-item {
       padding: 6px 0;
+    }
+    &__container{
+      box-sizing: border-box;
+      display: flex;
+      flex-wrap: wrap;
+      justify-content: space-between;
+      max-width: var(--footer__container-width);
+      margin: auto;
+      padding: 0 var(--spacer-extra-big);
     }
   }
 }

--- a/packages/vue/src/components/organisms/SfFooter/SfFooter.stories.js
+++ b/packages/vue/src/components/organisms/SfFooter/SfFooter.stories.js
@@ -4,6 +4,7 @@ import { withKnobs, number, boolean } from "@storybook/addon-knobs";
 
 import SfFooter from "./SfFooter.vue";
 
+import SfHeader from "../SfHeader/SfHeader.vue";
 import SfList from "../SfList/SfList.vue";
 import SfImage from "../../atoms/SfImage/SfImage.vue";
 import SfMenuItem from "../../molecules/SfMenuItem/SfMenuItem.vue";
@@ -11,7 +12,7 @@ import SfMenuItem from "../../molecules/SfMenuItem/SfMenuItem.vue";
 storiesOf("Organisms|Footer", module)
   .addDecorator(withKnobs)
   .add("Common", () => ({
-    components: { SfFooter, SfList, SfImage, SfMenuItem },
+    components: { SfFooter, SfHeader, SfList, SfImage, SfMenuItem },
     props: {
       column: {
         default: number("column", 4, {}, "Props")
@@ -50,14 +51,9 @@ storiesOf("Organisms|Footer", module)
     computed: {
       itemSpacer() {
         return this.isMobile
-          ? { padding: "1.25rem 2.5rem" }
+          ? { padding: "1.25rem" }
           : { padding: "6px 0" };
       },
-      spacer() {
-        return this.isMobile
-          ? { maxWidth: "1024px", margin: "auto", padding: "0 1.25rem" }
-          : { maxWidth: "1024px", margin: "auto", padding: "0 2.5rem" };
-      }
     },
     mounted() {
       this.isMobile =
@@ -78,12 +74,11 @@ storiesOf("Organisms|Footer", module)
     template: `<SfFooter
         :column="column"
         :multiple="multiple"
-        :style="{maxWidth: '1024px', margin: 'auto'}"
       >
         <SfFooterColumn v-for="column in columns" :key="column.title" :title="column.title" :style="{marginLeft: column.title && 'auto'}">
           <SfList v-if="column.items">
             <SfListItem v-for="item in column.items" :key="item">
-              <SfMenuItem :label="item" :style="itemSpacer"/>
+              <SfMenuItem :label="item"/>
             </SfListItem>
           </SfList>
           <div v-else :style="{display: 'flex', ...itemSpacer}">

--- a/packages/vue/src/components/organisms/SfFooter/SfFooter.stories.js
+++ b/packages/vue/src/components/organisms/SfFooter/SfFooter.stories.js
@@ -50,10 +50,8 @@ storiesOf("Organisms|Footer", module)
     },
     computed: {
       itemSpacer() {
-        return this.isMobile
-          ? { padding: "1.25rem" }
-          : { padding: "6px 0" };
-      },
+        return this.isMobile ? { padding: "1.25rem" } : { padding: "6px 0" };
+      }
     },
     mounted() {
       this.isMobile =

--- a/packages/vue/src/components/organisms/SfFooter/SfFooter.vue
+++ b/packages/vue/src/components/organisms/SfFooter/SfFooter.vue
@@ -1,6 +1,8 @@
 <template>
   <footer class="sf-footer" :style="style">
-    <slot />
+    <div class="sf-footer__container">
+      <slot />
+    </div>
   </footer>
 </template>
 <script>

--- a/packages/vue/src/components/organisms/SfHeader/SfHeader.vue
+++ b/packages/vue/src/components/organisms/SfHeader/SfHeader.vue
@@ -59,7 +59,7 @@
         <slot name="language-selector" />
       </header>
     </div>
-    <div class="sf-header__sticky-holder" :style="height" />
+    <div v-if="isSticky" class="sf-header__sticky-holder" :style="height" />
   </div>
 </template>
 <script>


### PR DESCRIPTION
# Related issue
<!-- paste a link to related issue -->

# Scope of work
<!-- describe what you did -->
adjust SfFooter to SfHeader styling API
# Screenshots of visual changes
[desktop]
![image](https://user-images.githubusercontent.com/12138170/73849614-85de8300-482a-11ea-93b8-8fc5da62beda.png)

# Checklist

- [x] I followed [composition rules](https://docs.storefrontui.io/contributing/coding-guidelines.html#component-rules) for my component
- [x] I tested the component in most common device sizes (can be tested in Storybook [from viewport addon in top menu](https://github.com/storybooks/storybook/tree/master/addons/viewport))
