### PR TITLE
Fix: SfTabs content on dektop

### DIFF
--- a/packages/shared/styles/components/organisms/SfTabs.scss
+++ b/packages/shared/styles/components/organisms/SfTabs.scss
@@ -29,6 +29,7 @@
   }
   &__content {
     order: var(--tabs-content-order);
+    width: var(--tabs-content-width);
     @include border(--tabs-content-border, 1px 0, solid, var(--c-light));
     color: var(--tabs-content-color, var(--c-text));
     @include font(
@@ -52,12 +53,13 @@
     --tabs-title-z-index: 1;
     --tabs-content-order: 1;
     --tabs-title-flex: 0 0 auto;
+    --tabs-content-width: 100%;
     --tabs-title-margin: 0 var(--spacer-lg) -2px 0;
     --tabs-title-padding: var(--spacer-xs) 0;
     --tabs-title-color: var(--c-text-muted);
     --tabs-title-font-size: var(--h4-font-size);
     --tabs-content-tab-padding: var(--spacer-base) 0;
-    --tabs-content-border-width: 1px 0 0 0;
+    --tabs-content-border-width: 0;
     --tabs-chevron-display: none;
     &__title {
       &--active {


### PR DESCRIPTION
# Related issue
no

# Scope of work
fix content showing in the same line with title

# Screenshots of visual changes
![sfTabs_desktop](https://user-images.githubusercontent.com/32042425/77119784-73658500-6a37-11ea-97ca-373051ba1b0f.png)


# Checklist

- [x] No commented blocks of code left
- [x] Run tests and docs
- [x] Self code-reviewed

If applicable:

- [ ] I followed [composition rules](https://docs.storefrontui.io/contributing/coding-guidelines.html#component-rules) for my component
- [ ] I tested the component in most common device sizes (can be tested in Storybook [from viewport addon in top menu](https://github.com/storybooks/storybook/tree/master/addons/viewport))
 - [ ] I accept [Individual Contributor License Agreement](https://github.com/DivanteLtd/next/blob/master/CLA.md)
