### PR TITLE
fix: SfButton variants - background color on hover

### DIFF
--- a/packages/shared/styles/components/atoms/SfButton.scss
+++ b/packages/shared/styles/components/atoms/SfButton.scss
@@ -33,7 +33,7 @@
     &.color-#{$color} {
       --button-background: #{$primary};
       &:hover {
-        --button-background: #{$variant};
+        --button-background: var(--c-#{$color}-lighten);
       }
     }
   }


### PR DESCRIPTION
# Related issue
Closes #700 

# Scope of work
Change background color on hover for variant colors

# Checklist

- [x] No commented blocks of code left
- [x] Run tests and docs
- [x] Self code-reviewed

If applicable:

- [ ] I followed [composition rules](https://docs.storefrontui.io/contributing/coding-guidelines.html#component-rules) for my component
- [ ] I tested the component in most common device sizes (can be tested in Storybook [from viewport addon in top menu](https://github.com/storybooks/storybook/tree/master/addons/viewport))

  
