### PR TITLE
fix: SfProductCard - addToCart button position

### DIFF
--- a/packages/shared/styles/components/organisms/SfProductCard.scss
+++ b/packages/shared/styles/components/organisms/SfProductCard.scss
@@ -64,8 +64,9 @@
     --button-padding: var(--spacer-medium);
     --circle-icon-position: absolute;
     right: var(--product-card-add-button-right, 1rem);
+    bottom: var(--product-card-add-button-bottom, 0);
     display: var(--product-card-add-button-display, none);
-    transform: var(--product-card-add-button-transform, translateY(-50%));
+    transform: var(--product-card-add-button-transform, translateY(50%));
     opacity: var(--product-card-add-button-opacity, 0);
     cursor: pointer;
     &--icons-enter-active {


### PR DESCRIPTION
# Related issue

# Scope of work
Fix position of addToCart button

# Checklist

- [x] No commented blocks of code left
- [x] Run tests and docs
- [x] Self code-reviewed

If applicable:

- [x] I followed [composition rules](https://docs.storefrontui.io/contributing/coding-guidelines.html#component-rules) for my component
- [x] I tested the component in most common device sizes (can be tested in Storybook [from viewport addon in top menu](https://github.com/storybooks/storybook/tree/master/addons/viewport))

  
