### PR TITLE
a11y: clickable elements visible on focus

### DIFF
--- a/packages/shared/styles/components/organisms/SfCollectedProduct.scss
+++ b/packages/shared/styles/components/organisms/SfCollectedProduct.scss
@@ -18,6 +18,9 @@
     opacity: var(--collected-product-remove-opacity);
     right: var(--collected-product-remove-right, var(--spacer-xs));
     transition: var(--collected-product-remove-transition);
+    &:focus {
+      --collected-product-remove-opacity: 1;
+    }
     &--circle-icon {
       top: var(--collected-product-remove-top);
       display: var(--collected-product-remove-circle-icon-display, none);
@@ -107,11 +110,6 @@
           --collected-product-box-shadow,
           0px 4px 11px rgba(var(--c-dark-base), 0.1)
         );
-      }
-    }
-    &__remove {
-      &:focus {
-        --collected-product-remove-opacity: 1;
       }
     }
     &__aside {

--- a/packages/shared/styles/components/organisms/SfCollectedProduct.scss
+++ b/packages/shared/styles/components/organisms/SfCollectedProduct.scss
@@ -109,6 +109,11 @@
         );
       }
     }
+    &__remove {
+      &:focus {
+        --collected-product-remove-opacity: 1;
+      }
+    }
     &__aside {
       flex: 0 0 8.75rem;
     }

--- a/packages/shared/styles/components/organisms/SfProductCard.scss
+++ b/packages/shared/styles/components/organisms/SfProductCard.scss
@@ -67,6 +67,9 @@
     display: var(--product-card-add-button-display, none);
     transform: var(--product-card-add-button-transform, translate3d(0, 50%, 0));
     opacity: var(--product-card-add-button-opacity, 0);
+    &:focus {
+      --product-card-add-button-opacity: 1;
+    }
     &--icons-enter-active {
       animation: var(--product-card-add-button-enter-animation, bounce 0.4s);
     }
@@ -113,6 +116,9 @@
       opacity 150ms ease-in-out
     );
     cursor: pointer;
+    &:focus {
+      --product-card-wishlist-icon-opacity: 1;
+    }
   }
   &--on-wishlist {
     --product-card-wishlist-icon-opacity: 1;

--- a/packages/vue/src/examples/pages/cart/Cart.vue
+++ b/packages/vue/src/examples/pages/cart/Cart.vue
@@ -41,12 +41,12 @@
                 <template #actions>
                   <div class="desktop-only collected-product__actions">
                     <SfButton
-                      class="sf-button--text color-secondary collected-product__action"
+                      class="sf-button--text color-secondary collected-product__save"
                     >
                       Save for later
                     </SfButton>
                     <SfButton
-                      class="sf-button--text color-secondary collected-product__action"
+                      class="sf-button--text color-secondary collected-product__compare"
                     >
                       Add to compare
                     </SfButton>
@@ -246,13 +246,24 @@ export default {
   }
   &__actions {
     transition: opacity 150ms ease-in-out;
-    opacity: var(--cp-actions-opacity, 0);
   }
-  &__action {
+  &__save,
+  &__compare {
     --button-padding: 0;
+    &:focus {
+      --cp-save-opacity: 1;
+      --cp-compare-opacity: 1;
+    }
+  }
+  &__save {
+    opacity: var(--cp-save-opacity, 0);
+  }
+  &__compare {
+    opacity: var(--cp-compare-opacity, 0);
   }
   &:hover {
-    --cp-actions-opacity: 1;
+    --cp-save-opacity: 1;
+    --cp-compare-opacity: 1;
   }
 }
 </style>


### PR DESCRIPTION
# Related issue
Closes #

# Scope of work
Elements that are visible only on hover now they are visible also on focus

# Screenshots of visual changes

![Zrzut ekranu z 2020-05-04 13-49-52](https://user-images.githubusercontent.com/46591755/80962933-48c86380-8e0e-11ea-863e-e38c3d66d28e.png)
![Zrzut ekranu z 2020-05-04 13-50-12](https://user-images.githubusercontent.com/46591755/80962976-58e04300-8e0e-11ea-9c3c-5f62be50346d.png)
![Zrzut ekranu z 2020-05-04 13-50-31](https://user-images.githubusercontent.com/46591755/80962991-5f6eba80-8e0e-11ea-9ba5-924d4e648b0c.png)
