### PR TITLE
fix: noscript fallback for SfImage

### DIFF
--- a/packages/shared/styles/components/atoms/SfImage.scss
+++ b/packages/shared/styles/components/atoms/SfImage.scss
@@ -36,6 +36,7 @@
     padding: var(--image-ovarlay-padding, var(--spacer-sm));
     background: var(--image-ovarlay-background, rgba(var(--c-dark-base), 0.6));
     color: var(--image-overlay-color, var(--c-white));
+    opacity: var(--image-overlay-opacity, 0);
     @include font(
       --image-overlay-font,
       var(--font-light),
@@ -43,5 +44,9 @@
       1.6,
       var(--font-family-secondary)
     );
+    transition: opacity 150ms ease-in-out;
+  }
+  &:hover{
+    --image-overlay-opacity: 1
   }
 }

--- a/packages/vue/src/components/atoms/SfImage/SfImage.vue
+++ b/packages/vue/src/components/atoms/SfImage/SfImage.vue
@@ -4,8 +4,6 @@
     :class="{ 'sf-image--has-size': size && source }"
     :style="size"
     v-on="$listeners"
-    @mouseover="isHovered = true"
-    @mouseleave="isHovered = false"
   >
     <template v-if="isPicture">
       <picture>
@@ -81,7 +79,6 @@ export default {
   data() {
     return {
       isLoaded: false,
-      isHovered: false,
     };
   },
   computed: {

--- a/packages/vue/src/components/atoms/SfImage/SfImage.vue
+++ b/packages/vue/src/components/atoms/SfImage/SfImage.vue
@@ -1,23 +1,13 @@
 <template>
   <div
     class="sf-image"
-    :class="{ 'sf-image--has-size': wrapper }"
-    :style="wrapper"
+    :class="{ 'sf-image--has-size': size && source }"
+    :style="size"
     v-on="$listeners"
-    @mouseover="overlay = true"
-    @mouseleave="overlay = false"
+    @mouseover="isHovered = true"
+    @mouseleave="isHovered = false"
   >
-    <template v-if="typeof source === 'string'">
-      <img
-        v-if="show"
-        ref="image"
-        :src="source"
-        :alt="alt"
-        :width="width"
-        :height="height"
-      />
-    </template>
-    <template v-else>
+    <template v-if="isPicture">
       <picture>
         <source
           :srcset="source.desktop.url"
@@ -25,49 +15,55 @@
         />
         <source
           :srcset="source.mobile.url"
-          :media="`(max-width: ${pictureBreakpoint}px)`"
+          :media="`(max-width: ${pictureBreakpoint - 1}px)`"
         />
         <img
-          v-if="show"
-          ref="image"
-          :src="source"
-          :alt="alt"
+          v-show="source.desktop.url"
+          :src="source.desktop.url"
+          v-bind="$attrs"
           :width="width"
           :height="height"
         />
       </picture>
     </template>
-    <transition name="fade">
-      <div v-if="showOverlay" class="sf-image__overlay">
-        <slot />
-      </div>
-    </transition>
+    <template v-else>
+      <img
+        v-show="source"
+        :src="source"
+        v-bind="$attrs"
+        :width="width"
+        :height="height"
+      />
+    </template>
+    <noscript v-if="lazy" inline-template>
+      <img :src="noscript" v-bind="$attrs" :width="width" :height="height" />
+    </noscript>
+    <div v-if="hasOverlay" class="sf-image__overlay">
+      <slot />
+    </div>
   </div>
 </template>
 <script>
 import lozad from "lozad";
 export default {
   name: "SfImage",
+  inheritAttrs: false,
   props: {
     src: {
       type: [String, Object],
-      default: () => ({ mobile: { url: "" }, desktop: { url: "" } }),
-    },
-    alt: {
-      type: String,
       default: "",
-    },
-    width: {
-      type: [String, Number],
-      default: undefined,
-    },
-    height: {
-      type: [String, Number],
-      default: undefined,
     },
     lazy: {
       type: Boolean,
       default: true,
+    },
+    width: {
+      type: [String, Number],
+      default: null,
+    },
+    height: {
+      type: [String, Number],
+      default: null,
     },
     pictureBreakpoint: {
       type: Number,
@@ -84,61 +80,51 @@ export default {
   },
   data() {
     return {
-      show: false,
-      overlay: false,
+      isLoaded: false,
+      isHovered: false,
     };
   },
   computed: {
+    isPicture() {
+      return typeof this.src === "object";
+    },
     source() {
-      let src = this.src || "";
-      if (typeof src === "object") {
-        if (!src.desktop || !src.mobile) {
-          const object = src.desktop || src.mobile || { url: "" };
-          src = object.url;
-        }
-      }
-      return src;
+      const allow =
+        (this.isLoaded && this.lazy) || (!this.isLoaded && !this.lazy);
+      const disallow = this.isPicture
+        ? { desktop: { url: null }, mobile: { url: null } }
+        : null;
+      return allow ? this.src : disallow;
     },
-    showOverlay() {
-      return this.$slots.default && this.overlay;
+    noscript() {
+      return this.isPicture ? this.src.desktop.url : this.src;
     },
-    wrapper() {
+    size() {
       return (
         this.width &&
-        this.height &&
-        `--_image-width: ${this.width}; --_image-height: ${this.height}`
+        this.height && {
+          "--_image-width": this.width,
+          "--_image-height": this.height,
+        }
       );
     },
-  },
-  watch: {
-    lazy: {
-      handler(value) {
-        this.show = !value;
-      },
-      immediate: true,
+    hasOverlay() {
+      return this.$slots.default;
     },
   },
   mounted() {
-    if (!this.lazy) {
-      this.show = true;
-      return;
-    }
-    this.lozad();
-  },
-  methods: {
-    lozad() {
-      const vm = this;
-      this.$nextTick(() => {
-        const observer = lozad(vm.$el, {
-          load() {
-            vm.show = true;
-          },
-          rootMargin: this.rootMargin,
-          threshold: this.threshold,
-        });
-        observer.observe();
+    if (!this.lazy) return;
+    const vm = this;
+    this.$nextTick(() => {
+      const observer = lozad(vm.$el, {
+        load() {
+          vm.isLoaded = true;
+        },
+        rootMargin: vm.rootMargin,
+        threshold: vm.threshold,
       });
-    },
+      observer.observe();
+    });
   },
 };
 </script>


### PR DESCRIPTION
# Related issue
<!-- paste a link to related issue -->
https://github.com/DivanteLtd/next/issues/398
Closes #1066

# Scope of work
<!-- describe what you did -->
added `noscript` fallback image only for lazy-loaded images and add few improvements

# Screenshots of visual changes
<!-- if visual changes applied -->

# Checklist

- [x] No commented blocks of code left
- [x] Run tests and docs
- [x] Self code-reviewed

If applicable:

- [x] I followed [composition rules](https://docs.storefrontui.io/contributing/coding-guidelines.html#component-rules) for my component
- [x] I tested the component in most common device sizes (can be tested in Storybook [from viewport addon in top menu](https://github.com/storybooks/storybook/tree/master/addons/viewport))
 - [x] I accept [Individual Contributor License Agreement](https://github.com/DivanteLtd/next/blob/master/CLA.md)
