### PR TITLE
fix: forwarded events on SfBottomNavigationItem

### DIFF
--- a/packages/vue/src/components/organisms/SfBottomNavigation/_internal/SfBottomNavigationItem.vue
+++ b/packages/vue/src/components/organisms/SfBottomNavigation/_internal/SfBottomNavigationItem.vue
@@ -2,6 +2,7 @@
   <div
     class="sf-bottom-navigation-item"
     :class="{ 'sf-bottom-navigation-item--floating': isFloating }"
+    v-on="$listeners"
   >
     <slot name="icon" v-bind="{ icon, iconSize, isFloating }">
       <SfCircleIcon


### PR DESCRIPTION
# Related issue
https://github.com/DivanteLtd/shopware-pwa/pull/467

# Scope of work
- fix issue with click event on bottom item menu by adding to SfBottomNavigationItem `v-on="$listeners"` to forward events

# Checklist

- [x] No commented blocks of code left
- [x] Run tests and docs
- [x] Self code-reviewed

If applicable:

- [ ] I followed [composition rules](https://docs.storefrontui.io/contributing/coding-guidelines.html#component-rules) for my component
- [ ] I tested the component in most common device sizes (can be tested in Storybook [from viewport addon in top menu](https://github.com/storybooks/storybook/tree/master/addons/viewport))

  
