### PR TITLE
add: scss font mixin

### DIFF
--- a/packages/shared/styles/helpers/_typography.scss
+++ b/packages/shared/styles/helpers/_typography.scss
@@ -7,9 +7,22 @@ $typography-map: (
 );
 
 // Use it to set component font styles
-@function font($element, $font-weight, $font-size, $line-height, $font-family) {
-  @return var(#{$element}-font-weight, $font-weight)
-    var(#{$element}-font-size, $font-size) /
+@function _font(
+  $element,
+  $font-weight,
+  $font-size,
+  $line-height,
+  $font-family
+) {
+  @return var(#{$element}-weight, $font-weight)
+    var(#{$element}-size, $font-size) /
     var(#{$element}-line-height, $line-height)
-    var(#{$element}-font-family, $font-family);
+    var(#{$element}-family, $font-family);
+}
+
+@mixin font($element, $font-weight, $font-size, $line-height, $font-family) {
+  font: var(
+    #{$element},
+    _font($element, $font-weight, $font-size, $line-height, $font-family)
+  );
 }


### PR DESCRIPTION
Scope of work
Add mixin for font

Use it like this:
```css
 @include font(--breadcrumbs-font, 400, var(--font-size-small), 1.6, var(--body-font-family-secondary));
```

# Checklist

- [ ] No commented blocks of code left
- [ ] Run tests and docs
- [ ] Self code-reviewed

If applicable:

- [ ] I followed [composition rules](https://docs.storefrontui.io/contributing/coding-guidelines.html#component-rules) for my component
- [ ] I tested the component in most common device sizes (can be tested in Storybook [from viewport addon in top menu](https://github.com/storybooks/storybook/tree/master/addons/viewport))

  
