### PR TITLE
feat: more generic slots for SfProductCard

### DIFF
--- a/packages/vue/src/components/organisms/SfProductCard/SfProductCard.stories.js
+++ b/packages/vue/src/components/organisms/SfProductCard/SfProductCard.stories.js
@@ -520,7 +520,7 @@ storiesOf("Organisms|ProductCard", module)
         @click:wishlist="alert('@click:wishlist')"
         @click:reviews="alert('@click:reviews')"
     >
-      <template #title="{ title }">
+      <template #details-top="{ title }">
         CUSTOM TITLE
       </template>
     </SfProductCard>`,
@@ -722,7 +722,7 @@ storiesOf("Organisms|ProductCard", module)
         @click:wishlist="alert('@click:wishlist')"
         @click:reviews="alert('@click:reviews')"
     >
-      <template #price="{ specialPrice, regularPrice }">
+      <template #details-center="{ specialPrice, regularPrice }">
         CUSTOM PRICE
       </template>
     </SfProductCard>`,
@@ -823,7 +823,7 @@ storiesOf("Organisms|ProductCard", module)
         @click:wishlist="alert('@click:wishlist')"
         @click:reviews="alert('@click:reviews')"
     >
-      <template #reviews="{ maxRating, scoreRating }">
+      <template #details-bottom="{ maxRating, scoreRating }">
         CUSTOM REVIEWS
       </template>
     </SfProductCard>`,

--- a/packages/vue/src/components/organisms/SfProductCard/SfProductCard.vue
+++ b/packages/vue/src/components/organisms/SfProductCard/SfProductCard.vue
@@ -76,7 +76,7 @@
         </slot>
       </template>
     </div>
-    <slot name="title" v-bind="{ title, link }">
+    <slot name="details-top" v-bind="{ title, link }">
       <SfLink :link="link" class="sf-product-card__link">
         <h3 class="sf-product-card__title">
           {{ title }}
@@ -97,7 +97,7 @@
         />
       </slot>
     </SfButton>
-    <slot name="price" v-bind="{ specialPrice, regularPrice }">
+    <slot name="details-center" v-bind="{ specialPrice, regularPrice }">
       <SfPrice
         v-if="regularPrice"
         class="sf-product-card__price"
@@ -105,7 +105,7 @@
         :special="specialPrice"
       />
     </slot>
-    <slot name="reviews" v-bind="{ maxRating, scoreRating }">
+    <slot name="details-bottom" v-bind="{ maxRating, scoreRating }">
       <div
         v-if="typeof scoreRating === 'number'"
         class="sf-product-card__reviews"


### PR DESCRIPTION
# Related issue
Closes #1249 

# Scope of work
Slots for title, price, and reviews are more generic now: details-top, details-center, details-bottom

# Screenshots of visual changes
No visual changes
