### PR TITLE
fix: SfImage breaks height of content height

### DIFF
--- a/packages/shared/styles/components/atoms/SfImage.scss
+++ b/packages/shared/styles/components/atoms/SfImage.scss
@@ -2,7 +2,7 @@
 
 .sf-image {
   position: relative;
-  display: block;
+  display: inline-block;
   line-height: 0;
   overflow: hidden;
   img {

--- a/packages/shared/styles/components/atoms/SfImage.scss
+++ b/packages/shared/styles/components/atoms/SfImage.scss
@@ -2,7 +2,7 @@
 
 .sf-image {
   position: relative;
-  display: inline-block;
+  display: block;
   line-height: 0;
   overflow: hidden;
   img {

--- a/packages/shared/styles/components/organisms/SfProductCardHorizontal.scss
+++ b/packages/shared/styles/components/organisms/SfProductCardHorizontal.scss
@@ -21,6 +21,7 @@
 
   &__image-wrapper {
     position: relative;
+    line-height: 0;
   }
 
   &__image,


### PR DESCRIPTION
# Scope of work
<!-- describe what you did -->
- `display: inline-block` breaks the height of the content in SfProductCardHorizontal, SfCollectedProduct, SfGroupedProduct
- changed it to `display: block`
[EDIT]
- changed wrapper of SfImage line-height to `0` in SfProductCardHorizontal 
@pspaczek Can you check it? 

# Screenshots of visual changes
<!-- if visual changes applied -->

# Checklist

- [x] No commented blocks of code left
- [x] Run tests and docs
- [x] Self code-reviewed
