### PR TITLE
fix: remove blur from focus-directive

### DIFF
--- a/packages/vue/src/utilities/directives/focus-directive.js
+++ b/packages/vue/src/utilities/directives/focus-directive.js
@@ -2,7 +2,6 @@ export const focus = {
   bind(el) {
     el._mouseHandler = function () {
       el.style.outline = "none";
-      el.blur();
     };
     el._keyHandler = function () {
       el.style.outline = "";


### PR DESCRIPTION
# Related issue
<!-- paste a link to related issue -->
#960 

# Scope of work
<!-- describe what you did -->
- remove blur from focus directive, it breaks elements that they already have blur e.g. SfSelect 

# Screenshots of visual changes
<!-- if visual changes applied -->

# Checklist

- [x] No commented blocks of code left
- [x] Run tests and docs
- [x] Self code-reviewed
