### PR TITLE
feat: add sflink to button

### DIFF
--- a/packages/shared/styles/components/atoms/SfButton.scss
+++ b/packages/shared/styles/components/atoms/SfButton.scss
@@ -1,5 +1,6 @@
 @import "../../helpers";
 .sf-button {
+  --link-color: var(--button-color, var(--c-light-variant));
   box-sizing: border-box;
   position: relative;
   width: var(--button-size, var(--button-width));
@@ -42,6 +43,9 @@
         --button-background: #{$variant};
       }
     }
+  }
+  &.sf-link { 
+    --button-width: var(--spacer-3xl);
   }
   &:hover {
     --button-box-shadow-opacity: 0.25;

--- a/packages/vue/src/components/atoms/SfButton/SfButton.stories.js
+++ b/packages/vue/src/components/atoms/SfButton/SfButton.stories.js
@@ -37,11 +37,8 @@ storiesOf("Atoms|Button", module)
       disabled: {
         default: boolean("disabled", false, "Props"),
       },
-      nativeButton: {
-        default: boolean("native button tag", true, "Props"),
-      },
-      href: {
-        default: text("link", "https://www.storefrontui.io/", "Props"),
+      link: {
+        default: text("link", "", "Props"),
       }
     },
     components: { SfButton },
@@ -49,7 +46,7 @@ storiesOf("Atoms|Button", module)
       :class="customClass"
       :disabled="disabled"
       :nativeButton="nativeButton"
-      :link="href">
+      :link="link">
       {{customLabel}}
     </SfButton>`,
   }))
@@ -82,10 +79,7 @@ storiesOf("Atoms|Button", module)
       disabled: {
         default: boolean("disabled", false, "Props"),
       },
-      nativeButton: {
-        default: boolean("native button tag", false, "Props"),
-      },
-      href: {
+      link: {
         default: text("link", "https://www.storefrontui.io/", "Props"),
       }
     },
@@ -94,7 +88,7 @@ storiesOf("Atoms|Button", module)
       :class="customClass"
       :disabled="disabled"
       :nativeButton="nativeButton"
-      :link="href">
+      :link="link">
       {{customLabel}}
     </SfButton>`,
   }));

--- a/packages/vue/src/components/atoms/SfButton/SfButton.stories.js
+++ b/packages/vue/src/components/atoms/SfButton/SfButton.stories.js
@@ -37,11 +37,64 @@ storiesOf("Atoms|Button", module)
       disabled: {
         default: boolean("disabled", false, "Props"),
       },
+      nativeButton: {
+        default: boolean("native button tag", true, "Props"),
+      },
+      href: {
+        default: text("link", "https://www.storefrontui.io/", "Props"),
+      }
     },
     components: { SfButton },
     template: `<SfButton
       :class="customClass"
-      :disabled="disabled">
+      :disabled="disabled"
+      :nativeButton="nativeButton"
+      :link="href">
+      {{customLabel}}
+    </SfButton>`,
+  }))
+  .add("Link as button", () => ({
+    props: {
+      customClass: {
+        default: options(
+          "CSS modifiers",
+          {
+            "sf-button--outline": "sf-button--outline",
+            "sf-button--underlined": "sf-button--underlined",
+            "sf-button--text": "sf-button--text",
+            "sf-button--full-width": "sf-button--full-width",
+            "sf-button--pure": "sf-button--pure",
+            "color-primary": "color-primary",
+            "color-secondary": "color-secondary",
+            "color-warning": "color-warning",
+            "color-danger": "color-danger",
+            "color-info": "color-info",
+            "color-success": "color-success",
+          },
+          "",
+          { display: "multi-select" },
+          "CSS Modifiers"
+        ),
+      },
+      customLabel: {
+        default: text("default", "Shop now", "Slots"),
+      },
+      disabled: {
+        default: boolean("disabled", false, "Props"),
+      },
+      nativeButton: {
+        default: boolean("native button tag", false, "Props"),
+      },
+      href: {
+        default: text("link", "https://www.storefrontui.io/", "Props"),
+      }
+    },
+    components: { SfButton },
+    template: `<SfButton
+      :class="customClass"
+      :disabled="disabled"
+      :nativeButton="nativeButton"
+      :link="href">
       {{customLabel}}
     </SfButton>`,
   }));

--- a/packages/vue/src/components/atoms/SfButton/SfButton.vue
+++ b/packages/vue/src/components/atoms/SfButton/SfButton.vue
@@ -1,19 +1,25 @@
 <template>
-  <button
+  <component
+    :is="tag"
     v-focus
     class="sf-button"
     v-bind="$attrs"
     :disabled="disabled"
+    :link="link"
     v-on="$listeners"
   >
     <!--@slot Use this slot to place content inside the button.-->
     <slot />
-  </button>
+  </component>
 </template>
 <script>
 import { focus } from "../../../utilities/directives";
+import SfLink from "../SfLink/SfLink.vue";
 export default {
   name: "SfButton",
+  components: {
+    SfLink,
+  },
   directives: {
     focus,
   },
@@ -24,6 +30,28 @@ export default {
     disabled: {
       type: Boolean,
       default: false,
+    },
+    /**
+     * To change for "a" tag chose false
+     */
+    nativeButton: {
+      type: Boolean,
+      default: true,
+    },
+    /**
+     * Link for "a" tag
+     */
+    href: {
+      type: [String, Object],
+      default: "",
+    },
+  },
+  computed: {
+    tag() {
+      return this.nativeButton === true ? "button" : "SfLink";
+    },
+    link() {
+      return this.nativeButton === true ? undefined : this.href;
     },
   },
 };

--- a/packages/vue/src/components/atoms/SfButton/SfButton.vue
+++ b/packages/vue/src/components/atoms/SfButton/SfButton.vue
@@ -5,7 +5,7 @@
     class="sf-button"
     v-bind="$attrs"
     :disabled="disabled"
-    :link="href"
+    :link="link"
     v-on="$listeners"
   >
     <!--@slot Use this slot to place content inside the button.-->
@@ -32,14 +32,7 @@ export default {
       default: false,
     },
     /**
-     * To change for "a" tag choose false
-     */
-    nativeButton: {
-      type: Boolean,
-      default: true,
-    },
-    /**
-     * Link for "a" tag
+     * Link for "a" tag, when empty it is button.
      */
     link: {
       type: [String, Object],
@@ -48,10 +41,7 @@ export default {
   },
   computed: {
     tag() {
-      return this.nativeButton === true ? "button" : "SfLink";
-    },
-    href() {
-      return this.nativeButton === true ? null : this.link;
+      return this.link ? "SfLink" : "button";
     },
   },
 };

--- a/packages/vue/src/components/atoms/SfButton/SfButton.vue
+++ b/packages/vue/src/components/atoms/SfButton/SfButton.vue
@@ -5,7 +5,7 @@
     class="sf-button"
     v-bind="$attrs"
     :disabled="disabled"
-    :link="link"
+    :link="href"
     v-on="$listeners"
   >
     <!--@slot Use this slot to place content inside the button.-->
@@ -32,7 +32,7 @@ export default {
       default: false,
     },
     /**
-     * To change for "a" tag chose false
+     * To change for "a" tag choose false
      */
     nativeButton: {
       type: Boolean,
@@ -41,7 +41,7 @@ export default {
     /**
      * Link for "a" tag
      */
-    href: {
+    link: {
       type: [String, Object],
       default: "",
     },
@@ -50,8 +50,8 @@ export default {
     tag() {
       return this.nativeButton === true ? "button" : "SfLink";
     },
-    link() {
-      return this.nativeButton === true ? undefined : this.href;
+    href() {
+      return this.nativeButton === true ? null : this.link;
     },
   },
 };


### PR DESCRIPTION
# Related issue
Closes #1241 

# Scope of work
Add props to change component from native button to a tag (nativeButton) and link prop with link for "a" tag. Component is switching from "button" to "a" tag depending on boolean prop, if true it is a "button" if false it's SfLink component. Style is adjusted accordingly.
 

# Screenshots of visual changes
![image](https://user-images.githubusercontent.com/32042425/84865976-63cafc00-b079-11ea-812d-2857b99f261a.png)


# Checklist

- [x] No commented blocks of code left
- [x] Run tests and docs
- [x] Self code-reviewed
