### PR TITLE
[DOCS] Add missing slot description in components #799

### DIFF
--- a/packages/vue/src/components/atoms/SfCircleIcon/SfCircleIcon.vue
+++ b/packages/vue/src/components/atoms/SfCircleIcon/SfCircleIcon.vue
@@ -12,6 +12,7 @@
       />
     </slot>
     <transition name="sf-circle-icon__badge">
+      <!-- @slot If hasBadge is true, adds small bagde on icon -->
       <slot v-if="hasBadge" name="badge" v-bind="{ badgeLabel, hasBadge }">
         <div class="sf-circle-icon__badge">
           {{ badgeLabel }}

--- a/packages/vue/src/components/atoms/SfIcon/SfIcon.vue
+++ b/packages/vue/src/components/atoms/SfIcon/SfIcon.vue
@@ -5,6 +5,7 @@
     :style="iconCustomStyle"
     v-on="$listeners"
   >
+    <!-- @slot Use this slot to replace icon -->
     <slot v-bind="{ viewBox, iconPaths, icon }">
       <svg
         class="sf-icon-path"

--- a/packages/vue/src/components/atoms/SfImage/SfImage.vue
+++ b/packages/vue/src/components/atoms/SfImage/SfImage.vue
@@ -39,6 +39,7 @@
     </template>
     <transition name="fade">
       <div v-if="showOverlay" class="sf-image__overlay">
+        <!-- @slot If showOverlay is true, adds overlay on image -->
         <slot />
       </div>
     </transition>

--- a/packages/vue/src/components/atoms/SfInput/SfInput.vue
+++ b/packages/vue/src/components/atoms/SfInput/SfInput.vue
@@ -24,6 +24,7 @@
         <!-- @slot Custom input label -->
         <slot name="label" v-bind="{ label }">{{ label }}</slot>
       </label>
+      <!-- @slot if isPassword is true, show characters as dots in input -->
       <slot
         v-if="isPassword"
         v-bind="{

--- a/packages/vue/src/components/atoms/SfPrice/SfPrice.vue
+++ b/packages/vue/src/components/atoms/SfPrice/SfPrice.vue
@@ -1,5 +1,6 @@
 <template>
   <div class="sf-price">
+    <!-- @slot Custom special price -->
     <slot name="special" v-bind="{ special }">
       <ins v-if="special" class="sf-price__value sf-price__value--special">{{
         special

--- a/packages/vue/src/components/molecules/SfAddToCart/SfAddToCart.vue
+++ b/packages/vue/src/components/molecules/SfAddToCart/SfAddToCart.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="sf-add-to-cart" data-test="sf-add-to-card">
+    <!--@slot Custom content that will replace default Add to cart button design.-->
     <slot name="add-to-cart-btn">
-      <!--@slot Custom content that will replace default Add to cart button design.-->
       <SfButton
         class="sf-add-to-cart__button"
         :disabled="disabled"
@@ -10,6 +10,7 @@
         Add to cart
       </SfButton>
     </slot>
+    <!-- @slot Custom content that will replace default quantity selector design -->
     <slot name="quantity-select-input" v-bind="{ qty }">
       <SfQuantitySelector
         :qty="qty"

--- a/packages/vue/src/components/molecules/SfBanner/SfBanner.vue
+++ b/packages/vue/src/components/molecules/SfBanner/SfBanner.vue
@@ -1,21 +1,25 @@
 <template>
   <section class="sf-banner" :style="style" v-on="isMobile ? $listeners : {}">
     <div class="sf-banner__container">
+      <!-- @slot Custom content that will replace subtitle -->
       <slot name="subtitle" v-bind="{ subtitle }">
         <h2 v-if="subtitle" class="sf-banner__subtitle">
           {{ subtitle }}
         </h2>
       </slot>
+      <!-- @slot Custom content that will replace title -->
       <slot name="title" v-bind="{ title }">
         <h1 v-if="title" class="sf-banner__title">
           {{ title }}
         </h1>
       </slot>
+      <!-- @slot Custom content that will replace description -->
       <slot name="description" v-bind="{ description }">
         <p v-if="description" class="sf-banner__description">
           {{ description }}
         </p>
       </slot>
+      <!-- @slot Custom call to action -->
       <slot name="call-to-action" v-bind="{ buttonText }">
         <SfButton
           v-if="buttonText"

--- a/packages/vue/src/components/molecules/SfBar/SfBar.vue
+++ b/packages/vue/src/components/molecules/SfBar/SfBar.vue
@@ -1,5 +1,6 @@
 <template>
   <div class="sf-bar">
+    <!-- @slot Custom content that will replace chevron-left -->
     <slot name="back">
       <div class="sf-bar__icon">
         <SfIcon
@@ -12,9 +13,11 @@
         />
       </div>
     </slot>
+    <!--  @slot Custom content that will replace title -->
     <slot name="title" v-bind="{ title }">
       <div class="sf-bar__title">{{ title }}</div>
     </slot>
+    <!-- @slot Custom content that will replace icon -->
     <slot name="close">
       <div class="sf-bar__icon">
         <SfIcon

--- a/packages/vue/src/components/molecules/SfFilter/SfFilter.vue
+++ b/packages/vue/src/components/molecules/SfFilter/SfFilter.vue
@@ -7,9 +7,11 @@
     v-on="$listeners"
   >
     <template #label>
+      <!-- @slot Custom content for label -->
       <slot name="label" v-bind="{ label }">
         <div class="sf-filter__label">{{ label }}</div>
       </slot>
+      <!-- @slot Custom content for count -->
       <slot name="count" v-bind="{ count }">
         <div class="sf-filter__count">{{ count }}</div>
       </slot>

--- a/packages/vue/src/components/molecules/SfGallery/SfGallery.vue
+++ b/packages/vue/src/components/molecules/SfGallery/SfGallery.vue
@@ -44,6 +44,7 @@
       </transition>
     </div>
     <div class="sf-gallery__thumbs">
+      <!-- @slot Custom content on active image -->
       <slot name="thumbs" v-bind="{ images, active: activeIndex, go }">
         <div
           v-for="(image, index) in images"

--- a/packages/vue/src/components/molecules/SfMenuItem/SfMenuItem.vue
+++ b/packages/vue/src/components/molecules/SfMenuItem/SfMenuItem.vue
@@ -1,16 +1,16 @@
 <template>
   <div class="sf-menu-item" v-on="$listeners">
-    <!-- @slot -->
+    <!-- @slot Custom content for icon -->
     <slot name="icon" />
-    <!-- @slot -->
+    <!-- @slot Custom content for label -->
     <slot name="label" v-bind="{ label }">
       <span class="sf-menu-item__label">{{ label }}</span>
     </slot>
-    <!-- @slot -->
+    <!-- @slot Custom content for count -->
     <slot name="count" v-bind="{ count }">
       <span class="sf-menu-item__count">{{ count }}</span>
     </slot>
-    <!-- @slot -->
+    <!-- @slot Custom content for navigation icon on mobile -->
     <slot name="mobile-nav-icon" v-bind="{ icon }">
       <SfIcon
         v-if="icon"

--- a/packages/vue/src/components/molecules/SfPagination/SfPagination.vue
+++ b/packages/vue/src/components/molecules/SfPagination/SfPagination.vue
@@ -16,20 +16,24 @@
       </li>
       <template v-if="showFirst">
         <li class="sf-pagination__item">
+          <!-- @slot Custom markup for numbers -->
           <slot name="number" v-bind="{ go, number: 1 }">
             <button class="sf-pagination__button" @click="go(1)">1</button>
           </slot>
         </li>
         <li class="sf-pagination__item">
+          <!-- @slot Custom markup for points -->
           <slot name="points">...</slot>
         </li>
       </template>
+      <!-- @slot Custom markup for numbers -->
       <slot v-bind="{ go }">
         <li
           v-for="number in limitedPageNumbers"
           :key="number"
           class="sf-pagination__item"
         >
+          <!-- @slot Custom markup for number -->
           <slot name="number" v-bind="{ go, number }">
             <button
               class="sf-pagination__button"
@@ -43,9 +47,11 @@
       </slot>
       <template v-if="showLast">
         <li class="sf-pagination__item">
+          <!-- @slot Custom markup for points -->
           <slot name="points">...</slot>
         </li>
         <li class="sf-pagination__item">
+          <!-- @slot Custom markup for number -->
           <slot name="number" v-bind="{ go, number: total }">
             <button class="sf-pagination__button" @click="go(total)">
               {{ total }}

--- a/packages/vue/src/components/molecules/SfProductOption/SfProductOption.vue
+++ b/packages/vue/src/components/molecules/SfProductOption/SfProductOption.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="sf-product-option">
-    <!-- @slot -->
+    <!-- @slot Use this slot to replace product color option-->
     <slot name="color" v-bind="{ color }">
       <div
         v-if="color"
@@ -8,7 +8,7 @@
         :style="{ background: color }"
       ></div>
     </slot>
-    <!-- @slot -->
+    <!-- @slot Custom content for label -->
     <slot name="label" v-bind="{ label }">
       <div class="sf-product-option__label">{{ label }}</div>
     </slot>

--- a/packages/vue/src/components/molecules/SfScrollable/SfScrollable.vue
+++ b/packages/vue/src/components/molecules/SfScrollable/SfScrollable.vue
@@ -1,6 +1,7 @@
 <template>
   <div class="sf-scrollable" :class="{ 'sf-scrollable--is-open': !isHidden }">
     <Simplebar ref="content" class="sf-scrollable__content" :style="style">
+      <!-- @slot Use this slot to place scrollable content -->
       <slot />
     </Simplebar>
     <SfButton

--- a/packages/vue/src/components/molecules/SfSearchBar/SfSearchBar.vue
+++ b/packages/vue/src/components/molecules/SfSearchBar/SfSearchBar.vue
@@ -11,7 +11,7 @@
       @keyup.esc="$emit('input', '')"
       @blur="$emit('blur')"
     />
-    <!-- @slot -->
+    <!-- @slot Custom content will replace search icon-->
     <slot name="icon">
       <span class="sf-search-bar__icon">
         <SfIcon
@@ -21,7 +21,7 @@
         />
       </span>
     </slot>
-    <!-- @slot -->
+    <!-- @slot Custom content will replace clear icon -->
     <slot name="clear-icon">
       <div class="sf-search-bar__clear-icon" @click="clearSearchBar">
         <SfIcon icon="cross" size="xxs" view-box="0 0 20 20" />

--- a/packages/vue/src/components/molecules/SfSection/SfSection.vue
+++ b/packages/vue/src/components/molecules/SfSection/SfSection.vue
@@ -12,7 +12,6 @@
         :class="{ 'sf-heading--no-underline': hasUnderlinedModifier }"
       />
     </slot>
-    <!--@slot Section content.-->
     <div class="sf-section__content">
       <!--@slot Section content.-->
       <slot />

--- a/packages/vue/src/components/molecules/SfSelect/SfSelect.vue
+++ b/packages/vue/src/components/molecules/SfSelect/SfSelect.vue
@@ -21,6 +21,7 @@
     <div style="position: relative">
       <!-- eslint-disable-next-line vue/no-v-html -->
       <div class="sf-select__selected sf-select-option" v-html="html"></div>
+      <!-- @slot Slot for custom label -->
       <slot name="label">
         <div v-if="label" class="sf-select__label">
           {{ label }}
@@ -31,6 +32,7 @@
         <div v-show="open" class="sf-select__dropdown">
           <!--  sf-select__option -->
           <ul :style="{ maxHeight }" class="sf-select__options">
+            <!-- @slot Use this select to place custom select options -->
             <slot />
           </ul>
           <SfButton

--- a/packages/vue/src/components/molecules/SfSelect/_internal/SfSelectOption.vue
+++ b/packages/vue/src/components/molecules/SfSelect/_internal/SfSelectOption.vue
@@ -6,7 +6,7 @@
     :aria-selected="selected === value ? 'true' : 'false'"
     @click="clicked"
   >
-    <!-- @slot -->
+    <!-- @slot Custom content for options to select-->
     <slot />
   </li>
 </template>

--- a/packages/vue/src/components/molecules/SfSteps/SfSteps.vue
+++ b/packages/vue/src/components/molecules/SfSteps/SfSteps.vue
@@ -27,6 +27,7 @@
       ></div>
     </div>
     <div class="sf-steps__content">
+      <!-- @slot Slot for custom content in steps -->
       <slot></slot>
     </div>
   </div>

--- a/packages/vue/src/components/molecules/SfSteps/_internal/SfStep.vue
+++ b/packages/vue/src/components/molecules/SfSteps/_internal/SfStep.vue
@@ -1,5 +1,6 @@
 <template>
   <div class="sf-step">
+    <!-- @slot Use this slot to place custom content in active step -->
     <slot v-if="active" :index="index"></slot>
   </div>
 </template>

--- a/packages/vue/src/components/molecules/SfSticky/SfSticky.vue
+++ b/packages/vue/src/components/molecules/SfSticky/SfSticky.vue
@@ -6,7 +6,7 @@
       'sf-sticky--bound': isBound
     }"
   >
-    <!-- @slot -->
+    <!-- @slot Use this slot to place sticky custom content -->
     <slot />
   </div>
 </template>

--- a/packages/vue/src/components/organisms/SfAccordion/_internal/SfAccordionItem.vue
+++ b/packages/vue/src/components/organisms/SfAccordion/_internal/SfAccordionItem.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="sf-accordion-item">
-    <!-- @slot -->
+    <!-- @slot Slot for custom header -->
     <slot
       name="header"
       v-bind="{
@@ -23,7 +23,7 @@
     </slot>
     <transition :name="$parent.transition">
       <div v-if="isOpen" class="sf-accordion-item__content">
-        <!-- @slot -->
+        <!-- @slot Slot for custom items -->
         <slot />
       </div>
     </transition>

--- a/packages/vue/src/components/organisms/SfBannerGrid/SfBannerGrid.vue
+++ b/packages/vue/src/components/organisms/SfBannerGrid/SfBannerGrid.vue
@@ -3,19 +3,23 @@
     <template v-if="bannerGrid === 1">
       <div class="sf-banner-grid__row">
         <div class="sf-banner-grid__col">
+          <!-- @slot Use this slot to place custom content in banner A -->
           <slot name="banner-A" />
         </div>
         <div class="sf-banner-grid__col sf-banner-grid__col--medium">
+          <!-- @slot Use this slot to place custom content in banner B -->
           <slot name="banner-B" />
         </div>
         <div class="sf-banner-grid__col">
           <div class="sf-banner-grid__row">
             <div class="sf-banner-grid__col">
+              <!-- @slot Use this slot to place custom content in banner C -->
               <slot name="banner-C" />
             </div>
           </div>
           <div class="sf-banner-grid__row">
             <div class="sf-banner-grid__col">
+              <!-- @slot Use this slot to place custom content in banner D -->
               <slot name="banner-D" />
             </div>
           </div>
@@ -25,19 +29,23 @@
     <template v-if="bannerGrid === 2">
       <div class="sf-banner-grid__row">
         <div class="sf-banner-grid__col sf-banner-grid__col--small">
+          <!-- @slot Use this slot to place custom content in banner A -->
           <slot name="banner-A" />
         </div>
         <div class="sf-banner-grid__col">
           <div class="sf-banner-grid__row">
             <div class="sf-banner-grid__col">
+              <!-- @slot Use this slot to place custom content in banner B -->
               <slot name="banner-B" />
             </div>
             <div class="sf-banner-grid__col">
+              <!-- @slot Use this slot to place custom content in banner C -->
               <slot name="banner-C" />
             </div>
           </div>
           <div class="sf-banner-grid__row">
             <div class="sf-banner-grid__col">
+              <!-- @slot Use this slot to place custom content in banner D -->
               <slot name="banner-D" />
             </div>
           </div>

--- a/packages/vue/src/components/organisms/SfBottomNavigation/SfBottomNavigation.vue
+++ b/packages/vue/src/components/organisms/SfBottomNavigation/SfBottomNavigation.vue
@@ -1,5 +1,6 @@
 <template>
   <div class="sf-bottom-navigation">
+    <!-- @slot Use this slot to add custom content in bottom navigation -->
     <slot />
   </div>
 </template>

--- a/packages/vue/src/components/organisms/SfBottomNavigation/_internal/SfBottomNavigationItem.vue
+++ b/packages/vue/src/components/organisms/SfBottomNavigation/_internal/SfBottomNavigationItem.vue
@@ -3,6 +3,7 @@
     class="sf-bottom-navigation-item"
     :class="{ 'sf-bottom-navigation-item--floating': isFloating }"
   >
+    <!-- @slot Slot for icons -->
     <slot name="icon" v-bind="{ icon, iconSize, isFloating }">
       <SfCircleIcon
         v-if="isFloating"
@@ -18,6 +19,7 @@
         class="sf-bottom-navigation-item__icon"
       />
     </slot>
+    <!-- @slot Slot for labels -->
     <slot name="label" v-bind="{ label }">
       <div
         v-if="label"

--- a/packages/vue/src/components/organisms/SfCarousel/_internal/SfCarouselItem.vue
+++ b/packages/vue/src/components/organisms/SfCarousel/_internal/SfCarouselItem.vue
@@ -1,5 +1,6 @@
 <template>
   <li class="sf-carousel-item glide__slide">
+    <!-- @slot Slot for carousel item -->
     <slot />
   </li>
 </template>

--- a/packages/vue/src/components/organisms/SfCollectedProduct/SfCollectedProduct.vue
+++ b/packages/vue/src/components/organisms/SfCollectedProduct/SfCollectedProduct.vue
@@ -1,5 +1,6 @@
 <template>
   <div class="sf-collected-product">
+    <!-- @slot Use this slot to place remove icon -->
     <slot name="remove" v-bind="{ removeHandler }">
       <SfCircleIcon
         icon="cross"
@@ -8,6 +9,7 @@
       />
     </slot>
     <div class="sf-collected-product__aside">
+      <!-- @slot Use this slot to place custom image -->
       <slot name="image" v-bind="{ image, title }">
         <SfImage
           :src="image"
@@ -17,6 +19,7 @@
           class="sf-collected-product__image"
         />
       </slot>
+      <!-- @slot Use this slot to place custom input -->
       <slot name="input">
         <SfQuantitySelector
           :qty="qty"
@@ -26,9 +29,11 @@
       </slot>
     </div>
     <div class="sf-collected-product__main">
+      <!-- @slot Use this slot to replace title -->
       <slot name="title" v-bind="{ title }">
         <div class="sf-collected-product__title">{{ title }}</div>
       </slot>
+      <!-- @slot Use this slot to replace price -->
       <slot name="price" v-bind="{ specialPrice, regularPrice }">
         <SfPrice
           v-if="regularPrice"
@@ -37,7 +42,9 @@
         />
       </slot>
       <div class="sf-collected-product__details">
+        <!-- @slot Use this slot to replace configuration -->
         <slot name="configuration"> </slot>
+        <!-- @slot Use this slot to replace actions -->
         <slot name="actions"> </slot>
       </div>
     </div>

--- a/packages/vue/src/components/organisms/SfContentPages/_internal/SfContentCategory.vue
+++ b/packages/vue/src/components/organisms/SfContentPages/_internal/SfContentCategory.vue
@@ -1,5 +1,6 @@
 <template>
   <div class="sf-content-category">
+    <!-- @slot Use this slot for content category -->
     <slot />
   </div>
 </template>

--- a/packages/vue/src/components/organisms/SfFooter/SfFooter.vue
+++ b/packages/vue/src/components/organisms/SfFooter/SfFooter.vue
@@ -1,6 +1,7 @@
 <template>
   <footer class="sf-footer" :style="style">
     <div class="sf-footer__container">
+      <!-- @slot Use this slot to place footer content -->
       <slot />
     </div>
   </footer>

--- a/packages/vue/src/components/organisms/SfFooter/_internal/SfFooterColumn.vue
+++ b/packages/vue/src/components/organisms/SfFooter/_internal/SfFooterColumn.vue
@@ -8,6 +8,7 @@
     </div>
     <transition name="fade">
       <div v-if="open" class="sf-footer-column__content">
+        <!-- @slot Slot for footer content in columns -->
         <slot />
       </div>
     </transition>

--- a/packages/vue/src/components/organisms/SfHeader/_internal/SfHeaderNavigationItem.vue
+++ b/packages/vue/src/components/organisms/SfHeader/_internal/SfHeaderNavigationItem.vue
@@ -1,5 +1,6 @@
 <template>
   <div :style="maxWidth" class="sf-header-navigation-item" v-on="$listeners">
+    <!-- @slot Slot for custom navigation -->
     <slot />
   </div>
 </template>

--- a/packages/vue/src/components/organisms/SfList/SfList.vue
+++ b/packages/vue/src/components/organisms/SfList/SfList.vue
@@ -1,6 +1,6 @@
 <template>
   <ul class="sf-list">
-    <!-- @slot -->
+    <!-- @slot Custom content for list item-->
     <slot />
   </ul>
 </template>

--- a/packages/vue/src/components/organisms/SfList/_internal/SfListItem.vue
+++ b/packages/vue/src/components/organisms/SfList/_internal/SfListItem.vue
@@ -1,6 +1,6 @@
 <template>
   <li class="sf-list__item">
-    <!-- @slot -->
+    <!-- @slot Custom content for list item-->
     <slot />
   </li>
 </template>

--- a/packages/vue/src/components/organisms/SfMegaMenu/SfMegaMenu.vue
+++ b/packages/vue/src/components/organisms/SfMegaMenu/SfMegaMenu.vue
@@ -28,6 +28,7 @@
             </SfListItem>
           </SfList>
           <div class="sf-mega-menu__aside-content">
+            <!-- @slot Slot for aside content -->
             <slot name="aside" />
           </div>
         </div>

--- a/packages/vue/src/components/organisms/SfProductCard/SfProductCard.vue
+++ b/packages/vue/src/components/organisms/SfProductCard/SfProductCard.vue
@@ -7,6 +7,7 @@
       class="sf-product-card__link"
     >
       <div class="sf-product-card__image-wrapper">
+        <!-- @slot Use this slot to replace image -->
         <slot name="image" v-bind="{ image, title }">
           <template v-if="Array.isArray(image)">
             <SfImage
@@ -28,6 +29,7 @@
             :height="imageHeight"
           />
         </slot>
+        <!-- @slot Use this slot to replace badge -->
         <slot name="badge" v-bind="{ badgeLabel, badgeColor }">
           <SfBadge
             v-if="badgeLabel"
@@ -37,6 +39,7 @@
           >
         </slot>
         <template v-if="showAddToCartButton">
+          <!-- @slot Use this slot to replace add to cart icon -->
           <slot
             name="add-to-cart"
             v-bind="{ isAddedToCart, showAddedToCartBadge, isAddingToCart }"
@@ -54,6 +57,7 @@
                   name="sf-product-card__add-button--icons"
                   mode="out-in"
                 >
+                  <!-- @slot Use this slot to replace add to cart icon -->
                   <slot v-if="!isAddingToCart" name="add-to-cart-icon">
                     <SfIcon
                       key="add_to_cart"
@@ -62,6 +66,7 @@
                       color="white"
                     />
                   </slot>
+                  <!-- @slot Use this slot to replace added to cart icon -->
                   <slot v-else name="adding-to-cart-icon">
                     <SfIcon
                       key="added_to_cart"
@@ -76,6 +81,7 @@
           </slot>
         </template>
       </div>
+      <!-- @slot Use this slot to replace title -->
       <slot name="title" v-bind="{ title }">
         <h3 class="sf-product-card__title">
           {{ title }}
@@ -88,6 +94,7 @@
       :class="wishlistIconClasses"
       @click="toggleIsOnWishlist"
     >
+      <!-- @slot Use this slot to replace wishlist icon -->
       <slot name="wishlist-icon" v-bind="{ currentWishlistIcon }">
         <SfIcon
           :icon="currentWishlistIcon"
@@ -97,6 +104,7 @@
         />
       </slot>
     </button>
+    <!-- @slot Use this slot to replace price -->
     <slot name="price" v-bind="{ specialPrice, regularPrice }">
       <SfPrice
         v-if="regularPrice"
@@ -105,6 +113,7 @@
         :special="specialPrice"
       />
     </slot>
+    <!-- @slot Use this slot to replace rating -->
     <slot name="reviews" v-bind="{ maxRating, scoreRating }">
       <div
         v-if="typeof scoreRating === 'number'"

--- a/packages/vue/src/components/organisms/SfSidebar/SfSidebar.vue
+++ b/packages/vue/src/components/organisms/SfSidebar/SfSidebar.vue
@@ -13,6 +13,7 @@
           />
         </slot>
         <div ref="content" class="sf-sidebar__content">
+          <!-- @slot Use this slot to change title -->
           <slot name="title" v-bind="{ title, subtitle, headingLevel }">
             <SfHeading
               v-if="title"
@@ -22,8 +23,10 @@
               class="sf-heading--left sf-heading--no-underline sf-sidebar__title desktop-only"
             />
           </slot>
+          <!-- @slot Use this slot to change subtitle -->
           <slot />
         </div>
+        <!-- @slot Use this slot to change icon -->
         <slot name="circle-icon" v-bind="{ close, button }">
           <SfCircleIcon
             v-if="button"

--- a/packages/vue/src/components/organisms/SfTable/SfTable.vue
+++ b/packages/vue/src/components/organisms/SfTable/SfTable.vue
@@ -1,5 +1,6 @@
 <template>
   <table class="sf-table">
+    <!-- @slot Custom content for table -->
     <slot />
   </table>
 </template>

--- a/packages/vue/src/components/organisms/SfTable/_internal/SfTableData.vue
+++ b/packages/vue/src/components/organisms/SfTable/_internal/SfTableData.vue
@@ -1,5 +1,6 @@
 <template>
   <td class="sf-table__data">
+    <!-- @slot Custom content for table data -->
     <slot />
   </td>
 </template>

--- a/packages/vue/src/components/organisms/SfTable/_internal/SfTableHeader.vue
+++ b/packages/vue/src/components/organisms/SfTable/_internal/SfTableHeader.vue
@@ -1,5 +1,6 @@
 <template>
   <th class="sf-table__header">
+    <!-- @slot Custom content fo rtable header -->
     <slot />
   </th>
 </template>

--- a/packages/vue/src/components/organisms/SfTable/_internal/SfTableHeading.vue
+++ b/packages/vue/src/components/organisms/SfTable/_internal/SfTableHeading.vue
@@ -1,5 +1,6 @@
 <template>
   <tr class="sf-table__heading">
+    <!-- @slot Custom content for table heading -->
     <slot />
   </tr>
 </template>

--- a/packages/vue/src/components/organisms/SfTable/_internal/SfTableRow.vue
+++ b/packages/vue/src/components/organisms/SfTable/_internal/SfTableRow.vue
@@ -1,5 +1,6 @@
 <template>
   <tr class="sf-table__row">
+    <!-- @slot Custom content for data in rows -->
     <slot />
   </tr>
 </template>


### PR DESCRIPTION
# Related issue
Closes #799 

# Scope of work
Added comments above slots

# Checklist

- [ ] No commented blocks of code left
- [ ] Run tests and docs
- [ ] Self code-reviewed

If applicable:

- [ ] I followed [composition rules](https://docs.storefrontui.io/contributing/coding-guidelines.html#component-rules) for my component
- [ ] I tested the component in most common device sizes (can be tested in Storybook [from viewport addon in top menu](https://github.com/storybooks/storybook/tree/master/addons/viewport))

  
