### PR TITLE
[docs] Fixed broken links from the documentation

### DIFF
--- a/packages/vue/docs/customization.md
+++ b/packages/vue/docs/customization.md
@@ -1,6 +1,6 @@
 # How to customize Storefront UI components
 
-One of the key goals of Storefront Ui is to provide you with a ready to use design system that will you allow to recreate almost every design. 
+One of the key goals of Storefront Ui is to provide you with a ready to use design system that will you allow to recreate almost every design.
 
 Below you can read how you can customize different aspects of its styles and components.
 
@@ -8,8 +8,8 @@ Below you can read how you can customize different aspects of its styles and com
 
 ## Intro to CSS Custom Properties
 CSS Custom Properties (or so called CSS variables) are extremaly powerful and have a great inpact on how we write and structure our styles. We decided to migrate from SCSS to CSS variables for many reasons:
-- **Easy-theming** 
-You can easily overwrite any variable as they are dynamic (unlike variables defined using preprocessors). All elements that use the variable will automatically reflect the change. 
+- **Easy-theming**
+You can easily overwrite any variable as they are dynamic (unlike variables defined using preprocessors). All elements that use the variable will automatically reflect the change.
 ```css
 .sf-button {
   background: var(--button-background, var(--c-primary));
@@ -60,7 +60,7 @@ And how it looks now, thanks to the power of CSS Custom Properties:
 To learn more about CSS variables and the default approach we use check out [MDN web docs](https://developer.mozilla.org/docs/Web/CSS/Using_CSS_custom_properties)
 
 ## Customizing styles
-In most scenarios, when you're designing a new app you're starting with a style guide. A style guide is a set of common design standards and principles used in a whole project. It usually covers things such as typography or colors. 
+In most scenarios, when you're designing a new app you're starting with a style guide. A style guide is a set of common design standards and principles used in a whole project. It usually covers things such as typography or colors.
 
 We can represent style guide as a set of global CSS variables. By using them we are abstracting visual configuration from html and CSS structure to declarative variables. Thank to this approach we can ship updates to Storefront UI without breaking your projects.
 
@@ -71,7 +71,7 @@ You can override them to shape the look and feel of your project. There are two 
     --font-family-primary: 'Raleway', serif;
 }
 ```
-- **Component-specific** variables are meant to customize behavior of certain component type (like `SfButton`) and cover edge cases of any project. 
+- **Component-specific** variables are meant to customize behavior of certain component type (like `SfButton`) and cover edge cases of any project.
 For example, the following code will change default (not modified by other CSS rules) background color of every `SfButton` component in your project to `red`.
 ```css
 .sf-button {
@@ -84,18 +84,18 @@ And this code will change `width` of icon inside `SfArrow` to `2rem`.
 .sf-arrow {
   --icon-width: 2rem;
 }
-```    
+```
 
-## Global variables 
+## Global variables
 **You can override any global variable as well as  component-specific variables.**
 
 Below you can find more information about global variables for **typography, layout variables (spacers) and colors.**
-To find the components variables to override, go to [Components documentation](https://docs.storefrontui.io/components). 
+To find the components variables to override, go to [Components documentation](https://docs.storefrontui.io/components/accordion.html).
 
 ### Typography
 <<< @/../shared/styles/variables/_typography.scss
 
-### Spacers 
+### Spacers
 <<< @/../shared/styles/variables/_layout.scss
 
 ### Colors
@@ -121,7 +121,7 @@ This code:
 
 ```scss
 @include generate-color-variants(--_c-green-primary, #5ece7b);
-``` 
+```
 
 will generate the following variables:
 
@@ -140,7 +140,7 @@ Once we have generated all the internal color variants, we can assign them to th
 
 ```scss
 @include assign-color-variants(--c-primary, --_c-green-primary);
-``` 
+```
 
 This code will generate the following variables:
 
@@ -151,7 +151,7 @@ This code will generate the following variables:
 --c-primary-darken: var(--_c-green-primary-darken);
 ```
 
-#### How to override color variables? 
+#### How to override color variables?
 
 :::tip For example:
 ```scss
@@ -175,7 +175,7 @@ This code will generate the following variables:
 Even though global and component-specific variables are providing decent level of customization, there might be edge cases that a user would like to cover as well.
 You can achieve that with vue slots.
 
-Almost every Storefront UI component is divided into sections (following BEM convention). Each of them is wrapped into a Vue slot to let you replace parts of it's HTML. 
+Almost every Storefront UI component is divided into sections (following BEM convention). Each of them is wrapped into a Vue slot to let you replace parts of it's HTML.
 
 Take a look at below example. This is how `SfPagination` component look like out of the box:
 
@@ -183,16 +183,16 @@ Take a look at below example. This is how `SfPagination` component look like out
 
 ````html
 
-<SfPagination 
-  :current="currentPage" 
-  :total="20" 
-  :visible="5"  
+<SfPagination
+  :current="currentPage"
+  :total="20"
+  :visible="5"
   @click="page => currentPage = page"
 />
 
 ````
 
-Let's say we want to display `prev` and `next` buttons instead of default arrow icons. 
+Let's say we want to display `prev` and `next` buttons instead of default arrow icons.
 
 In component documentation we can read that it has `next` and `prev` slots. We can use them to add our custom behavior. For every slot you have access to methods and data properties related to it's functionality via slot scope. In our case it would be `go` function that will move forward/backward and `isDisabled` property that tells us if there is a next or previous page.
 We can use the latest to disable buttons when they're not usable.

--- a/packages/vue/src/components/molecules/SfAddToCart/SfAddToCart.md
+++ b/packages/vue/src/components/molecules/SfAddToCart/SfAddToCart.md
@@ -1,5 +1,5 @@
 # component-description
-Add-to-cart [button](Button.html) and quantity input field with maximum stock validation.
+Add-to-cart [button](button.html) and quantity input field with maximum stock validation.
 
 # storybook-iframe-height
 5rem

--- a/packages/vue/src/components/molecules/SfBanner/SfBanner.md
+++ b/packages/vue/src/components/molecules/SfBanner/SfBanner.md
@@ -1,5 +1,5 @@
 # component-description
-Banner component which features various text levels, a background and a [button](Button.html).
+Banner component which features various text levels, a background and a [button](button.html).
 
 # storybook-iframe-height
 10rem


### PR DESCRIPTION
# Related issue
https://github.com/DivanteLtd/storefront-ui/issues/1157

# Scope of work
<!-- describe what you did -->
Fixed broken links with below pages
- [Customization](packages/vue/docs/customization.md)
- [AddToCart](packages/vue/src/components/molecules/SfAddToCart/SfAddToCart.md) component
- [Banner](packages/vue/src/components/molecules/SfBanner/SfBanner.md) component

# Screenshots of visual changes
<!-- if visual changes applied -->
![image](https://user-images.githubusercontent.com/9442993/81202360-1d976d00-8fe4-11ea-888f-45acfac464ff.png)
![image](https://user-images.githubusercontent.com/9442993/81202388-2ab45c00-8fe4-11ea-9b16-fb936c73f2ed.png)
![image](https://user-images.githubusercontent.com/9442993/81202420-34d65a80-8fe4-11ea-8849-c601be772a37.png)


# Checklist

- [ ] No commented blocks of code left
- [X] Run tests and docs
- [X] Self code-reviewed

If applicable:

- [ ] I followed [composition rules](https://docs.storefrontui.io/contributing/coding-guidelines.html#component-rules) for my component
- [X] I tested the component in most common device sizes (can be tested in Storybook [from viewport addon in top menu](https://github.com/storybooks/storybook/tree/master/addons/viewport))
 - [X] I accept [Individual Contributor License Agreement](https://github.com/DivanteLtd/next/blob/master/CLA.md)
