### PR TITLE
feat: add bottom navigation and mega menu to default theme

### DIFF
--- a/packages/vue/src/components/organisms/SfMegaMenu/SfMegaMenu.stories.js
+++ b/packages/vue/src/components/organisms/SfMegaMenu/SfMegaMenu.stories.js
@@ -88,7 +88,7 @@ storiesOf("Organisms|MegaMenu", module)
         :title="category.title"
       >
         <SfList>
-          <SfListItem v-for="(subcategory, key) in category.subcategories">
+          <SfListItem v-for="(subcategory, index) in category.subcategories" :key="index">
             <SfMenuItem :label="subcategory.title"></SfMenuItem>
           </SfListItem>
         </SfList>

--- a/packages/vue/src/examples/templates/default/Default.vue
+++ b/packages/vue/src/examples/templates/default/Default.vue
@@ -10,8 +10,35 @@
         <SfHeaderNavigationItem
           v-for="(category, key) in shopRootCategories"
           :key="key"
+          @mouseover="currentCategoryTitle = category.title"
+          @mouseleave="currentCategoryTitle = null"
         >
-          <a href="">{{ category }}</a>
+          <SfLink>
+            {{ category.title }}
+          </SfLink>
+          <SfMegaMenu
+            :visible="
+              currentCategoryTitle && category.title === currentCategoryTitle
+            "
+            class="mega-menu"
+            :title="category.title"
+          >
+            <SfMegaMenuColumn
+              v-for="(subcategory, index) in category.subcategories"
+              :key="index"
+              :title="subcategory.title"
+            >
+              <SfList>
+                <SfListItem
+                  v-for="(subcategoryChild,
+                  childIndex) in subcategory.subcategories"
+                  :key="childIndex"
+                >
+                  <SfMenuItem :label="subcategoryChild.title"></SfMenuItem>
+                </SfListItem>
+              </SfList>
+            </SfMegaMenuColumn>
+          </SfMegaMenu>
         </SfHeaderNavigationItem>
       </template>
     </SfHeader>
@@ -29,11 +56,75 @@
         </SfList>
       </SfFooterColumn>
     </SfFooter>
+    <SfBottomNavigation v-if="isMobile" class="bottom-navigation">
+      <SfBottomNavigationItem
+        :icon="'home'"
+        :label="'Home'"
+        :icon-active="'home_fill'"
+      />
+      <SfBottomNavigationItem
+        :icon="'menu'"
+        :label="'Menu'"
+        icon-size="20px"
+        @click="changeVisibility"
+      />
+      <SfBottomNavigationItem
+        :icon="'heart'"
+        :icon-active="'heart_fill'"
+        :label="'Heart'"
+        icon-size="20px"
+      />
+      <SfBottomNavigationItem
+        :icon="'profile'"
+        :icon-active="'profile_fill'"
+        :label="'Profile'"
+        icon-size="20px"
+      />
+      <SfBottomNavigationItem label="Basket" icon="add_to_cart" is-floating />
+    </SfBottomNavigation>
+    <SfSidebar
+      :visible="isVisible"
+      :overlay="false"
+      :title="currentCategoryName[currentCategoryName.length - 1]"
+      :persistent="true"
+      @close="prevCategory()"
+    >
+      <SfMenuItem v-for="(category, index) in currentCategory" :key="index">
+        <template #label>
+          <SfLink :link="category.link">
+            {{ category.title }}
+          </SfLink>
+        </template>
+        <template #mobile-nav-icon>
+          <SfIcon
+            v-if="category.subcategories"
+            icon="chevron_right"
+            size="14px"
+            @click="nextCategory(category, index)"
+          />
+          <span v-else></span>
+        </template>
+      </SfMenuItem>
+    </SfSidebar>
   </div>
 </template>
 <script>
-import { SfHeader, SfFooter, SfList, SfMenuItem } from "@storefront-ui/vue";
+import {
+  SfHeader,
+  SfFooter,
+  SfList,
+  SfMenuItem,
+  SfMegaMenu,
+  SfLink,
+  SfSidebar,
+  SfIcon,
+  SfBottomNavigation,
+} from "@storefront-ui/vue";
 import Home from "../../pages/home/Home.vue";
+import {
+  mapMobileObserver,
+  unMapMobileObserver,
+} from "../../../utilities/mobile-observer";
 export default {
   name: "Default",
   components: {
@@ -41,6 +132,11 @@ export default {
     SfFooter,
     SfList,
     SfMenuItem,
+    SfMegaMenu,
+    SfLink,
+    SfBottomNavigation,
+    SfSidebar,
+    SfIcon,
     Home,
   },
   data() {
@@ -50,7 +146,157 @@ export default {
         desktop: { url: "/assets/logo.svg" },
       },
       shopName: "Storefront UI",
-      shopRootCategories: ["women", "man", "kids"],
+      isVisible: false,
+      currentCategoryTitle: null,
+      currentCategoryName: [],
+      currentCategoryPath: [],
+      currentCategory: [],
+      shopRootCategories: [
+        {
+          title: "Clothing",
+          link: "/clothing",
+          subcategories: [
+            {
+              title: "Skirts",
+              link: "/skirts",
+              subcategories: [
+                {
+                  title: "Long",
+                  link: "/long",
+                },
+                {
+                  title: "Short",
+                  link: "/short",
+                },
+              ],
+            },
+            {
+              title: "Sweaters",
+              link: "/sweaters",
+              subcategories: [
+                {
+                  title: "Long",
+                  link: "/long",
+                },
+                {
+                  title: "Short",
+                  link: "/short",
+                },
+              ],
+            },
+            {
+              title: "Dresses",
+              link: "/dresses",
+              subcategories: [
+                {
+                  title: "Long",
+                  link: "/long",
+                },
+                {
+                  title: "Short",
+                  link: "/short",
+                },
+              ],
+            },
+          ],
+        },
+        {
+          title: "Accesories",
+          link: "/accesories",
+          subcategories: [
+            {
+              title: "Bags & Purses",
+              link: "/skirts",
+              subcategories: [
+                {
+                  title: "Long",
+                  link: "/long",
+                },
+                {
+                  title: "Short",
+                  link: "/short",
+                },
+              ],
+            },
+            {
+              title: "Belts",
+              link: "/belts",
+              subcategories: [
+                {
+                  title: "Long",
+                  link: "/long",
+                },
+                {
+                  title: "Short",
+                  link: "/short",
+                },
+              ],
+            },
+            {
+              title: "Gloves",
+              link: "/gloves",
+              subcategories: [
+                {
+                  title: "Long",
+                  link: "/long",
+                },
+                {
+                  title: "Short",
+                  link: "/short",
+                },
+              ],
+            },
+          ],
+        },
+        {
+          title: "Shoes",
+          link: "/shoes",
+          subcategories: [
+            {
+              title: "Boots",
+              link: "/boots",
+              subcategories: [
+                {
+                  title: "Long",
+                  link: "/long",
+                },
+                {
+                  title: "Short",
+                  link: "/short",
+                },
+              ],
+            },
+            {
+              title: "Heels",
+              link: "/heels",
+              subcategories: [
+                {
+                  title: "Long",
+                  link: "/long",
+                },
+                {
+                  title: "Short",
+                  link: "/short",
+                },
+              ],
+            },
+            {
+              title: "Flat shoes",
+              link: "/flat",
+              subcategories: [
+                {
+                  title: "Long",
+                  link: "/long",
+                },
+                {
+                  title: "Short",
+                  link: "/short",
+                },
+              ],
+            },
+          ],
+        },
+      ],
       footerColumns: [
         {
           title: "About us",
@@ -71,10 +317,49 @@ export default {
       ],
     };
   },
+  computed: {
+    ...mapMobileObserver(),
+  },
+  mounted() {
+    this.currentCategory = this.shopRootCategories;
+  },
+  beforeDestroy() {
+    unMapMobileObserver();
+  },
+  methods: {
+    changeVisibility() {
+      this.isVisible = !this.isVisible;
+    },
+    nextCategory({ title }, index) {
+      this.currentCategoryPath.push(index);
+      this.currentCategoryName.push(title);
+      this.getCurrentCategory();
+    },
+    prevCategory() {
+      this.currentCategoryPath.length
+        ? this.currentCategoryPath.pop()
+        : this.changeVisibility();
+      this.currentCategoryName.pop();
+      this.getCurrentCategory();
+    },
+    getCurrentCategory() {
+      this.currentCategory = this.shopRootCategories;
+      this.currentCategoryPath.forEach((index) => {
+        this.currentCategory = this.currentCategory[index].subcategories;
+      });
+    },
+  },
 };
 </script>
 <style lang="scss" scoped>
 @import "~@storefront-ui/vue/styles";
-#default {
+.mega-menu {
+  position: absolute;
+  left: 0;
+  width: 100%;
+  top: 100%;
+}
+.bottom-navigation {
+  --bottom-navigation-z-index: 2;
 }
 </style>


### PR DESCRIPTION
# Related issue
Related #1242 

# Scope of work
<!-- describe what you did -->

MegaMenu and BottomNavigation components has been added to the default template

# Screenshots of visual changes
<!-- if visual changes applied -->
![default template](https://user-images.githubusercontent.com/32803679/85377419-56aa8300-b539-11ea-8c74-6008d5ae06b1.gif)

# Checklist

- [x] No commented blocks of code left
- [ ] Run tests and docs
- [x] Self code-reviewed

If applicable:

- [x] I followed [composition rules](https://docs.storefrontui.io/contributing/coding-guidelines.html#component-rules) for my component
- [x] I tested the component in most common device sizes (can be tested in Storybook [from viewport addon in top menu](https://github.com/storybooks/storybook/tree/master/addons/viewport))
 - [x] I accept [Individual Contributor License Agreement](https://github.com/DivanteLtd/next/blob/master/CLA.md)
