### PR TITLE
fix: global variables

### DIFF
--- a/packages/shared/styles/variables/_layout.scss
+++ b/packages/shared/styles/variables/_layout.scss
@@ -1,7 +1,7 @@
 :root {
   --spacer-xs: 0.5rem; //8px
   --spacer-sm: 1rem; //1rem
-  --spacer-basse: 1.5rem; //24px
+  --spacer-base: 1.5rem; //24px
   --spacer-lg: 2.5rem; //40px
   --spacer-xl: 5rem; //80px
   --spacer-2xl: 10rem; //160px

--- a/packages/shared/styles/variables/_layout.scss
+++ b/packages/shared/styles/variables/_layout.scss
@@ -1,8 +1,8 @@
 :root {
-  --spacer-extra-small: 0.5rem; //8px
-  --spacer-small: 1rem; //1rem
-  --spacer-regular: 1.5rem; //24px
-  --spacer-medium: 2.5rem; //40px
-  --spacer-big: 5rem; //80px
-  --spacer-extra-big: 10rem; //160px
+  --spacer-xs: 0.5rem; //8px
+  --spacer-sm: 1rem; //1rem
+  --spacer-basse: 1.5rem; //24px
+  --spacer-lg: 2.5rem; //40px
+  --spacer-xl: 5rem; //80px
+  --spacer-2xl: 10rem; //160px
 }

--- a/packages/shared/styles/variables/_typography.scss
+++ b/packages/shared/styles/variables/_typography.scss
@@ -1,22 +1,24 @@
 @import "../helpers";
 :root {
-  // font family
-  --body-font-family-primary: "Roboto", serif;
-  --body-font-family-secondary: "Raleway", sans-serif;
-
-  // font weight
-  --font-weight-light: 300;
-  --font-weight-regular: 400;
-  --font-weight-bold: 500;
-  --font-weight-extra-bold: 600;
-
-  // font size
-  --font-size-extra-small: 0.75rem; //12px
-  --font-size-small: 0.875rem; //14px
-  --font-size-regular: 1rem; //16px
-  --font-size-big: 1.125rem; //18px
-
-  // heading font size
+  // font-family
+  --font-family-primary: "Roboto", serif;
+  --font-family-secondary: "Raleway", sans-serif;
+  // font-weight
+  --font-light: 300;
+  --font-normal: 400;
+  --font-medium: 500;
+  --font-semibold: 600;
+  --font-bold: 700;
+  --font-extra-bold: 800;
+  --font-black: 900;
+  // font-size
+  --font-2xs: 0.625rem; //10px
+  --font-xs: 0.75rem; //12px
+  --font-sm: 0.875rem; //14px
+  --font-base: 1rem; //16px
+  --font-lg: 1.125rem; //18px
+  --font-xl: 1.5rem; //24px
+  // heading font-size
   --h1-font-size: 1.625rem; //26px
   --h2-font-size: 1.375rem; //22px
   --h3-font-size: 1.125rem; //18px
@@ -31,12 +33,4 @@
     --h5-font-size: 0.875rem; //14px
     --h6-font-size: 0.875rem; //14px
   }
-
-  // heading font weight
-  --h1-font-weight: 600;
-  --h2-font-weight: 400;
-  --h3-font-weight: 500;
-  --h4-font-weight: 400;
-  --h5-font-weight: 700;
-  --h6-font-weight: 400;
 }


### PR DESCRIPTION
# Scope of work
<!-- describe what you did -->
After a long discussion about the name of 10px font size we decide to change our variable name convention  to more flexibility

## _typography font-weight

Before | After
------------ | -------------
--font-weight-light: 300 | --font-light: 300
--font-weight-regular: 400 | --font-normal: 400
--font-weight-bold: 500 | --font-medium: 500
--font-weight-extra-bold: 600 | --font-semibold: 600
undefined | --font-bold: 700
undefined | --font-extra-bold: 800
undefined | --font-black: 900

## _typography font-size
Before | After
------------ | -------------
undefined | --font-2xs: 10px
--font-size-extra-small: 0.75rem | --font-xs: 12px
--font-size-small: 0.875rem | --font-sm: 14px
--font-size-regular: 1rem | --font-base: 16px
--font-size-big: 1.125rem | --font-lg: 18px
undefined | --font-xl: 24px

## _tayout font-size
Before | After
------------ | -------------
 --spacer-extra-small: 0.5rem | --spacer-xs: 8px
  --spacer-small: 1rem | --spacer-sm: 16px
  --spacer-regular: 1.5rem | --spacer-basse: 24px
  --spacer-medium: 2.5rem | --spacer-lg: 40px
  --spacer-big: 5rem | --spacer-xl: 80px
  --spacer-extra-big: 10rem | --spacer-2xl: 100px
