### PR TITLE
fix: SfInput - show-password button stops triggering submit

### DIFF
--- a/packages/vue/src/components/atoms/SfInput/SfInput.vue
+++ b/packages/vue/src/components/atoms/SfInput/SfInput.vue
@@ -33,9 +33,10 @@
         name="show-password"
       >
         <SfButton
+          class="sf-input__password-button"
+          type="button"
           aria-label="switch-visibility-password"
           :aria-pressed="isPasswordVisible.toString()"
-          class="sf-input__password-button"
           @click="switchVisibilityPassword"
         >
           <SfIcon


### PR DESCRIPTION
# Related issue
Closes #782 

# Scope of work
Add `type="button"` to SfButton with show-password-icon

# Checklist

- [x] No commented blocks of code left
- [x] Run tests and docs
- [x] Self code-reviewed

If applicable:

- [ ] I followed [composition rules](https://docs.storefrontui.io/contributing/coding-guidelines.html#component-rules) for my component
- [ ] I tested the component in most common device sizes (can be tested in Storybook [from viewport addon in top menu](https://github.com/storybooks/storybook/tree/master/addons/viewport))

  
