### PR TITLE
fix: default font for SfModal

### DIFF
--- a/packages/shared/styles/components/molecules/SfModal.scss
+++ b/packages/shared/styles/components/molecules/SfModal.scss
@@ -23,6 +23,13 @@
   &__content {
     overflow-y: auto;
     padding: var(--modal-content-padding, var(--spacer-base) var(--spacer-sm));
+    @include font(
+      --modal-content-font,
+      var(--font-light),
+      var(--font-base),
+      1.6,
+      var(--font-family-primary)
+    );
   }
   &__close {
     position: absolute;


### PR DESCRIPTION
# Related issue
<!-- paste a link to related issue -->
none
# Scope of work
<!-- describe what you did -->
set font for SfModal content

# Checklist

- [x] No commented blocks of code left
- [x] Run tests and docs
- [x] Self code-reviewed

If applicable:

- [x] I followed [composition rules](https://docs.storefrontui.io/contributing/coding-guidelines.html#component-rules) for my component
- [x] I tested the component in most common device sizes (can be tested in Storybook [from viewport addon in top menu](https://github.com/storybooks/storybook/tree/master/addons/viewport))
 - [x] I accept [Individual Contributor License Agreement](https://github.com/DivanteLtd/next/blob/master/CLA.md)
