### PR TITLE
fix: button add to card on SfProductCard

### DIFF
--- a/packages/shared/styles/components/organisms/SfProductCard.scss
+++ b/packages/shared/styles/components/organisms/SfProductCard.scss
@@ -29,6 +29,11 @@
   &:active {
     --product-card-box-shadow: 0px 4px 11px rgba(29, 31, 34, 0.1);
   }
+  &__link {
+    display: block;
+    line-height: 0;
+    text-decoration: none;
+  }
   &__title {
     margin: var(--product-card-title-margin, var(--spacer-xs) 0 0 0);
     @include font(
@@ -41,7 +46,6 @@
   }
   &__image-wrapper {
     position: relative;
-    display: flex;
   }
   &__image,
   &__picture {
@@ -62,8 +66,8 @@
   &__add-button {
     --circle-icon-position: absolute;
     --button-box-shadow: 0px 4px 11px rgba(29, 31, 34, 0.1);
-    right: var(--product-card-add-button-right, 1.5rem);
-    top: var(--product-card-add-button-top, 18.2rem);
+    right: var(--product-card-add-button-right, 1rem);
+    bottom: var(--product-card-add-button-bottom, 0);
     display: var(--product-card-add-button-display, none);
     transform: var(--product-card-add-button-transform, translate3d(0, 50%, 0));
     opacity: var(--product-card-add-button-opacity, 0);

--- a/packages/vue/src/components/organisms/SfProductCard/SfProductCard.vue
+++ b/packages/vue/src/components/organisms/SfProductCard/SfProductCard.vue
@@ -1,13 +1,7 @@
 <template>
   <div class="sf-product-card">
-    <component
-      :is="linkComponentTag"
-      v-focus
-      :href="linkComponentTag === 'a' ? link : undefined"
-      :to="link && linkComponentTag !== 'a' ? link : undefined"
-      class="sf-product-card__link"
-    >
-      <div class="sf-product-card__image-wrapper">
+    <div class="sf-product-card__image-wrapper">
+      <SfLink class="sf-product-card__link" :link="link">
         <slot name="image" v-bind="{ image, title }">
           <template v-if="Array.isArray(image)">
             <SfImage
@@ -29,61 +23,66 @@
             :height="imageHeight"
           />
         </slot>
-        <slot name="badge" v-bind="{ badgeLabel, badgeColor }">
-          <SfBadge
-            v-if="badgeLabel"
-            class="sf-product-card__badge"
-            :class="badgeColorClass"
-            >{{ badgeLabel }}</SfBadge
+      </SfLink>
+      <slot name="badge" v-bind="{ badgeLabel, badgeColor }">
+        <SfBadge
+          v-if="badgeLabel"
+          class="sf-product-card__badge"
+          :class="badgeColorClass"
+          >{{ badgeLabel }}</SfBadge
+        >
+      </slot>
+      <template v-if="showAddToCartButton">
+        <slot
+          name="add-to-cart"
+          v-bind="{
+            isAddedToCart,
+            showAddedToCartBadge,
+            isAddingToCart,
+            title,
+          }"
+        >
+          <SfCircleIcon
+            class="sf-product-card__add-button"
+            :aria-label="`Add to Cart ${title}`"
+            :has-badge="showAddedToCartBadge"
+            :disabled="addToCartDisabled"
+            @click="onAddToCart"
           >
+            <div class="sf-product-card__add-button--icons">
+              <transition
+                name="sf-product-card__add-button--icons"
+                mode="out-in"
+              >
+                <slot v-if="!isAddingToCart" name="add-to-cart-icon">
+                  <SfIcon
+                    key="add_to_cart"
+                    icon="add_to_cart"
+                    size="20px"
+                    color="white"
+                  />
+                </slot>
+                <slot v-else name="adding-to-cart-icon">
+                  <SfIcon
+                    key="added_to_cart"
+                    icon="added_to_cart"
+                    size="20px"
+                    color="white"
+                  />
+                </slot>
+              </transition>
+            </div>
+          </SfCircleIcon>
         </slot>
-      </div>
+      </template>
+    </div>
+    <SfLink class="sf-product-card__link" :link="link">
       <slot name="title" v-bind="{ title }">
         <h3 class="sf-product-card__title">
           {{ title }}
         </h3>
       </slot>
-    </component>
-    <template v-if="showAddToCartButton">
-      <slot
-        name="add-to-cart"
-        v-bind="{
-          isAddedToCart,
-          showAddedToCartBadge,
-          isAddingToCart,
-          title,
-        }"
-      >
-        <SfCircleIcon
-          class="sf-product-card__add-button"
-          :aria-label="`Add to Cart ${title}`"
-          :has-badge="showAddedToCartBadge"
-          :disabled="addToCartDisabled"
-          @click="onAddToCart"
-        >
-          <div class="sf-product-card__add-button--icons">
-            <transition name="sf-product-card__add-button--icons" mode="out-in">
-              <slot v-if="!isAddingToCart" name="add-to-cart-icon">
-                <SfIcon
-                  key="add_to_cart"
-                  icon="add_to_cart"
-                  size="20px"
-                  color="white"
-                />
-              </slot>
-              <slot v-else name="adding-to-cart-icon">
-                <SfIcon
-                  key="added_to_cart"
-                  icon="added_to_cart"
-                  size="20px"
-                  color="white"
-                />
-              </slot>
-            </transition>
-          </div>
-        </SfCircleIcon>
-      </slot>
-    </template>
+    </SfLink>
     <SfButton
       v-if="wishlistIcon !== false"
       :aria-label="`${ariaLabel} ${title}`"
@@ -132,7 +131,9 @@
 <script>
 import { focus } from "../../../utilities/directives/focus-directive.js";
 import { colorsValues as SF_COLORS } from "@storefront-ui/shared/variables/colors";
+import { deprecationWarning } from "../../../utilities/helpers/deprecation-warning.js";
 import SfIcon from "../../atoms/SfIcon/SfIcon.vue";
+import SfLink from "../../atoms/SfLink/SfLink.vue";
 import SfPrice from "../../atoms/SfPrice/SfPrice.vue";
 import SfRating from "../../atoms/SfRating/SfRating.vue";
 import SfImage from "../../atoms/SfImage/SfImage.vue";
@@ -146,6 +147,7 @@ export default {
     SfRating,
     SfIcon,
     SfImage,
+    SfLink,
     SfCircleIcon,
     SfBadge,
     SfButton,
@@ -208,6 +210,7 @@ export default {
      * Link element tag
      * By default it'll be 'router-link' if Vue Router
      * is available on instance, or 'a' otherwise.
+     * @deprecated will be removed in 1.0.0 use SfLink instead
      */
     linkTag: {
       type: String,
@@ -323,6 +326,10 @@ export default {
       }`;
     },
     linkComponentTag() {
+      deprecationWarning(
+        this.$options.name,
+        "Prop 'linkTag' has been deprecated and will be removed in v1.0.0. Use 'SfLink' instead."
+      );
       if (this.linkTag) {
         return this.linkTag;
       }


### PR DESCRIPTION
# Related issue
<!-- paste a link to related issue -->
Closes #

# Scope of work
<!-- describe what you did -->
- [x] Restored styles for floating Add to cart button
- [x] Made separate SfLink for image and title

After some research and discussions, I decided to fix SfProductCard links as simple as possible without complicated hacks. According to other ecommerce solutions and our UX designer @mbaran-dvnt, title and image should be linkable. So the best way is to make these two elements as separate links.
If someone finds here better solution taking our case into account, feel free to comment :)


# Screenshots of visual changes
<!-- if visual changes applied -->

# Checklist

- [x] No commented blocks of code left
- [x] Run tests and docs
- [x] Self code-reviewed

If applicable:

- [ ] I followed [composition rules](https://docs.storefrontui.io/contributing/coding-guidelines.html#component-rules) for my component
- [ ] I tested the component in most common device sizes (can be tested in Storybook [from viewport addon in top menu](https://github.com/storybooks/storybook/tree/master/addons/viewport))
 - [ ] I accept [Individual Contributor License Agreement](https://github.com/DivanteLtd/next/blob/master/CLA.md)
