### PR TITLE
fix: remove spinners on input number on firefox 

### DIFF
--- a/packages/shared/styles/components/atoms/SfInput.scss
+++ b/packages/shared/styles/components/atoms/SfInput.scss
@@ -116,6 +116,7 @@
         -webkit-appearance: none;
         margin: 0;
       }
+      -moz-appearance: textfield;
     }
   }
 


### PR DESCRIPTION
# Related issue
no

# Scope of work
SfInput css: remove spinner buttons on input type number on firefox.

# Screenshots of visual changes
![image (1)](https://user-images.githubusercontent.com/32042425/76291485-80eb7400-62ad-11ea-9e72-a7859d76cd3a.png)

# Checklist

- [x] No commented blocks of code left
- [x] Run tests and docs
- [x] Self code-reviewed

If applicable:

- [ ] I followed [composition rules](https://docs.storefrontui.io/contributing/coding-guidelines.html#component-rules) for my component
- [ ] I tested the component in most common device sizes (can be tested in Storybook [from viewport addon in top menu](https://github.com/storybooks/storybook/tree/master/addons/viewport))

  
