### PR TITLE
fix: font sizes variables

### DIFF
--- a/packages/shared/styles/variables/_typography.scss
+++ b/packages/shared/styles/variables/_typography.scss
@@ -11,15 +11,9 @@
 
   // font size
   --font-size-extra-small: 0.75rem; //12px
-  --font-size-small: 0.75rem; //12px
+  --font-size-small: 0.875rem; //14px
   --font-size-regular: 1rem; //16px
   --font-size-big: 1.125rem; //18px
-  @include for-desktop {
-    --font-size-extra-small: 0.75rem; //12px
-    --font-size-small: 0.875rem; //14px
-    --font-size-regular: 1.125rem; //18px
-    --font-size-big: 1.125rem; //18px
-  }
 
   // heading font size
   --h1-font-size: 1.625rem; //26px


### PR DESCRIPTION
# Related issue
<!-- paste a link to related issue -->

# Scope of work
<!-- describe what you did -->
after a long analyst, I think we can use the same body font sizes on desktop and mobile
``` scss
  --font-size-extra-small: 0.75rem; //12px
  --font-size-small: 0.875rem; //14px
  --font-size-regular: 1rem; //16px
  --font-size-big: 1.125rem; //18px
```
# Screenshots of visual changes
<!-- if visual changes applied -->

# Checklist

- [ ] No commented blocks of code left
- [ ] Run tests and docs
- [ ] Self code-reviewed

If applicable:

- [ ] I followed [composition rules](https://docs.storefrontui.io/contributing/coding-guidelines.html#component-rules) for my component
- [ ] I tested the component in most common device sizes (can be tested in Storybook [from viewport addon in top menu](https://github.com/storybooks/storybook/tree/master/addons/viewport))

  
