### PR TITLE
fix: change button to div on SfBottomNavigation

### DIFF
--- a/packages/shared/styles/components/organisms/SfBottomNavigation.scss
+++ b/packages/shared/styles/components/organisms/SfBottomNavigation.scss
@@ -54,6 +54,10 @@
   &--has-margin {
     --bottom-navigation-item-label-margin: var(--spacer-xs) 0 0 0;
   }
+  &__icon {
+    background: transparent;
+    padding: 0;
+  }
   &--floating {
     --icon-color: var(--c-white);
     & .sf-circle-icon {

--- a/packages/vue/src/components/organisms/SfBottomNavigation/_internal/SfBottomNavigationItem.vue
+++ b/packages/vue/src/components/organisms/SfBottomNavigation/_internal/SfBottomNavigationItem.vue
@@ -1,6 +1,5 @@
 <template>
-  <button
-    v-focus
+  <div
     class="sf-bottom-navigation-item"
     :class="{
       'sf-bottom-navigation-item--active': isActive,
@@ -16,12 +15,12 @@
         icon-color="white"
         icon-size="28px"
       />
-      <SfIcon
+      <SfButton
         v-else-if="icon"
-        :icon="currentIcon"
-        :size="iconSize"
-        class="sf-bottom-navigation-item__icon"
-      />
+        class="sf-button--pure sf-bottom-navigation-item__icon"
+      >
+        <SfIcon :icon="currentIcon" :size="iconSize" />
+      </SfButton>
     </slot>
     <slot name="label" v-bind="{ label }">
       <div
@@ -34,11 +33,12 @@
         {{ label }}
       </div>
     </slot>
-  </button>
+  </div>
 </template>
 <script>
 import SfIcon from "../../../atoms/SfIcon/SfIcon.vue";
 import SfCircleIcon from "../../../atoms/SfCircleIcon/SfCircleIcon.vue";
+import SfButton from "../../../atoms/SfButton/SfButton.vue";
 import { focus } from "../../../../utilities/directives/focus-directive.js";
 export default {
   name: "SfBottomNavigationItem",
@@ -46,6 +46,7 @@ export default {
   components: {
     SfCircleIcon,
     SfIcon,
+    SfButton,
   },
   props: {
     icon: {


### PR DESCRIPTION
# Related issue
<!-- paste a link to related issue -->
Closes #
Related: https://github.com/DivanteLtd/next/issues/427
# Scope of work
<!-- describe what you did -->
- [x] SfBottomNavigationItem changed to `div`

SfBottomNavigationItem cant be a button because inside there is a SfCircleIcon which is a button. Click on SfBottomNavigation only moves click event to the button so from the a11y side everything is working fine.

# Screenshots of visual changes
<!-- if visual changes applied -->

# Checklist

- [ ] No commented blocks of code left
- [ ] Run tests and docs
- [ ] Self code-reviewed

If applicable:

- [ ] I followed [composition rules](https://docs.storefrontui.io/contributing/coding-guidelines.html#component-rules) for my component
- [ ] I tested the component in most common device sizes (can be tested in Storybook [from viewport addon in top menu](https://github.com/storybooks/storybook/tree/master/addons/viewport))
 - [ ] I accept [Individual Contributor License Agreement](https://github.com/DivanteLtd/next/blob/master/CLA.md)
