### PR TITLE
fix: move add to cart button outside the link

### DIFF
--- a/packages/shared/styles/components/organisms/SfProductCard.scss
+++ b/packages/shared/styles/components/organisms/SfProductCard.scss
@@ -62,8 +62,8 @@
   &__add-button {
     --circle-icon-position: absolute;
     --button-box-shadow: 0px 4px 11px rgba(29, 31, 34, 0.1);
-    right: var(--product-card-add-button-right, 1rem);
-    bottom: var(--product-card-add-button-bottom, 0);
+    right: var(--product-card-add-button-right, 1.5rem);
+    top: var(--product-card-add-button-top, 18.2rem);
     display: var(--product-card-add-button-display, none);
     transform: var(--product-card-add-button-transform, translate3d(0, 50%, 0));
     opacity: var(--product-card-add-button-opacity, 0);
@@ -119,7 +119,7 @@
   }
   @include for-desktop {
     --product-card-max-width: 15.5rem;
-    --product-card-padding: calc(var(--spacer-sm));
+    --product-card-padding: var(--spacer-sm);
     --product-card-title-margin: var(--spacer-xl) 0 0 0;
     --product-card-transition: box-shadow 150ms ease-in-out;
     --product-card-wishlist-icon-top: var(--spacer-lg);

--- a/packages/vue/src/components/organisms/SfProductCard/SfProductCard.vue
+++ b/packages/vue/src/components/organisms/SfProductCard/SfProductCard.vue
@@ -37,49 +37,6 @@
             >{{ badgeLabel }}</SfBadge
           >
         </slot>
-        <template v-if="showAddToCartButton">
-          <slot
-            name="add-to-cart"
-            v-bind="{
-              isAddedToCart,
-              showAddedToCartBadge,
-              isAddingToCart,
-              title,
-            }"
-          >
-            <SfCircleIcon
-              class="sf-product-card__add-button"
-              :aria-label="`Add to Cart ${title}`"
-              :has-badge="showAddedToCartBadge"
-              :disabled="addToCartDisabled"
-              @click="onAddToCart"
-            >
-              <div class="sf-product-card__add-button--icons">
-                <transition
-                  name="sf-product-card__add-button--icons"
-                  mode="out-in"
-                >
-                  <slot v-if="!isAddingToCart" name="add-to-cart-icon">
-                    <SfIcon
-                      key="add_to_cart"
-                      icon="add_to_cart"
-                      size="20px"
-                      color="white"
-                    />
-                  </slot>
-                  <slot v-else name="adding-to-cart-icon">
-                    <SfIcon
-                      key="added_to_cart"
-                      icon="added_to_cart"
-                      size="20px"
-                      color="white"
-                    />
-                  </slot>
-                </transition>
-              </div>
-            </SfCircleIcon>
-          </slot>
-        </template>
       </div>
       <slot name="title" v-bind="{ title }">
         <h3 class="sf-product-card__title">
@@ -87,6 +44,46 @@
         </h3>
       </slot>
     </component>
+    <template v-if="showAddToCartButton">
+      <slot
+        name="add-to-cart"
+        v-bind="{
+          isAddedToCart,
+          showAddedToCartBadge,
+          isAddingToCart,
+          title,
+        }"
+      >
+        <SfCircleIcon
+          class="sf-product-card__add-button"
+          :aria-label="`Add to Cart ${title}`"
+          :has-badge="showAddedToCartBadge"
+          :disabled="addToCartDisabled"
+          @click="onAddToCart"
+        >
+          <div class="sf-product-card__add-button--icons">
+            <transition name="sf-product-card__add-button--icons" mode="out-in">
+              <slot v-if="!isAddingToCart" name="add-to-cart-icon">
+                <SfIcon
+                  key="add_to_cart"
+                  icon="add_to_cart"
+                  size="20px"
+                  color="white"
+                />
+              </slot>
+              <slot v-else name="adding-to-cart-icon">
+                <SfIcon
+                  key="added_to_cart"
+                  icon="added_to_cart"
+                  size="20px"
+                  color="white"
+                />
+              </slot>
+            </transition>
+          </div>
+        </SfCircleIcon>
+      </slot>
+    </template>
     <button
       v-if="wishlistIcon !== false"
       v-focus

--- a/packages/vue/src/examples/pages/category/Category.vue
+++ b/packages/vue/src/examples/pages/category/Category.vue
@@ -100,6 +100,7 @@
             :max-rating="product.rating.max"
             :score-rating="product.rating.score"
             :is-on-wishlist="product.isOnWishlist"
+            :show-add-to-cart-button="true"
             class="products__product-card"
             @click:wishlist="toggleWishlist(i)"
           />


### PR DESCRIPTION
# Related issue
<!-- paste a link to related issue -->
Closes #1130

# Scope of work
<!-- describe what you did -->
- [x] move add to cart button outside the link component
- [x] fix position

# Screenshots of visual changes
<!-- if visual changes applied -->

# Checklist

- [x] No commented blocks of code left
- [x] Run tests and docs
- [x] Self code-reviewed

If applicable:

- [ ] I followed [composition rules](https://docs.storefrontui.io/contributing/coding-guidelines.html#component-rules) for my component
- [ ] I tested the component in most common device sizes (can be tested in Storybook [from viewport addon in top menu](https://github.com/storybooks/storybook/tree/master/addons/viewport))
 - [ ] I accept [Individual Contributor License Agreement](https://github.com/DivanteLtd/next/blob/master/CLA.md)
