### PR TITLE
fix: move v-on to div that has focus (#1270)

### DIFF
--- a/packages/vue/src/components/molecules/SfSelect/SfSelect.vue
+++ b/packages/vue/src/components/molecules/SfSelect/SfSelect.vue
@@ -19,7 +19,6 @@
     @keyup.up="move(-1)"
     @keyup.down="move(1)"
     @keyup.enter="enter($event)"
-    v-on="$listeners"
   >
     <div style="position: relative;">
       <div
@@ -27,6 +26,7 @@
         v-focus
         tabindex="0"
         class="sf-select__selected sf-select-option"
+        v-on="$listeners"
         v-html="html"
       ></div>
       <slot name="label">


### PR DESCRIPTION
# Related issue
Closes #1270 [BUG] Can't put @blur for validation purposes on SfSelect

# Scope of work
Move `v-on` to the div that has focus.

# Checklist
- [x] No commented blocks of code left
- [x] Run tests and docs
- [x] Self code-reviewed

If applicable:
- [x] I followed [composition rules](https://docs.storefrontui.io/contributing/coding-guidelines.html#component-rules) for my component
- [x] I tested the component in most common device sizes (can be tested in Storybook [from viewport addon in top menu](https://github.com/storybooks/storybook/tree/master/addons/viewport))
 - [x] I accept [Individual Contributor License Agreement](https://github.com/DivanteLtd/next/blob/master/CLA.md)
