### PR TITLE
fix: minus sign in SfQuantitySelector

### DIFF
--- a/packages/vue/src/components/atoms/SfQuantitySelector/SfQuantitySelector.vue
+++ b/packages/vue/src/components/atoms/SfQuantitySelector/SfQuantitySelector.vue
@@ -4,7 +4,7 @@
       :disabled="disabled"
       class="sf-quantity-selector__button"
       @click="$emit('input', parseInt(qty, 10) - 1)"
-      >-</SfButton
+      >&minus;</SfButton
     >
     <SfInput
       type="number"


### PR DESCRIPTION
# Related issue
 #960 

# Scope of work
Minus sign "-" was read as pause so has been changed to &minus;
