### PR TITLE
refactor(atoms): SfColor

### DIFF
--- a/packages/shared/styles/components/atoms/SfColor.scss
+++ b/packages/shared/styles/components/atoms/SfColor.scss
@@ -29,11 +29,10 @@
   }
 
   @include for-desktop {
-    --color-width: 0.75rem;
-    --color-height: 0.75rem;
-
-    &:hover,
-    &--active {
+    --color-size: 0.75rem;
+    
+    &--active,
+    &:hover {
       transform: scale(1.667);
     }
     &:hover {

--- a/packages/shared/styles/components/atoms/SfColor.scss
+++ b/packages/shared/styles/components/atoms/SfColor.scss
@@ -2,24 +2,48 @@
 
 .sf-color {
   box-sizing: border-box;
+  position: relative;
   width: var(--color-width, var(--color-size, 2.5rem));
   height: var(--color-height, var(--color-size, 2.5rem));
-  padding: var(--color-padding, 3px);
   background: var(--color-background);
   border: 0;
   border-radius: var(--color-border-radius);
-  &__fill {
-    box-sizing: border-box;
-    width: 100%;
-    height: 100%;
-    border: var(--color-fill-border, 2px solid transparent);
-    border-radius: var(--color-border-radius);
-    transition: border-color 150ms linear;
+  box-shadow: var(--color-box-shadow);
+  transition: transform 150ms linear, box-shadow 150ms linear;
+  cursor: pointer;
+
+  &__badge {
+    --badge-padding: var(--spacer-extra-small);
+    --badge-border-radius: 100%;
+    position: absolute;
+    top: -25%;
+    right: -25%;
+
+    &-enter-active {
+      animation: bounce-in 300ms;
+    }
+
+    &-leave-active {
+      animation: bounce-in 300ms reverse;
+    }
   }
-  &--active,
-  &:hover {
-    --color-fill-border: 2px solid var(--c-white);
+
+  @include for-desktop {
+    --color-width: 0.75rem;
+    --color-height: 0.75rem;
+
+    &:hover,
+    &--active {
+      transform: scale(1.667);
+    }
+    &:hover {
+      --color-box-shadow: 0px 4px 4px rgba(var(--c-dark-base), 0.25);
+    }
+    &:active {
+      --color-box-shadow: none;
+    }
   }
+
   &--rounded {
     --color-border-radius: 100%;
   }

--- a/packages/vue/src/components/atoms/SfColor/SfColor.vue
+++ b/packages/vue/src/components/atoms/SfColor/SfColor.vue
@@ -7,16 +7,27 @@
     :aria-pressed="selected.toString()"
     v-on="$listeners"
   >
-    <!-- @slot Custom color markup -->
-    <slot>
-      <div v-if="color" class="sf-color__fill" />
-    </slot>
+    <!-- @slot Use it to replace badge to custom element -->
+    <transition name="sf-color__badge">
+      <slot v-if="selected" name="badge">
+        <SfBadge class="sf-color__badge mobile-only">
+          <SfIcon icon="check" size="7px" color="white" />
+        </SfBadge>
+      </slot>
+    </transition>
   </button>
 </template>
 <script>
 import { focus } from "../../../utilities/directives/focus-directive.js";
+import SfBadge from "../../atoms/SfBadge/SfBadge.vue";
+import SfIcon from "../../atoms/SfIcon/SfIcon.vue";
+
 export default {
   name: "SfColor",
+  components: {
+    SfBadge,
+    SfIcon
+  },
   directives: {
     focus: focus
   },


### PR DESCRIPTION
# Scope of work
add SfBadge with SfIcon on selected only for mobile
refactor SfColor styles 

# Checklist

- [x] No commented blocks of code left
- [x] Run tests and docs
- [x] Self code-reviewed

If applicable:

- [x] I followed [composition rules](https://docs.storefrontui.io/contributing/coding-guidelines.html#component-rules) for my component
- [x] I tested the component in most common device sizes (can be tested in Storybook [from viewport addon in top menu](https://github.com/storybooks/storybook/tree/master/addons/viewport))

  
