### PR TITLE
fix: add possibility to change height of divider

### DIFF
--- a/packages/shared/styles/components/atoms/SfDivider.scss
+++ b/packages/shared/styles/components/atoms/SfDivider.scss
@@ -4,5 +4,7 @@
   margin: var(--divider-margin);
   max-width: var(--divider-max-width);
   width: var(--divider-width);
+  height: var(--divider-height);
+  background: var(--divider-background);
   @include border(--divider-border, 1px, solid, var(--c-light));
 }


### PR DESCRIPTION
# Related issue
<!-- paste a link to related issue -->
Closes #1108 
We should stay with border property for now because it is already implemented. For more customization, I add height and background property if you want to modify it, now it should be easy @aniamusial :)
# Scope of work
<!-- describe what you did -->
- [x] add `--divider-height` and `--divider-background` variables
# Screenshots of visual changes
<!-- if visual changes applied -->

# Checklist

- [x] No commented blocks of code left
- [x] Run tests and docs
- [x] Self code-reviewed

If applicable:

- [ ] I followed [composition rules](https://docs.storefrontui.io/contributing/coding-guidelines.html#component-rules) for my component
- [ ] I tested the component in most common device sizes (can be tested in Storybook [from viewport addon in top menu](https://github.com/storybooks/storybook/tree/master/addons/viewport))
 - [ ] I accept [Individual Contributor License Agreement](https://github.com/DivanteLtd/next/blob/master/CLA.md)
