### PR TITLE
fix: overlay transition opacity conflicting

### DIFF
--- a/packages/shared/styles/components/atoms/SfOverlay.scss
+++ b/packages/shared/styles/components/atoms/SfOverlay.scss
@@ -1,12 +1,10 @@
 @import '../../variables';
 :root {
-  --overlay__background-color: var(--c-black);
-  --overlay__opacity: .8;
+  --overlay__background-color: rgba(29, 31, 34, .8);
   --overlay-z-index: 1;
 }
 .sf-overlay {
   background: var(--overlay__background-color);
-  opacity: var(--overlay__opacity);
   position: fixed;
   top: 0;
   right: 0;


### PR DESCRIPTION
# Related issue
Closes #772

# Scope of work
There was an issue between the opacity bound for the aspect of the SfOverlay and the fade transition's opacity. To get rid of this conflict, as the opacity of the SfOverlay was only for esthetical purposes, I removed it's opacity and used a rgba like it's done for the SfImage [example](https://github.com/DivanteLtd/storefront-ui/blob/develop/packages/shared/styles/components/atoms/SfImage.scss#L3).

You might ask the question but I couldn't use the `rgba` function from sass in which you just have to pass a color and an opacity like this example.
```
rgba($color, $opacity)
```
Why couldn't I ? Because css variables are dynamic and so they can't be compiled at build time by sass. Doing this was resulting as if there was no color on the background.

Also I've considered using a `!important` in the opacity of the fade transition as it could look logic. But I didn't wanted my first contribution to the codebase to be a !important and rgba felt more fancy !

# Checklist

- [x] No commented blocks of code left
- [x] Run tests and docs
- [x] Self code-reviewed
  
