### PR TITLE
fix: v-focus with capture

### DIFF
--- a/packages/vue/src/utilities/directives/focus-directive.js
+++ b/packages/vue/src/utilities/directives/focus-directive.js
@@ -8,7 +8,7 @@ export const focus = {
       el.focus();
     };
     window.addEventListener("mousedown", el._mouseHandler);
-    el.addEventListener("keyup", el._keyHandler);
+    el.addEventListener("keyup", el._keyHandler, true);
   },
   unbind(el) {
     window.removeEventListener("mousedown", el._mouseHandler);


### PR DESCRIPTION
# Related issue
#960 
There is a problem with some organisms with v-focus - clicking a tab didn't change focus to another element.

# Scope of work
Added capture option for event listener 

