### PR TITLE
fix: specificity for cancel button in SfDropdown

### DIFF
--- a/packages/shared/styles/components/molecules/SfDropdown.scss
+++ b/packages/shared/styles/components/molecules/SfDropdown.scss
@@ -48,6 +48,7 @@
   &__cancel,
   &__title {
     @include for-desktop {
+      --button-display: none;
       display: none;
     }
   }


### PR DESCRIPTION
# Related issue
<!-- paste a link to related issue -->
Closes #

# Scope of work
<!-- describe what you did -->

# Screenshots of visual changes
<!-- if visual changes applied -->

# Checklist

- [ ] No commented blocks of code left
- [ ] Run tests and docs
- [ ] Self code-reviewed

If applicable:

- [ ] I followed [composition rules](https://docs.storefrontui.io/contributing/coding-guidelines.html#component-rules) for my component
- [ ] I tested the component in most common device sizes (can be tested in Storybook [from viewport addon in top menu](https://github.com/storybooks/storybook/tree/master/addons/viewport))
 - [ ] I accept [Individual Contributor License Agreement](https://github.com/DivanteLtd/next/blob/master/CLA.md)
