### PR TITLE
fix: checkbox font size

### DIFF
--- a/packages/shared/styles/components/atoms/SfCheckbox.scss
+++ b/packages/shared/styles/components/atoms/SfCheckbox.scss
@@ -1,6 +1,6 @@
 @import "../../helpers";
-.sf-checkbox {  
-  &__container {   
+.sf-checkbox {
+  &__container {
      position: relative;
     display: flex;
     align-items: center;
@@ -33,11 +33,11 @@
   &__label {
     flex: 1;
     margin: var(--checkbox-label-margin, 0 0 0 var(--spacer-sm));
-    color: var(--checkbox-label-color, var(--c-text));
+    color: var(--checkbox-label-color, var(--_c-dark-secondary));
     @include font(
       --checkbox-font,
-      var(--font-medium),
-      var(--font-xs),
+      var(--font-normal),
+      var(--font-sm),
       1.6,
       var(--font-family-secondary)
     );
@@ -45,6 +45,7 @@
   &--is-active {
     --checkbox-border-color: var(--c-primary);
     --checkbox-background: var(--c-primary);
+    --checkbox-label-color: var(--c-text);
     &.sf-checkbox--has-error {
       --checkbox-border-color: var(--c-danger);
       --checkbox-background: var(--c-danger);
@@ -58,8 +59,8 @@
     --checkbox-label-color: var(--c-text-disabled);
     --checkbox-border-color: var(--c-text-disabled);
   }
-  input {    
-    position: absolute;    
+  input {
+    position: absolute;
     opacity: 0;
     left: -1000%;
     width: 1px;

--- a/packages/shared/styles/components/molecules/SfFilter.scss
+++ b/packages/shared/styles/components/molecules/SfFilter.scss
@@ -10,10 +10,10 @@
     display: var(--filter-label-display, flex);
     align-items: var(--filter-label-align-items, center);
     margin: var(--filter-label-margin, 0);
-    color: var(--filter-label-color);
+    color: var(--filter-label-color, var(--_c-dark-secondary));
     @include font(
       --filter-label-font,
-      var(--font-medium),
+      var(--font-normal),
       var(--font-base),
       1.4,
       var(--font-family-secondary)
@@ -41,13 +41,13 @@
     --filter-color-margin: 0;
     --filter-label-margin: 0 0 0 var(--spacer-sm);
     --filter-count-margin: 0 0 0 auto;
-    --filter-label-font-size: var(--font-2xs);
-    --filter-count-font-size: var(--font-2xs);
+    --filter-label-font-size: var(--font-sm);
+    --filter-count-font-size: var(--font-sm);
   }
   &--active {
+    --filter-label-color: var(--c-text);
     @include for-desktop {
       --filter-label-text-decoration: underline;
-      --filter-label-transform: scale(1.4);
     }
   }
   &--is-color {

--- a/packages/shared/styles/components/organisms/SfSidebar.scss
+++ b/packages/shared/styles/components/organisms/SfSidebar.scss
@@ -39,7 +39,7 @@
       --sidebar-content-padding,
       var(--spacer-base) var(--spacer-sm)
     );
-    color: var(--sidebar-content-color, vaR(--c-text));
+    color: var(--sidebar-content-color, var(--c-text));
     @include font(
       --sidebar-content-font,
       var(--font-light),


### PR DESCRIPTION
# Scope of work
<!-- describe what you did -->
adjust checkbox and filter label size to design, use 14px 

# Screenshots of visual changes
<!-- if visual changes applied -->
after changes
![Zrzut ekranu 2020-05-22 o 13 42 15](https://user-images.githubusercontent.com/12138170/82664481-1900c480-9c32-11ea-8182-23f2b2e138cd.png)

before changes
![Zrzut ekranu 2020-05-22 o 13 41 38](https://user-images.githubusercontent.com/12138170/82664479-18682e00-9c32-11ea-9fbf-026f30a93965.png)

# Checklist

- [ ] No commented blocks of code left
- [ ] Run tests and docs
- [ ] Self code-reviewed

If applicable:

- [ ] I followed [composition rules](https://docs.storefrontui.io/contributing/coding-guidelines.html#component-rules) for my component
- [ ] I tested the component in most common device sizes (can be tested in Storybook [from viewport addon in top menu](https://github.com/storybooks/storybook/tree/master/addons/viewport))
 - [ ] I accept [Individual Contributor License Agreement](https://github.com/DivanteLtd/next/blob/master/CLA.md)
