### PR TITLE
fix: add missing hasCarousel prop to stories

### DIFF
--- a/packages/vue/src/components/organisms/SfGroupedProduct/SfGroupedProduct.stories.js
+++ b/packages/vue/src/components/organisms/SfGroupedProduct/SfGroupedProduct.stories.js
@@ -194,6 +194,9 @@ storiesOf("Organisms|GroupedProduct", module)
       settings: {
         default: object("settings", { type: "slider" }, "Props")
       },
+      hasCarousel: {
+        default: boolean("hasCarousel", true, "Props")
+      },
       image: {
         default: object(
           "image",
@@ -259,6 +262,9 @@ storiesOf("Organisms|GroupedProduct", module)
     props: {
       settings: {
         default: object("settings", { type: "slider" }, "Props")
+      },
+      hasCarousel: {
+        default: boolean("hasCarousel", true, "Props")
       },
       image: {
         default: object(
@@ -326,6 +332,9 @@ storiesOf("Organisms|GroupedProduct", module)
       settings: {
         default: object("settings", { type: "slider" }, "Props")
       },
+      hasCarousel: {
+        default: boolean("hasCarousel", true, "Props")
+      },
       image: {
         default: object(
           "image",
@@ -391,6 +400,9 @@ storiesOf("Organisms|GroupedProduct", module)
     props: {
       settings: {
         default: object("settings", { type: "slider" }, "Props")
+      },
+      hasCarousel: {
+        default: boolean("hasCarousel", true, "Props")
       },
       image: {
         default: object(
@@ -458,6 +470,9 @@ storiesOf("Organisms|GroupedProduct", module)
       settings: {
         default: object("settings", { type: "slider" }, "Props")
       },
+      hasCarousel: {
+        default: boolean("hasCarousel", true, "Props")
+      },
       image: {
         default: object(
           "image",
@@ -523,6 +538,9 @@ storiesOf("Organisms|GroupedProduct", module)
     props: {
       settings: {
         default: object("settings", { type: "slider" }, "Props")
+      },
+      hasCarousel: {
+        default: boolean("hasCarousel", true, "Props")
       },
       image: {
         default: object(


### PR DESCRIPTION
# Related issue
Closes #797 

# Scope of work
Add missing hasCarousel prop to stories

# Checklist

- [x] No commented blocks of code left
- [x] Run tests and docs
- [x] Self code-reviewed

If applicable:

- [ ] I followed [composition rules](https://docs.storefrontui.io/contributing/coding-guidelines.html#component-rules) for my component
- [ ] I tested the component in most common device sizes (can be tested in Storybook [from viewport addon in top menu](https://github.com/storybooks/storybook/tree/master/addons/viewport))

  
