### PR TITLE
fix: revert image refs in SfImage

### DIFF
--- a/packages/vue/src/components/atoms/SfImage/SfImage.vue
+++ b/packages/vue/src/components/atoms/SfImage/SfImage.vue
@@ -17,6 +17,7 @@
         />
         <img
           v-show="source.desktop.url"
+          ref="image"
           :src="source.desktop.url"
           v-bind="$attrs"
           :width="width"
@@ -27,6 +28,7 @@
     <template v-else>
       <img
         v-show="source"
+        ref="image"
         :src="source"
         v-bind="$attrs"
         :width="width"


### PR DESCRIPTION
# Scope of work
<!-- describe what you did -->
Revert ref="image" to SfImage. It's used in SfGallery for zoom feat
# Checklist

- [x] No commented blocks of code left
- [x] Run tests and docs
- [x] Self code-reviewed

If applicable:

- [x] I followed [composition rules](https://docs.storefrontui.io/contributing/coding-guidelines.html#component-rules) for my component
- [x] I tested the component in most common device sizes (can be tested in Storybook [from viewport addon in top menu](https://github.com/storybooks/storybook/tree/master/addons/viewport))
 - [ ] I accept [Individual Contributor License Agreement](https://github.com/DivanteLtd/next/blob/master/CLA.md)
