### PR TITLE
#750 fix: docs build fails due to outdated links

### DIFF
--- a/packages/vue/docs/.vuepress/components/SfDocsColors.vue
+++ b/packages/vue/docs/.vuepress/components/SfDocsColors.vue
@@ -61,8 +61,8 @@ export default {
 }
 </style>
 <style lang="scss">
-@import "~@storefront-ui/shared/styles/variables/_functions.scss";
-@import "~@storefront-ui/shared/styles/variables/_colors.scss";
+@import "~@storefront-ui/shared/styles/variables/scss/_functions.scss";
+@import "~@storefront-ui/shared/styles/variables/scss/_colors.scss";
 
 @each $pallete, $color in $icon-colors {
     .#{$pallete} {

--- a/packages/vue/docs/.vuepress/components/SfDocsSizes.vue
+++ b/packages/vue/docs/.vuepress/components/SfDocsSizes.vue
@@ -57,7 +57,7 @@ h3 {
 }
 </style>
 <style lang="scss" scoped>
-@import "~@storefront-ui/shared/styles/variables/_typography.scss";
+@import "~@storefront-ui/shared/styles/variables/scss/_typography.scss";
 
 @each $profile, $typo_sizes in $typography-map {
   @each $name, $size in $typo_sizes {

--- a/packages/vue/docs/contributing/creating-new-component.md
+++ b/packages/vue/docs/contributing/creating-new-component.md
@@ -1,6 +1,6 @@
 # How to create/edit Storefront UI component
 
-At this point we assume you're already familiar with [our coding guidelines](coding-guidelines.md) and know how to [work with our Figma designs](working-with-designs.md). The below section will guide you through how to create your first component for the library!
+At this point we assume you're already familiar with [our coding guidelines](coding-guidelines.md) and know how to [work with our Figma designs](../design/working-with-designs.md). The below section will guide you through how to create your first component for the library!
 
 ## Generate the component's template
 

--- a/packages/vue/src/components/organisms/SfProductCard/SfProductCard.stories.js
+++ b/packages/vue/src/components/organisms/SfProductCard/SfProductCard.stories.js
@@ -11,7 +11,7 @@ import {
 
 import SfProductCard from "./SfProductCard.vue";
 
-import { colorsValues } from "@storefront-ui/shared/variables/colors";
+import { colorsValues as colors } from "@storefront-ui/shared/variables/colors";
 
 storiesOf("Organisms|ProductCard", module)
   .addDecorator(withKnobs)
@@ -38,7 +38,7 @@ storiesOf("Organisms|ProductCard", module)
         default: text("badgeLabel", "-50%", "Props")
       },
       badgeColor: {
-        default: select("color", colorsValues, "pink-primary", "Props")
+        default: select("color", colors, "pink-primary", "Props")
       },
       title: {
         default: text("title", "Cotton Sweater", "Props")
@@ -124,7 +124,7 @@ storiesOf("Organisms|ProductCard", module)
         default: text("badgeLabel", "-50%", "Props")
       },
       badgeColor: {
-        default: select("color", colorsValues, "pink-primary", "Props")
+        default: select("color", colors, "pink-primary", "Props")
       },
       title: {
         default: text("title", "Cotton Sweater", "Props")
@@ -234,7 +234,7 @@ storiesOf("Organisms|ProductCard", module)
         default: text("badgeLabel", "-50%", "Props")
       },
       badgeColor: {
-        default: select("color", colorsValues, "pink-primary", "Props")
+        default: select("color", colors, "pink-primary", "Props")
       },
       title: {
         default: text("title", "Cotton Sweater", "Props")
@@ -334,7 +334,7 @@ storiesOf("Organisms|ProductCard", module)
         default: text("badgeLabel", "-50%", "Props")
       },
       badgeColor: {
-        default: select("color", colorsValues, "pink-primary", "Props")
+        default: select("color", colors, "pink-primary", "Props")
       },
       title: {
         default: text("title", "Cotton Sweater", "Props")
@@ -434,7 +434,7 @@ storiesOf("Organisms|ProductCard", module)
         default: text("badgeLabel", "-50%", "Props")
       },
       badgeColor: {
-        default: select("color", colorsValues, "pink-primary", "Props")
+        default: select("color", colors, "pink-primary", "Props")
       },
       title: {
         default: text("title", "Cotton Sweater", "Props")
@@ -534,7 +534,7 @@ storiesOf("Organisms|ProductCard", module)
         default: text("badgeLabel", "-50%", "Props")
       },
       badgeColor: {
-        default: select("color", colorsValues, "pink-primary", "Props")
+        default: select("color", colors, "pink-primary", "Props")
       },
       title: {
         default: text("title", "Cotton Sweater", "Props")
@@ -634,7 +634,7 @@ storiesOf("Organisms|ProductCard", module)
         default: text("badgeLabel", "-50%", "Props")
       },
       badgeColor: {
-        default: select("color", colorsValues, "pink-primary", "Props")
+        default: select("color", colors, "pink-primary", "Props")
       },
       title: {
         default: text("title", "Cotton Sweater", "Props")
@@ -734,7 +734,7 @@ storiesOf("Organisms|ProductCard", module)
         default: text("badgeLabel", "-50%", "Props")
       },
       badgeColor: {
-        default: select("color", colorsValues, "pink-primary", "Props")
+        default: select("color", colors, "pink-primary", "Props")
       },
       title: {
         default: text("title", "Cotton Sweater", "Props")


### PR DESCRIPTION
# Related issue
Closes #750 Docs build on develop fails

# Scope of work
* Update some SCSS imports in Vue files for docs
* Update a link in a MD file to a MD file which was moved
* Use `colors` as a named import for `colorsValues`. This is already declared in other files and hence expected in the auto-generation script.