### PR TITLE
fix: SfCarousel on safari, iOS

### DIFF
--- a/packages/shared/styles/components/organisms/SfCarousel.scss
+++ b/packages/shared/styles/components/organisms/SfCarousel.scss
@@ -37,4 +37,8 @@
     --carousel-controls-size: 15rem;
     --carousel-controls-display: flex;
   }
+  @supports (-webkit-touch-callout: none) {
+    --carousel-width: 100%;
+    --carousel-controls-display: none;
+  }
 }

--- a/packages/shared/styles/components/organisms/SfCarousel.scss
+++ b/packages/shared/styles/components/organisms/SfCarousel.scss
@@ -16,6 +16,7 @@
   }
   &__controls {
     position: var(--carousel-controls-position, absolute);
+
     top: var(--carousel-controls-top, 50%);
     left: var(--carousel-controls-left, 0);
     transform: var(--carousel-controls-transform, translate3d(0, -50%, 0));
@@ -38,7 +39,7 @@
     --carousel-controls-display: flex;
   }
   @supports (-webkit-touch-callout: none) {
-    --carousel-width: 100%;
+    --carousel-width: 100vw;
     --carousel-controls-display: none;
   }
 }


### PR DESCRIPTION
# Related issue
https://github.com/DivanteLtd/storefront-ui/issues/983
Closes #

# Scope of work
carousel fix on safari (iOS, model below iPhone 8) arrows removed.   

# Screenshots of visual changes

![image](https://user-images.githubusercontent.com/32042425/78706524-83bea080-790f-11ea-928e-1bec63813ea4.png)


# Checklist

- [x] No commented blocks of code left
- [ ] Run tests and docs
- [x] Self code-reviewed
