### PR TITLE
fix: font-weight variables

### DIFF
--- a/packages/shared/styles/variables/_typography.scss
+++ b/packages/shared/styles/variables/_typography.scss
@@ -6,8 +6,8 @@
 
   // font weight
   --font-weight-light: 300;
-  --font-weight-regular: 400,
-  --font-weight-bold: 500,
+  --font-weight-regular: 400;
+  --font-weight-bold: 500;
   --font-weight-extra-bold: 600;
 
   // font size

--- a/packages/shared/styles/variables/_typography.scss
+++ b/packages/shared/styles/variables/_typography.scss
@@ -6,8 +6,9 @@
 
   // font weight
   --font-weight-light: 300;
-  --font-weight-regular: 400;
-  --font-weight-bold: 600;
+  --font-weight-regular: 400,
+  --font-weight-bold: 500,
+  --font-weight-extra-bold: 600;
 
   // font size
   --font-size-extra-small: 0.75rem; //12px


### PR DESCRIPTION
# Scope of work
additional font-weight variable 

# Checklist

- [ ] No commented blocks of code left
- [ ] Run tests and docs
- [ ] Self code-reviewed

If applicable:

- [ ] I followed [composition rules](https://docs.storefrontui.io/contributing/coding-guidelines.html#component-rules) for my component
- [ ] I tested the component in most common device sizes (can be tested in Storybook [from viewport addon in top menu](https://github.com/storybooks/storybook/tree/master/addons/viewport))

  
