### PR TITLE
fix: providing classes does not affect the position of slider content in SfHero

### DIFF
--- a/packages/shared/styles/components/organisms/SfHero.scss
+++ b/packages/shared/styles/components/organisms/SfHero.scss
@@ -51,6 +51,15 @@
   &--align-right {
     --hero-item-justify-content: flex-end;
   }
+  &--position-bg-top-right {
+    background-position: top right;
+  }
+  &--position-bg-bottom-right {
+    background-position: bottom right;
+  }
+  &--position-bg-bottom-left {
+    background-position: bottom left;
+  }
   @include for-desktop {
     --hero-item-height: 36.625rem;
     --hero-item-padding: var(--spacer-2xl);

--- a/packages/vue/src/components/organisms/SfHero/SfHero.stories.js
+++ b/packages/vue/src/components/organisms/SfHero/SfHero.stories.js
@@ -67,6 +67,7 @@ storiesOf("Organisms|Hero", module)
           :background="background"
       />
       <SfHeroItem
+          :class="customClass"
           title="Colorful summer dresses are already in store"
           subtitle="Summer Collection 2019"
           button-text="Learn more"
@@ -136,6 +137,7 @@ storiesOf("Organisms|Hero", module)
         :background="background"
       />
       <SfHeroItem
+          :class="customClass"
           title="Colorful summer dresses are already in store"
           subtitle="Summer Collection 2019"
           button-text="Learn more"
@@ -205,6 +207,7 @@ storiesOf("Organisms|Hero", module)
           :background="background"
       />
       <SfHeroItem
+          :class="customClass"
           title="Colorful summer dresses are already in store"
           subtitle="Summer Collection 2019"
           button-text="Learn more"
@@ -274,6 +277,7 @@ storiesOf("Organisms|Hero", module)
           :background="background"
       />
       <SfHeroItem
+          :class="customClass"
           title="Colorful summer dresses are already in store"
           subtitle="Summer Collection 2019"
           button-text="Learn more"


### PR DESCRIPTION
# Related issue
Closes #1245

# Scope of work
Added modifiers and custom classes in second hero item in stories

# Screenshots of visual changes
![Zrzut ekranu z 2020-06-15 14-06-12](https://user-images.githubusercontent.com/46591755/84655543-69a5cd80-af11-11ea-94e8-aff73f79ed78.png)
