### PR TITLE
feat: add open by header in SfAccordion

### DIFF
--- a/packages/vue/src/components/organisms/SfAccordion/SfAccordion.stories.js
+++ b/packages/vue/src/components/organisms/SfAccordion/SfAccordion.stories.js
@@ -12,8 +12,8 @@ storiesOf("Organisms|Accordion", module)
   .add("Common", () => ({
     components: { SfAccordion, SfList, SfMenuItem },
     props: {
-      firstOpen: {
-        default: boolean("firstOpen", true, "Props")
+      open: {
+        default: text("open", "Clothing", "Props")
       },
       multiple: {
         default: boolean("multiple", false, "Props")
@@ -56,7 +56,7 @@ storiesOf("Organisms|Accordion", module)
       };
     },
     template: `<SfAccordion 
-        :first-open="firstOpen" 
+        :open="open" 
         :multiple="multiple"
         :show-chevron="showChevron"
         :transition="transition"
@@ -83,8 +83,8 @@ storiesOf("Organisms|Accordion", module)
   .add("[slot] header", () => ({
     components: { SfAccordion, SfList, SfMenuItem },
     props: {
-      firstOpen: {
-        default: boolean("firstOpen", true, "Props")
+      open: {
+        default: text("open", "Shoes", "Props")
       },
       multiple: {
         default: boolean("multiple", false, "Props")
@@ -127,7 +127,7 @@ storiesOf("Organisms|Accordion", module)
       };
     },
     template: `<SfAccordion
-        :first-open="firstOpen"
+        :open="open"
         :multiple="multiple"
         :show-chevron="showChevron"
         :transition="transition"

--- a/packages/vue/src/components/organisms/SfAccordion/SfAccordion.vue
+++ b/packages/vue/src/components/organisms/SfAccordion/SfAccordion.vue
@@ -15,7 +15,15 @@ export default {
   name: "SfAccordion",
   props: {
     /**
+     * Opens an accordion item based on title
+     */
+    open: {
+      type: [String, Array],
+      default: ""
+    },
+    /**
      * Opens the first accordion item if set to "true"
+     * @deprecated will be removed in 1.0.0 use open prop instead
      */
     firstOpen: {
       type: Boolean,
@@ -49,12 +57,24 @@ export default {
   },
   methods: {
     setAsOpen() {
-      if (this.$children.length) {
-        this.$children[0].isOpen = this.firstOpen;
+      if (this.$children && this.$children.length) {
+        // TODO remove in 1.0.0
+        if (this.firstOpen) {
+          this.$children[0].isOpen = this.firstOpen;
+          console.warn(
+            "[StorefrontUI][SfAccordion] firstOpen prop has been deprecated and will be removed in 1.0.0. Use open instead."
+          );
+          return;
+        }
+        this.$children.forEach(child => {
+          child.isOpen = Array.isArray(this.open)
+            ? this.open.includes(child.header)
+            : this.open === child.header;
+        });
       }
     },
     toggleHandler(slotId) {
-      if (!this.multiple) {
+      if (!this.multiple && !Array.isArray(this.open)) {
         this.$children.forEach(child => {
           child._uid === slotId
             ? (child.isOpen = !child.isOpen)

--- a/packages/vue/src/components/organisms/SfAccordion/SfAccordion.vue
+++ b/packages/vue/src/components/organisms/SfAccordion/SfAccordion.vue
@@ -58,7 +58,7 @@ export default {
   methods: {
     setAsOpen() {
       if (this.$children && this.$children.length) {
-        // TODO remove in 1.0.0
+        // TODO remove in 1.0.0 ->
         if (this.firstOpen) {
           this.$children[0].isOpen = this.firstOpen;
           console.warn(
@@ -66,6 +66,7 @@ export default {
           );
           return;
         }
+        // <- TODO remove in 1.0.0
         this.$children.forEach(child => {
           child.isOpen = Array.isArray(this.open)
             ? this.open.includes(child.header)

--- a/packages/vue/src/examples/pages/category/Category.vue
+++ b/packages/vue/src/examples/pages/category/Category.vue
@@ -112,7 +112,7 @@
     </div>
     <div class="main section">
       <div class="sidebar desktop-only">
-        <SfAccordion :first-open="true" :show-chevron="false">
+        <SfAccordion :open="sidebarAccordion[0].header" :show-chevron="false">
           <SfAccordionItem
             v-for="(accordion, i) in sidebarAccordion"
             :key="i"

--- a/packages/vue/src/examples/pages/checkout/_internal/ConfirmOrder.vue
+++ b/packages/vue/src/examples/pages/checkout/_internal/ConfirmOrder.vue
@@ -4,7 +4,7 @@
       title="4. Order review"
       class="sf-heading--left sf-heading--no-underline title"
     />
-    <SfAccordion first-open class="accordion mobile-only">
+    <SfAccordion open="Personal Details" class="accordion mobile-only">
       <SfAccordionItem header="Personal Details">
         <div class="accordion__item">
           <div class="accordion__content">


### PR DESCRIPTION
# Related issue
<!-- paste a link to related issue -->
Closes #954 

# Scope of work
<!-- describe what you did -->
- add `open` prop 
- add the possibility to open more that one item by passing header or headers in array
- updated stories
- deprecated `firstOpen` to be removed in 1.0.0 due to the fact this change is breaking change


# Screenshots of visual changes
<!-- if visual changes applied -->

# Checklist

- [ ] No commented blocks of code left
- [x] Run tests and docs
- [x] Self code-reviewed

