### PR TITLE
Add font-display: swap rule to google fonts

### DIFF
--- a/packages/shared/styles/_global.scss
+++ b/packages/shared/styles/_global.scss
@@ -1,6 +1,6 @@
 @import 'global/body';
 @import 'global/headings';
-@import url('https://fonts.googleapis.com/css?family=Raleway:300,400,400i,500,600,700|Roboto:300,300i,400,400i,500,700');
+@import url('https://fonts.googleapis.com/css?family=Raleway:300,400,400i,500,600,700|Roboto:300,300i,400,400i,500,700&font-display=swap');
 @import '~@glidejs/glide/dist/css/glide.core';
 @import 'variables/css/colors.scss';
 @import 'variables/css/layout.scss';


### PR DESCRIPTION
# Related issue

No related issues

# Scope of work

I've added `font-display: swap` CSS rule to `@font-face` declaration in google fonts. This rule prevent browsers to block displaying font until custom fonts (from Google Fonts in this case) are loaded. This should improve page speed loading time.

# Checklist

- [x] No commented blocks of code left
- [x] Run tests and docs
- [x] Self code-reviewed

If applicable:

- [x] I followed [composition rules](https://docs.storefrontui.io/contributing/coding-guidelines.html#component-rules) for my component
- [x] I tested the component in most common device sizes (can be tested in Storybook [from viewport addon in top menu](https://github.com/storybooks/storybook/tree/master/addons/viewport))

  
