### PR TITLE
fix typo in mega menu

### DIFF
--- a/packages/shared/styles/components/organisms/SfMegaMenu.scss
+++ b/packages/shared/styles/components/organisms/SfMegaMenu.scss
@@ -17,12 +17,12 @@
     --menu-item-text-transform: uppercase;
     display: var(--mega-menu-column-header-display, flex);
     padding: var(--mega-menu-column-header-padding, var(--spacer-sm));
-    margin: var(--mega-menu-column-header-maegin, 0);
+    margin: var(--mega-menu-column-header-margin, 0);
     @include border(--mega-menu-column-header-border, 0 0 1px 0, solid, var(--c-light));
     @include for-desktop {
       --menu-item-font-weight: var(--font-bold);
       padding: var(--mega-menu-column-header-padding, 0);
-      margin: var(--mega-menu-column-header-maegin, var(--spacer-sm) 0);
+      margin: var(--mega-menu-column-header-margin, var(--spacer-sm) 0);
       border-width: var(--mega-menu-column-header-border-width, 0);
     }
   }
@@ -100,12 +100,12 @@
       --menu-item-text-transform: uppercase;
       display: var(--mega-menu-column-header-display, flex);
       padding: var(--mega-menu-column-header-padding, var(--spacer-sm));
-      margin: var(--mega-menu-column-header-maegin, 0);
+      margin: var(--mega-menu-column-header-margin, 0);
       @include border(--mega-menu-column-header-border, 0 0 1px 0, solid, var(--c-light));
       @include for-desktop {
         --menu-item-font-weight: var(--font-bold);
         padding: var(--mega-menu-column-header-padding, 0);
-        margin: var(--mega-menu-column-header-maegin, var(--spacer-sm) 0);
+        margin: var(--mega-menu-column-header-margin, var(--spacer-sm) 0);
         border-width: var(--mega-menu-column-header-border-width, 0);
       }
     }


### PR DESCRIPTION
# Scope of work
<!-- describe what you did -->
Fixed typo in variable name in mega-menu component `--mega-menu-column-header-margin`

# Screenshots of visual changes
<!-- if visual changes applied -->

# Checklist

- [x] No commented blocks of code left
- [ ] Run tests and docs
- [x] Self code-reviewed

If applicable:

- [ ] I followed [composition rules](https://docs.storefrontui.io/contributing/coding-guidelines.html#component-rules) for my component
- [ ] I tested the component in most common device sizes (can be tested in Storybook [from viewport addon in top menu](https://github.com/storybooks/storybook/tree/master/addons/viewport))
 - [x] I accept [Individual Contributor License Agreement](https://github.com/DivanteLtd/next/blob/master/CLA.md)
