### PR TITLE
fix: SfButton fix --outline modifiers background

### DIFF
--- a/packages/shared/styles/components/atoms/SfButton.scss
+++ b/packages/shared/styles/components/atoms/SfButton.scss
@@ -61,6 +61,7 @@
       $primary: map-get($map, "primary");
       &.color-#{$color} {
         --button-border: 1px solid #{$primary};
+        --button-background: transparent;
         --button-color: #{$primary};
         &:hover {
           --button-background: #{$primary};


### PR DESCRIPTION
# Related issue
Closes #777 

# Scope of work
Add transparent bcg variable to outline modifiers

# Checklist

- [x] No commented blocks of code left
- [x] Run tests and docs
- [x] Self code-reviewed

If applicable:

- [ ] I followed [composition rules](https://docs.storefrontui.io/contributing/coding-guidelines.html#component-rules) for my component
- [ ] I tested the component in most common device sizes (can be tested in Storybook [from viewport addon in top menu](https://github.com/storybooks/storybook/tree/master/addons/viewport))

  
