### PR TITLE
fix: SfCollected product title display

### DIFF
--- a/packages/shared/styles/components/organisms/SfCollectedProduct.scss
+++ b/packages/shared/styles/components/organisms/SfCollectedProduct.scss
@@ -71,12 +71,12 @@
   }
   &__title {
     display: inline-block;
-    margin-bottom: var(--spacer-base);
+    margin: var(--collected-product-title-margin, 0 var(--spacer-base) var(--spacer-base) 0);
     --link-text-decoration: none;
     @include font(
       --collected-product-title-font,
       var(--font-normal),
-      var(--font-2xs),
+      var(--font-sm),
       1.6,
       var(--font-family-secondary)
     );

--- a/packages/vue/src/components/organisms/SfCollectedProduct/SfCollectedProduct.vue
+++ b/packages/vue/src/components/organisms/SfCollectedProduct/SfCollectedProduct.vue
@@ -60,7 +60,7 @@
         aria-label="More actions"
         class="sf-button--pure sf-collected-product__more-actions mobile-only"
       >
-        <SfIcon icon="more" />
+        <SfIcon icon="more" size="18px" />
       </SfButton>
     </slot>
   </div>


### PR DESCRIPTION
# Related issue
Closes #1234 

# Scope of work
SfCollectedProduct change title font-size and add title right margin to avoid overlapping icon.

# Screenshots of visual changes
![image](https://user-images.githubusercontent.com/32042425/83875624-baf6d580-a737-11ea-9bdc-7f17e29d2533.png)


# Checklist

- [x] No commented blocks of code left
- [x] Run tests and docs
- [x] Self code-reviewed
