### PR TITLE
fix: wishlist position in relation to image

### DIFF
--- a/packages/shared/styles/components/organisms/SfProductCard.scss
+++ b/packages/shared/styles/components/organisms/SfProductCard.scss
@@ -123,8 +123,8 @@
     --product-card-padding: var(--spacer-sm);
     --product-card-title-margin: var(--spacer-xl) 0 0 0;
     --product-card-transition: box-shadow 150ms ease-in-out;
-    --product-card-wishlist-icon-top: var(--spacer-lg);
-    --product-card-wishlist-icon-right: var(--spacer-lg);
+    --product-card-wishlist-icon-top: var(--spacer-base);
+    --product-card-wishlist-icon-right: var(--spacer-base);
     --product-card-wishlist-icon-opacity: 0;
     --product-card-add-button-display: flex;
   }

--- a/packages/vue/src/components/organisms/SfProductCard/SfProductCard.vue
+++ b/packages/vue/src/components/organisms/SfProductCard/SfProductCard.vue
@@ -35,6 +35,20 @@
           >{{ badgeLabel }}</SfBadge
         >
       </slot>
+      <SfButton
+        v-if="wishlistIcon !== false"
+        :aria-label="`${ariaLabel} ${title}`"
+        :class="wishlistIconClasses"
+        @click="toggleIsOnWishlist"
+      >
+        <slot name="wishlist-icon" v-bind="{ currentWishlistIcon }">
+          <SfIcon
+            :icon="currentWishlistIcon"
+            size="22px"
+            data-test="sf-wishlist-icon"
+          />
+        </slot>
+      </SfButton>
       <template v-if="showAddToCartButton">
         <slot
           name="add-to-cart"
@@ -83,20 +97,6 @@
         </h3>
       </SfLink>
     </slot>
-    <SfButton
-      v-if="wishlistIcon !== false"
-      :aria-label="`${ariaLabel} ${title}`"
-      :class="wishlistIconClasses"
-      @click="toggleIsOnWishlist"
-    >
-      <slot name="wishlist-icon" v-bind="{ currentWishlistIcon }">
-        <SfIcon
-          :icon="currentWishlistIcon"
-          size="22px"
-          data-test="sf-wishlist-icon"
-        />
-      </slot>
-    </SfButton>
     <slot name="price" v-bind="{ specialPrice, regularPrice }">
       <SfPrice
         v-if="regularPrice"


### PR DESCRIPTION
# Related issue
https://github.com/DivanteLtd/storefront-ui/issues/1240
Closes #1240 

# Scope of work
SfProductCard - move the whishlist button inside image-wrapper to position it relatively.

# Checklist

- [x] No commented blocks of code left
- [x] Run tests and docs
- [x] Self code-reviewed

