### PR TITLE
fix(a11y): order of SfQuantitySelector in SfAddToCart

### DIFF
--- a/packages/shared/styles/components/molecules/SfAddToCart.scss
+++ b/packages/shared/styles/components/molecules/SfAddToCart.scss
@@ -5,18 +5,16 @@
     --button-font-weight: var(--font-semibold);
     --button-width: 100%;
     align-items: center;
-    order: var(--add-to-cart-button-order);
     &:disabled {
       color: var(--c-text-disabled);
     }
   }
   &__select-quantity {
+    --add-to-cart-select-quantity-margin: 0 var(--spacer-sm) 0 0;
     flex: none;
     margin: var(--add-to-cart-select-quantity-margin, 0 0 0 var(--spacer-xs));
   }
   @include for-desktop {
-    --add-to-cart-button-order: 1;
-    --add-to-cart-select-quantity-margin: 0 var(--spacer-sm) 0 0;
     --add-to-cart-select-quantity-display: flex;
   }
 }

--- a/packages/vue/src/components/molecules/SfAddToCart/SfAddToCart.vue
+++ b/packages/vue/src/components/molecules/SfAddToCart/SfAddToCart.vue
@@ -1,5 +1,14 @@
 <template>
   <div aria-labelledby="AddToCart" class="sf-add-to-cart">
+    <slot name="quantity-select-input" v-bind="{ qty }">
+      <SfQuantitySelector
+        :qty="qty"
+        aria-label="Quantity"
+        :disabled="disabled"
+        class="sf-add-to-cart__select-quantity"
+        @input="$emit('input', $event)"
+      />
+    </slot>
     <slot name="add-to-cart-btn">
       <!--@slot Custom content that will replace default Add to cart button design.-->
       <SfButton
@@ -10,15 +19,6 @@
       >
         Add to cart
       </SfButton>
-    </slot>
-    <slot name="quantity-select-input" v-bind="{ qty }">
-      <SfQuantitySelector
-        :qty="qty"
-        aria-label="Quantity"
-        :disabled="disabled"
-        class="sf-add-to-cart__select-quantity"
-        @input="$emit('input', $event)"
-      />
     </slot>
   </div>
 </template>


### PR DESCRIPTION
# Related issue
<!-- paste a link to related issue -->
https://github.com/DivanteLtd/next/issues/425
Closes #1083

# Scope of work
<!-- describe what you did -->
SfQuantitySelector is always before SfButton "Add to cart". For mobile, you should use SfBottomNavigation to Add To Cart. 

# Screenshots of visual changes
<!-- if visual changes applied -->

# Checklist

- [x] No commented blocks of code left
- [x] Run tests and docs
- [x] Self code-reviewed

If applicable:

- [x] I followed [composition rules](https://docs.storefrontui.io/contributing/coding-guidelines.html#component-rules) for my component
- [x] I tested the component in most common device sizes (can be tested in Storybook [from viewport addon in top menu](https://github.com/storybooks/storybook/tree/master/addons/viewport))
 - [x] I accept [Individual Contributor License Agreement](https://github.com/DivanteLtd/next/blob/master/CLA.md)
