### PR TITLE
feat: input add hasIcon and textHelper props

### DIFF
--- a/packages/shared/styles/components/atoms/SfInput.scss
+++ b/packages/shared/styles/components/atoms/SfInput.scss
@@ -61,15 +61,18 @@
       1.2,
       var(--font-family-secondary)
     );
+    &--required {
+      color: var(--input-error-message-required-color, var(--c-primary));
+    }
   }
   &__helper-text {
-    color: var(--input-error-message-color, var(--c-primary));
-    height: calc(var(--font-xs) * 1.2);
+    color: var(--input-error-message-color, var(--c-secondary-variant));
+    height: calc(var(--font-base) * 1.6);
     @include font(
       --input-helper-text-font,
       var(--font-medium),
-      var(--font-xs),
-      1.2,
+      var(--font-base),
+      1.6,
       var(--font-family-secondary)
     );
   }

--- a/packages/shared/styles/components/atoms/SfInput.scss
+++ b/packages/shared/styles/components/atoms/SfInput.scss
@@ -67,12 +67,12 @@
   }
   &__helper-text {
     color: var(--input-error-message-color, var(--c-secondary-variant));
-    height: calc(var(--font-base) * 1.6);
+    height: calc(var(--font-xs) * 1.2);
     @include font(
       --input-helper-text-font,
       var(--font-medium),
-      var(--font-base),
-      1.6,
+      var(--font-xs),
+      1.2,
       var(--font-family-secondary)
     );
   }

--- a/packages/shared/styles/components/atoms/SfInput.scss
+++ b/packages/shared/styles/components/atoms/SfInput.scss
@@ -155,6 +155,14 @@
       content: "";
     }
   }
+  &__icon {
+    position: absolute;
+    --icon-width: var(--input-icon-width, var(--icon-size, 1rem));
+    --icon-height: var(--input-icon-height, var(--icon-size, 1rem));
+    top: var(--input-icon-top, 50%);
+    right: var(--input-icon-right, var(--spacer-xs));
+    transform: translate3d(0, -50%, 0);    
+  }
   &--invalid {
     --input-border-color: var(--c-danger);
     input {

--- a/packages/shared/styles/components/atoms/SfInput.scss
+++ b/packages/shared/styles/components/atoms/SfInput.scss
@@ -52,8 +52,9 @@
     }
   }
   &__error-message {
+    display: flex;    
     color: var(--input-error-message-color, var(--c-danger));
-    height: calc(var(--font-xs) * 1.2);
+    height: calc(var(--font-xs) * 1.2);    
     @include font(
       --input-error-message-font,
       var(--font-medium),
@@ -63,11 +64,13 @@
     );
     &--required {
       color: var(--input-error-message-required-color, var(--c-primary));
+      margin: var(--input-error-message-required-margin, 0 var(--spacer-2xs) 0 0);
     }
   }
   &__helper-text {
-    color: var(--input-error-message-color, var(--c-secondary-variant));
+    color: var(--input-helper-text-color, var(--c-secondary-variant));
     height: calc(var(--font-xs) * 1.2);
+    margin: var(--input-helper-text-margin, 0 0 var(--spacer-xs) 0);
     @include font(
       --input-helper-text-font,
       var(--font-medium),

--- a/packages/shared/styles/components/atoms/SfInput.scss
+++ b/packages/shared/styles/components/atoms/SfInput.scss
@@ -62,6 +62,17 @@
       var(--font-family-secondary)
     );
   }
+  &__helper-text {
+    color: var(--input-error-message-color, var(--c-primary));
+    height: calc(var(--font-xs) * 1.2);
+    @include font(
+      --input-helper-text-font,
+      var(--font-medium),
+      var(--font-xs),
+      1.2,
+      var(--font-family-secondary)
+    );
+  }
   &__wrapper,
   input {
     width: 100%;

--- a/packages/shared/styles/components/molecules/SfSelect.scss
+++ b/packages/shared/styles/components/molecules/SfSelect.scss
@@ -110,12 +110,25 @@
       width: 0;
     }
   }
+  &__helper-text {
+    color: var(--select-helper-text-color, var(--c-secondary-variant));
+    height: calc(var(--font-xs) * 1.2);
+    margin: var(--select-helper-text-margin, 0 0 var(--spacer-xs) 0);
+    @include font(
+      --select-helper-text-font,
+      var(--font-medium),
+      var(--font-xs),
+      1.2,
+      var(--font-family-secondary)
+    );
+  }
   &__error-message {
     --select-border-color: var(--c-danger);
+    display: flex;
     color: var(--select-error-message-color, var(--c-danger));
     height: calc(var(--font-xs) * 1.2);
     @include font(
-      --input-error-message-font,
+      --select-error-message-font,
       var(--font-medium),
       var(--font-xs),
       1.2,
@@ -123,6 +136,7 @@
     );
     &--required {
       color: var(--select-error-message-required-color, var(--c-primary));
+      margin: var(--select-error-message-required-margin, 0 var(--spacer-2xs) 0 0);
     }
   }
   &__cancel {

--- a/packages/shared/styles/components/molecules/SfSelect.scss
+++ b/packages/shared/styles/components/molecules/SfSelect.scss
@@ -121,6 +121,9 @@
       1.2,
       var(--font-family-secondary)
     );
+    &--required {
+      color: var(--select-error-message-required-color, var(--c-primary));
+    }
   }
   &__cancel {
     --button-background: var(--c-light);

--- a/packages/vue/src/components/atoms/SfInput/SfInput.stories.js
+++ b/packages/vue/src/components/atoms/SfInput/SfInput.stories.js
@@ -44,6 +44,9 @@ storiesOf("Atoms|Input", module)
       required: {
         default: boolean("required", true, "Props"),
       },
+      requiredMessage: {
+        default: text("requiredMessage", "Required", "Props"),
+      },
       disabled: {
         default: boolean("disabled", false, "Props"),
       },
@@ -76,6 +79,7 @@ storiesOf("Atoms|Input", module)
       :valid="valid"
       :error-message="errorMessage"
       :required="required"
+      :requiredMessage="requiredMessage"
       :disabled="disabled"
       aria-label="Input label"
       :has-show-password="hasShowPassword"
@@ -83,7 +87,6 @@ storiesOf("Atoms|Input", module)
       :hasIcon="hasIcon"
       :icon="icon"
       :colorIcon="colorIcon"
-      :sizeIcon="sizeIcon"
       :helperText="helperText"
       />`,
   }))
@@ -122,6 +125,9 @@ storiesOf("Atoms|Input", module)
       required: {
         default: boolean("required", true, "Props"),
       },
+      requiredMessage: {
+        default: text("requiredMessage", "Required", "Props"),
+      },
       disabled: {
         default: boolean("disabled", false, "Props"),
       },
@@ -154,17 +160,103 @@ storiesOf("Atoms|Input", module)
         :valid="valid"
         :error-message="errorMessage"
         :required="required"
+        :requiredMessage="requiredMessage"
         :disabled="disabled"
         :has-show-password="hasShowPassword"
         aria-label="Input label"
         :hasIcon="hasIcon"
         :icon="icon"
         :colorIcon="colorIcon"
-        :sizeIcon="sizeIcon"
         :helperText="helperText"
         >
       <template #label="{label}">
             <SfIcon icon="heart_fill" size="10px" style="margin-right: 4px; display: inline-block"/>{{label}}
+      </template>
+    </SfInput>`,
+  }))
+  .add("[slot] helper-text", () => ({
+    components: {
+      SfInput,
+      SfIcon,
+    },
+    props: {
+      customClass: {
+        default: options(
+          "CSS modifiers",
+          {
+            "sf-input--filled": "sf-input--filled",
+          },
+          "",
+          { display: "multi-select" },
+          "CSS Modifiers"
+        ),
+      },
+      type: {
+        default: text("type", "text", "Props"),
+      },
+      label: {
+        default: text("label", "First name", "Props"),
+      },
+      name: {
+        default: text("name", "first-name", "Props"),
+      },
+      errorMessage: {
+        default: text("errorMessage", "Something is wrong", "Props"),
+      },
+      valid: {
+        default: boolean("valid", false, "Props"),
+      },
+      required: {
+        default: boolean("required", false, "Props"),
+      },
+      requiredMessage: {
+        default: text("requiredMessage", "Required", "Props"),
+      },
+      disabled: {
+        default: boolean("disabled", false, "Props"),
+      },
+      hasShowPassword: {
+        default: boolean("hasShowPassword", false, "Props"),
+      },
+      hasIcon: {
+        default: boolean("hasIcon", false, "Props"),
+      },
+      icon: {
+        default: select("icon", iconsNames, "phone", "Props"),
+      },
+      colorIcon: {
+        default: select("colorIcon", ["", ...colors], "", "Props"),
+      },
+      helperText: {
+        default: text("helperText", "Password should consist of at least 2 digit, capital letter and special sign", "Props"),
+      },
+    },
+    data() {
+      return {
+        value: "Adam",
+      };
+    },
+    template: `<SfInput
+      v-model="value"
+      :type="type"
+      :label="label"
+      :name="name"
+      :valid="valid"
+      :error-message="errorMessage"
+      :required="required"
+      :requiredMessage="requiredMessage"
+      :disabled="disabled"
+      :has-show-password="hasShowPassword"
+      aria-label="Input label"
+      :hasIcon="hasIcon"
+      :icon="icon"
+      :colorIcon="colorIcon"
+      :helperText="helperText"
+      >
+      <template #helper-text="{helperText}">
+        <div>          
+          CUSTOM HELPER TEXT
+        </div>
       </template>
     </SfInput>`,
   }))
@@ -203,6 +295,9 @@ storiesOf("Atoms|Input", module)
       required: {
         default: boolean("required", false, "Props"),
       },
+      requiredMessage: {
+        default: text("requiredMessage", "Required", "Props"),
+      },
       disabled: {
         default: boolean("disabled", false, "Props"),
       },
@@ -235,13 +330,13 @@ storiesOf("Atoms|Input", module)
       :valid="valid"
       :error-message="errorMessage"
       :required="required"
+      :requiredMessage="requiredMessage"
       :disabled="disabled"
       :has-show-password="hasShowPassword"
       aria-label="Input label"
       :hasIcon="hasIcon"
       :icon="icon"
       :colorIcon="colorIcon"
-      :sizeIcon="sizeIcon"
       :helperText="helperText"
       >
       <template #error-message="{errorMessage}">
@@ -287,6 +382,9 @@ storiesOf("Atoms|Input", module)
       required: {
         default: boolean("required", false, "Props"),
       },
+      requiredMessage: {
+        default: text("requiredMessage", "Required", "Props"),
+      },
       disabled: {
         default: boolean("disabled", false, "Props"),
       },
@@ -319,13 +417,13 @@ storiesOf("Atoms|Input", module)
       :valid="valid"
       :error-message="errorMessage"
       :required="required"
+      :requiredMessage="requiredMessage"
       :disabled="disabled"
       :has-show-password="hasShowPassword"
       aria-label="Input label"
       :hasIcon="hasIcon"
       :icon="icon"
       :colorIcon="colorIcon"
-      :sizeIcon="sizeIcon"
       :helperText="helperText"
       >
       <template #error-message="{errorMessage}">
@@ -365,6 +463,9 @@ storiesOf("Atoms|Input", module)
       required: {
         default: boolean("required", false, "Props"),
       },
+      requiredMessage: {
+        default: text("requiredMessage", "Required", "Props"),
+      },
       disabled: {
         default: boolean("disabled", false, "Props"),
       },
@@ -397,6 +498,7 @@ storiesOf("Atoms|Input", module)
       :valid="valid"
       :error-message="errorMessage"
       :required="required"
+      :requiredMessage="requiredMessage"
       :disabled="disabled"
       aria-label="Input label"
       :has-show-password="hasShowPassword"
@@ -404,7 +506,6 @@ storiesOf("Atoms|Input", module)
       :hasIcon="hasIcon"
       :icon="icon"
       :colorIcon="colorIcon"
-      :sizeIcon="sizeIcon"
       :helperText="helperText"
       />`,
   }));

--- a/packages/vue/src/components/atoms/SfInput/SfInput.stories.js
+++ b/packages/vue/src/components/atoms/SfInput/SfInput.stories.js
@@ -36,7 +36,7 @@ storiesOf("Atoms|Input", module)
         default: text("name", "first-name", "Props"),
       },
       errorMessage: {
-        default: text("errorMessage", "Required.", "Props"),
+        default: text("errorMessage", "Something is wrong", "Props"),
       },
       valid: {
         default: boolean("valid", true, "Props"),
@@ -58,6 +58,9 @@ storiesOf("Atoms|Input", module)
       },
       colorIcon: {
         default: select("colorIcon", ["", ...colors], "", "Props"),
+      }, 
+      helperText: {
+        default: text("helperText", "Password should consist of at least 2 digit, capital letter and special sign", "Props"),
       },
     },
     data() {
@@ -81,6 +84,7 @@ storiesOf("Atoms|Input", module)
       :icon="icon"
       :colorIcon="colorIcon"
       :sizeIcon="sizeIcon"
+      :helperText="helperText"
       />`,
   }))
   .add("[slot] label", () => ({
@@ -110,7 +114,7 @@ storiesOf("Atoms|Input", module)
         default: text("name", "first-name", "Props"),
       },
       errorMessage: {
-        default: text("errorMessage", "Required.", "Props"),
+        default: text("errorMessage", "Something is wrong", "Props"),
       },
       valid: {
         default: boolean("valid", true, "Props"),
@@ -123,6 +127,18 @@ storiesOf("Atoms|Input", module)
       },
       hasShowPassword: {
         default: boolean("hasShowPassword", false, "Props"),
+      },
+      hasIcon: {
+        default: boolean("hasIcon", false, "Props"),
+      },
+      icon: {
+        default: select("icon", iconsNames, "phone", "Props"),
+      },
+      colorIcon: {
+        default: select("colorIcon", ["", ...colors], "", "Props"),
+      },
+      helperText: {
+        default: text("helperText", "Password should consist of at least 2 digit, capital letter and special sign", "Props"),
       },
     },
     data() {
@@ -141,6 +157,11 @@ storiesOf("Atoms|Input", module)
         :disabled="disabled"
         :has-show-password="hasShowPassword"
         aria-label="Input label"
+        :hasIcon="hasIcon"
+        :icon="icon"
+        :colorIcon="colorIcon"
+        :sizeIcon="sizeIcon"
+        :helperText="helperText"
         >
       <template #label="{label}">
             <SfIcon icon="heart_fill" size="10px" style="margin-right: 4px; display: inline-block"/>{{label}}
@@ -174,7 +195,7 @@ storiesOf("Atoms|Input", module)
         default: text("name", "first-name", "Props"),
       },
       errorMessage: {
-        default: text("errorMessage", "Required.", "Props"),
+        default: text("errorMessage", "Something is wrong", "Props"),
       },
       valid: {
         default: boolean("valid", false, "Props"),
@@ -187,6 +208,18 @@ storiesOf("Atoms|Input", module)
       },
       hasShowPassword: {
         default: boolean("hasShowPassword", false, "Props"),
+      },
+      hasIcon: {
+        default: boolean("hasIcon", false, "Props"),
+      },
+      icon: {
+        default: select("icon", iconsNames, "phone", "Props"),
+      },
+      colorIcon: {
+        default: select("colorIcon", ["", ...colors], "", "Props"),
+      },
+      helperText: {
+        default: text("helperText", "Password should consist of at least 2 digit, capital letter and special sign", "Props"),
       },
     },
     data() {
@@ -205,6 +238,11 @@ storiesOf("Atoms|Input", module)
       :disabled="disabled"
       :has-show-password="hasShowPassword"
       aria-label="Input label"
+      :hasIcon="hasIcon"
+      :icon="icon"
+      :colorIcon="colorIcon"
+      :sizeIcon="sizeIcon"
+      :helperText="helperText"
       >
       <template #error-message="{errorMessage}">
         <div>
@@ -241,7 +279,7 @@ storiesOf("Atoms|Input", module)
         default: text("name", "first-name", "Props"),
       },
       errorMessage: {
-        default: text("errorMessage", "Required.", "Props"),
+        default: text("errorMessage", "Something is wrong", "Props"),
       },
       valid: {
         default: boolean("valid", false, "Props"),
@@ -254,6 +292,18 @@ storiesOf("Atoms|Input", module)
       },
       hasShowPassword: {
         default: boolean("hasShowPassword", true, "Props"),
+      },
+      hasIcon: {
+        default: boolean("hasIcon", false, "Props"),
+      },
+      icon: {
+        default: select("icon", iconsNames, "phone", "Props"),
+      },
+      colorIcon: {
+        default: select("colorIcon", ["", ...colors], "", "Props"),
+      },
+      helperText: {
+        default: text("helperText", "Password should consist of at least 2 digit, capital letter and special sign", "Props"),
       },
     },
     data() {
@@ -272,6 +322,11 @@ storiesOf("Atoms|Input", module)
       :disabled="disabled"
       :has-show-password="hasShowPassword"
       aria-label="Input label"
+      :hasIcon="hasIcon"
+      :icon="icon"
+      :colorIcon="colorIcon"
+      :sizeIcon="sizeIcon"
+      :helperText="helperText"
       >
       <template #error-message="{errorMessage}">
         <SfIcon icon="info_shield" size="10px" color="#E22326" style="margin-right: 4px; display: inline-block"/> CUSTOM ERROR MESSAGE
@@ -302,7 +357,7 @@ storiesOf("Atoms|Input", module)
         default: text("name", "first-name", "Props"),
       },
       errorMessage: {
-        default: text("errorMessage", "Required.", "Props"),
+        default: text("errorMessage", "Something is wrong", "Props"),
       },
       valid: {
         default: boolean("valid", true, "Props"),
@@ -315,6 +370,18 @@ storiesOf("Atoms|Input", module)
       },
       hasShowPassword: {
         default: boolean("hasShowPassword", false, "Props"),
+      },
+      hasIcon: {
+        default: boolean("hasIcon", false, "Props"),
+      },
+      icon: {
+        default: select("icon", iconsNames, "phone", "Props"),
+      },
+      colorIcon: {
+        default: select("colorIcon", ["", ...colors], "", "Props"),
+      },
+      helperText: {
+        default: text("helperText", "Password should consist of at least 2 digit, capital letter and special sign", "Props"),
       },
     },
     data() {
@@ -334,5 +401,10 @@ storiesOf("Atoms|Input", module)
       aria-label="Input label"
       :has-show-password="hasShowPassword"
       :class="customClass"
+      :hasIcon="hasIcon"
+      :icon="icon"
+      :colorIcon="colorIcon"
+      :sizeIcon="sizeIcon"
+      :helperText="helperText"
       />`,
   }));

--- a/packages/vue/src/components/atoms/SfInput/SfInput.stories.js
+++ b/packages/vue/src/components/atoms/SfInput/SfInput.stories.js
@@ -4,7 +4,7 @@ import {
   text,
   boolean,
   optionsKnob as options,
-  select
+  select,
 } from "@storybook/addon-knobs";
 import { icons } from "@storefront-ui/shared/icons/icons";
 import { iconColorsValues as colors } from "@storefront-ui/shared/variables/colors";
@@ -61,9 +61,13 @@ storiesOf("Atoms|Input", module)
       },
       colorIcon: {
         default: select("colorIcon", ["", ...colors], "", "Props"),
-      }, 
+      },
       helperText: {
-        default: text("helperText", "Password should consist of at least 2 digit, capital letter and special sign", "Props"),
+        default: text(
+          "helperText",
+          "Password should consist of at least 2 digit, capital letter and special sign",
+          "Props"
+        ),
       },
     },
     data() {
@@ -144,7 +148,11 @@ storiesOf("Atoms|Input", module)
         default: select("colorIcon", ["", ...colors], "", "Props"),
       },
       helperText: {
-        default: text("helperText", "Password should consist of at least 2 digit, capital letter and special sign", "Props"),
+        default: text(
+          "helperText",
+          "Password should consist of at least 2 digit, capital letter and special sign",
+          "Props"
+        ),
       },
     },
     data() {
@@ -228,7 +236,11 @@ storiesOf("Atoms|Input", module)
         default: select("colorIcon", ["", ...colors], "", "Props"),
       },
       helperText: {
-        default: text("helperText", "Password should consist of at least 2 digit, capital letter and special sign", "Props"),
+        default: text(
+          "helperText",
+          "Password should consist of at least 2 digit, capital letter and special sign",
+          "Props"
+        ),
       },
     },
     data() {
@@ -314,7 +326,11 @@ storiesOf("Atoms|Input", module)
         default: select("colorIcon", ["", ...colors], "", "Props"),
       },
       helperText: {
-        default: text("helperText", "Password should consist of at least 2 digit, capital letter and special sign", "Props"),
+        default: text(
+          "helperText",
+          "Password should consist of at least 2 digit, capital letter and special sign",
+          "Props"
+        ),
       },
     },
     data() {
@@ -401,7 +417,11 @@ storiesOf("Atoms|Input", module)
         default: select("colorIcon", ["", ...colors], "", "Props"),
       },
       helperText: {
-        default: text("helperText", "Password should consist of at least 2 digit, capital letter and special sign", "Props"),
+        default: text(
+          "helperText",
+          "Password should consist of at least 2 digit, capital letter and special sign",
+          "Props"
+        ),
       },
     },
     data() {
@@ -482,7 +502,11 @@ storiesOf("Atoms|Input", module)
         default: select("colorIcon", ["", ...colors], "", "Props"),
       },
       helperText: {
-        default: text("helperText", "Password should consist of at least 2 digit, capital letter and special sign", "Props"),
+        default: text(
+          "helperText",
+          "Password should consist of at least 2 digit, capital letter and special sign",
+          "Props"
+        ),
       },
     },
     data() {

--- a/packages/vue/src/components/atoms/SfInput/SfInput.stories.js
+++ b/packages/vue/src/components/atoms/SfInput/SfInput.stories.js
@@ -4,8 +4,12 @@ import {
   text,
   boolean,
   optionsKnob as options,
+  select
 } from "@storybook/addon-knobs";
+import { icons } from "@storefront-ui/shared/icons/icons";
+import { iconColorsValues as colors } from "@storefront-ui/shared/variables/colors";
 import { SfInput, SfIcon } from "@storefront-ui/vue";
+const iconsNames = Object.keys(icons);
 storiesOf("Atoms|Input", module)
   .addDecorator(withKnobs)
   .add("Common", () => ({
@@ -46,6 +50,15 @@ storiesOf("Atoms|Input", module)
       hasShowPassword: {
         default: boolean("hasShowPassword", false, "Props"),
       },
+      hasIcon: {
+        default: boolean("hasIcon", false, "Props"),
+      },
+      icon: {
+        default: select("icon", iconsNames, "phone", "Props"),
+      },
+      colorIcon: {
+        default: select("colorIcon", ["", ...colors], "", "Props"),
+      },
     },
     data() {
       return {
@@ -64,6 +77,10 @@ storiesOf("Atoms|Input", module)
       aria-label="Input label"
       :has-show-password="hasShowPassword"
       :class="customClass"
+      :hasIcon="hasIcon"
+      :icon="icon"
+      :colorIcon="colorIcon"
+      :sizeIcon="sizeIcon"
       />`,
   }))
   .add("[slot] label", () => ({

--- a/packages/vue/src/components/atoms/SfInput/SfInput.vue
+++ b/packages/vue/src/components/atoms/SfInput/SfInput.vue
@@ -61,10 +61,22 @@
         />
       </slot>
     </div>
+    <div class="sf-input__helper-text">
+      <transition name="fade">
+        <!-- @slot Custom error message of form input -->
+        <slot v-if="helperText" name="helper-text" v-bind="{ helperText }">
+          <span>{{ helperText }}</span></slot
+        >
+      </transition>
+    </div>
     <div class="sf-input__error-message">
       <transition name="fade">
         <!-- @slot Custom error message of form input -->
-        <slot v-if="!valid" name="error-message" v-bind="{ errorMessage }">
+        <slot
+          v-if="!valid || required"
+          name="error-message"
+          v-bind="{ errorMessage }"
+        >
           <span>{{ errorMessage }}</span></slot
         >
       </transition>
@@ -163,6 +175,13 @@ export default {
       type: String,
       default: "",
     },
+    /**
+     * helper value of form input.
+     */
+    helperText: {
+      type: String,
+      default: null,
+    },
   },
   data() {
     return {
@@ -209,6 +228,14 @@ export default {
         if (isNaN(value)) {
           this.$emit("input");
         }
+      },
+    },
+    required: {
+      immediate: true,
+      handler: function (required) {
+        required
+          ? (this.errorMessage = `Required ${this.errorMessage}`)
+          : (this.errorMessage = null);
       },
     },
   },

--- a/packages/vue/src/components/atoms/SfInput/SfInput.vue
+++ b/packages/vue/src/components/atoms/SfInput/SfInput.vue
@@ -71,12 +71,14 @@
     </div>
     <div class="sf-input__error-message">
       <transition name="fade">
-        <!-- @slot Custom required message of form input -->
-        <slot name="required-message" v-bind="{ requiredMessage }">
-          <span v-if="required" class="sf-input__error-message--required"
-            >{{ requiredMessage }}
-          </span></slot
-        >
+        <div v-if="required">
+          <!-- @slot Custom required message of form input -->
+          <slot name="required-message" v-bind="{ requiredMessage }">
+            <span class="sf-input__error-message--required"
+              >{{ requiredMessage }}
+            </span></slot
+          >
+        </div>
       </transition>
       <transition name="fade">
         <!-- @slot Custom error message of form input -->

--- a/packages/vue/src/components/atoms/SfInput/SfInput.vue
+++ b/packages/vue/src/components/atoms/SfInput/SfInput.vue
@@ -48,6 +48,18 @@
           ></SfIcon>
         </SfButton>
       </slot>
+      <slot
+        v-if="!(hasShowPassword && type === 'password')"
+        name="icon"
+        v-bind="{ colorIcon, icon }"
+      >
+        <SfIcon
+          v-if="hasIcon"
+          class="sf-input__icon"
+          :color="colorIcon"
+          :icon="icon"
+        />
+      </slot>
     </div>
     <div class="sf-input__error-message">
       <transition name="fade">
@@ -135,6 +147,21 @@ export default {
     hasShowPassword: {
       type: Boolean,
       default: false,
+    },
+    /**
+     * Status and properties of icon display
+     */
+    hasIcon: {
+      type: Boolean,
+      default: false,
+    },
+    icon: {
+      type: String,
+      default: "",
+    },
+    colorIcon: {
+      type: String,
+      default: "",
     },
   },
   data() {

--- a/packages/vue/src/components/atoms/SfInput/SfInput.vue
+++ b/packages/vue/src/components/atoms/SfInput/SfInput.vue
@@ -61,24 +61,28 @@
         />
       </slot>
     </div>
-    <div class="sf-input__helper-text">
+    <div v-if="helperText" class="sf-input__helper-text">
       <transition name="fade">
         <!-- @slot Custom error message of form input -->
-        <slot v-if="helperText" name="helper-text" v-bind="{ helperText }">
+        <slot name="helper-text" v-bind="{ helperText }">
           <span>{{ helperText }}</span></slot
         >
       </transition>
     </div>
     <div class="sf-input__error-message">
       <transition name="fade">
+        <!-- @slot Custom required message of form input -->
+        <slot name="required-message" v-bind="{ requiredMessage }">
+          <span v-if="required" class="sf-input__error-message--required"
+            >{{ requiredMessage }}
+          </span></slot
+        >
+      </transition>
+      <transition name="fade">
         <!-- @slot Custom error message of form input -->
-        <slot
-          v-if="!valid || required"
-          name="error-message"
-          v-bind="{ errorMessage }"
-        >
-          <span>{{ errorMessage }}</span></slot
-        >
+        <slot name="error-message" v-bind="{ errorMessage }">
+          <span v-if="!valid">{{ errorMessage }}</span>
+        </slot>
       </transition>
     </div>
   </div>
@@ -144,6 +148,13 @@ export default {
       type: Boolean,
       default: false,
       description: "Native input required attribute",
+    },
+    /**
+     * Required message value of form input. It will be appeared if `required` is `true`.
+     */
+    requiredMessage: {
+      type: String,
+      default: null,
     },
     /**
      * Native input disabled attribute
@@ -228,14 +239,6 @@ export default {
         if (isNaN(value)) {
           this.$emit("input");
         }
-      },
-    },
-    required: {
-      immediate: true,
-      handler: function (required) {
-        required
-          ? (this.errorMessage = `Required ${this.errorMessage}`)
-          : (this.errorMessage = null);
       },
     },
   },

--- a/packages/vue/src/components/molecules/SfSelect/SfSelect.stories.js
+++ b/packages/vue/src/components/molecules/SfSelect/SfSelect.stories.js
@@ -43,6 +43,9 @@ storiesOf("Molecules|Select", module)
       required: {
         default: boolean("required", false, "Props"),
       },
+      requiredMessage: {
+        default: text("requiredMessage", "Required", "Props"),
+      },
       valid: {
         default: boolean("valid", true, "Props"),
       },
@@ -74,6 +77,7 @@ storiesOf("Molecules|Select", module)
         :label="label"
         :size="size"
         :required="required"
+        :requiredMessage="requiredMessage"
         :valid="valid"
         :disabled="disabled"
         :error-message="errorMessage"
@@ -107,6 +111,9 @@ storiesOf("Molecules|Select", module)
       required: {
         default: boolean("required", false, "Props"),
       },
+      requiredMessage: {
+        default: text("requiredMessage", "Required", "Props"),
+      },
       valid: {
         default: boolean("valid", true, "Props"),
       },
@@ -130,6 +137,7 @@ storiesOf("Molecules|Select", module)
         :label="label"
         :size="size"
         :required="required"
+        :requiredMessage="requiredMessage"
         :valid="valid"
         :disabled="disabled"
         :error-message="errorMessage">
@@ -165,6 +173,9 @@ storiesOf("Molecules|Select", module)
       required: {
         default: boolean("required", false, "Props"),
       },
+      requiredMessage: {
+        default: text("requiredMessage", "Required", "Props"),
+      },
       valid: {
         default: boolean("valid", false, "Props"),
       },
@@ -188,6 +199,7 @@ storiesOf("Molecules|Select", module)
         :label="label"
         :size="size"
         :required="required"
+        :requiredMessage="requiredMessage"
         :valid="valid"
         :disabled="disabled"
         :error-message="errorMessage">
@@ -223,6 +235,9 @@ storiesOf("Molecules|Select", module)
       required: {
         default: boolean("required", false, "Props"),
       },
+      requiredMessage: {
+        default: text("requiredMessage", "Required", "Props"),
+      },
       valid: {
         default: boolean("valid", false, "Props"),
       },
@@ -246,6 +261,7 @@ storiesOf("Molecules|Select", module)
         :label="label"
         :size="size"
         :required="required"
+        :requiredMessage="requiredMessage"
         :valid="valid"
         :disabled="disabled"
         :error-message="errorMessage">

--- a/packages/vue/src/components/molecules/SfSelect/SfSelect.vue
+++ b/packages/vue/src/components/molecules/SfSelect/SfSelect.vue
@@ -49,7 +49,20 @@
         </div>
       </transition>
     </div>
-    <div v-if="valid !== undefined" class="sf-select__error-message">
+    <div
+      v-if="valid !== undefined || required"
+      class="sf-select__error-message"
+    >
+      <transition name="fade">
+        <div v-if="required">
+          <!-- @slot Custom required message of form input -->
+          <slot name="required-message" v-bind="{ requiredMessage }">
+            <span class="sf-select__error-message--required"
+              >{{ requiredMessage }}
+            </span>
+          </slot>
+        </div>
+      </transition>
       <transition name="fade">
         <div v-if="!valid">
           <!-- @slot Custom error message of form select -->
@@ -107,6 +120,13 @@ export default {
     required: {
       type: Boolean,
       default: false,
+    },
+    /**
+     * Required message value of form select. It will be appeared if `required` is `true`.
+     */
+    requiredMessage: {
+      type: String,
+      default: null,
     },
     /**
      * Validate value of form input

--- a/packages/vue/src/examples/pages/checkout/_internal/PersonalDetails.vue
+++ b/packages/vue/src/examples/pages/checkout/_internal/PersonalDetails.vue
@@ -65,6 +65,7 @@
           v-if="createAccount"
           v-model="password"
           :has-show-password="true"
+          required-message="Required"
           type="password"
           label="Create Password"
           class="form__element"

--- a/packages/vue/src/examples/pages/checkout/_internal/PersonalDetails.vue
+++ b/packages/vue/src/examples/pages/checkout/_internal/PersonalDetails.vue
@@ -15,6 +15,7 @@
       <SfInput
         v-model="firstName"
         :value="firstName"
+        required-message="Required"
         label="First name"
         name="firstName"
         class="form__element form__element--half"
@@ -24,6 +25,7 @@
       <SfInput
         v-model="lastName"
         :value="lastName"
+        required-message="Required"
         label="Last name"
         name="lastName"
         class="form__element form__element--half form__element--half-even"
@@ -33,6 +35,7 @@
       <SfInput
         v-model="email"
         :value="email"
+        required-message="Required"
         label="Your email"
         name="email"
         class="form__element"

--- a/packages/vue/src/examples/pages/my-account/_internal/MyProfile.vue
+++ b/packages/vue/src/examples/pages/my-account/_internal/MyProfile.vue
@@ -8,6 +8,7 @@
       <div class="form">
         <SfInput
           v-model="firstName"
+          required-message="Required"
           name="firstName"
           label="First Name"
           required
@@ -15,6 +16,7 @@
         />
         <SfInput
           v-model="lastName"
+          required-message="Required"
           name="lastName"
           label="Last Name"
           required
@@ -22,6 +24,7 @@
         />
         <SfInput
           v-model="email"
+          required-message="Required"
           type="email"
           name="email"
           label="Your e-mail"
@@ -48,6 +51,7 @@
       <div class="form">
         <SfInput
           v-model="currentPassword"
+          required-message="Required"
           type="password"
           name="currentPassword"
           label="Current Password"
@@ -56,6 +60,7 @@
         />
         <SfInput
           v-model="newPassword"
+          required-message="Required"
           type="password"
           name="newPassword"
           label="New Password"
@@ -64,6 +69,7 @@
         />
         <SfInput
           v-model="repeatPassword"
+          required-message="Required"
           type="password"
           name="repeatPassword"
           label="Repeat Password"

--- a/packages/vue/src/examples/pages/my-account/_internal/ShippingDetails.vue
+++ b/packages/vue/src/examples/pages/my-account/_internal/ShippingDetails.vue
@@ -13,6 +13,7 @@
         <div class="form">
           <SfInput
             v-model="firstName"
+            required-message="Required"
             name="firstName"
             label="First Name"
             required
@@ -20,6 +21,7 @@
           />
           <SfInput
             v-model="lastName"
+            required-message="Required"
             name="lastName"
             label="Last Name"
             required
@@ -27,6 +29,7 @@
           />
           <SfInput
             v-model="streetName"
+            required-message="Required"
             name="streetName"
             label="Street Name"
             required
@@ -34,6 +37,7 @@
           />
           <SfInput
             v-model="apartment"
+            required-message="Required"
             name="apartment"
             label="House/Apartment number"
             required
@@ -41,6 +45,7 @@
           />
           <SfInput
             v-model="city"
+            required-message="Required"
             name="city"
             label="City"
             required
@@ -48,6 +53,7 @@
           />
           <SfInput
             v-model="state"
+            required-message="Required"
             name="state"
             label="State/Province"
             required
@@ -55,6 +61,7 @@
           />
           <SfInput
             v-model="zipCode"
+            required-message="Required"
             name="zipCode"
             label="Zip-code"
             required
@@ -62,6 +69,7 @@
           />
           <SfSelect
             v-model="country"
+            required-message="Required"
             name="country"
             label="Country"
             required
@@ -77,6 +85,7 @@
           </SfSelect>
           <SfInput
             v-model="phoneNumber"
+            required-message="Required"
             name="phone"
             label="Phone number"
             required


### PR DESCRIPTION
# Related issue
Closes #1104

# Scope of work
hasIcon, heleperText and requiredMessage props added.
Stories changed accordingly.
requiredMessage props added to myaccount and checkout pages (it doesn't work on shippng details)
![image](https://user-images.githubusercontent.com/32042425/80974302-d2812c80-8e20-11ea-9e6c-5148b7f809c2.png)

add required and helperText to SfSelect component
![image](https://user-images.githubusercontent.com/32042425/80974451-09efd900-8e21-11ea-97fa-658ec6f23685.png)

![image](https://user-images.githubusercontent.com/32042425/80974641-46bbd000-8e21-11ea-962a-1e52466c629c.png)
![image](https://user-images.githubusercontent.com/32042425/80974693-5cc99080-8e21-11ea-907d-13be345cfffc.png)


# Checklist

- [x] No commented blocks of code left
- [ ] Run tests and docs
- [x] Self code-reviewed