### PR TITLE
feat: listbox role moved to ul tag

### DIFF
--- a/packages/vue/src/components/molecules/SfSelect/SfSelect.vue
+++ b/packages/vue/src/components/molecules/SfSelect/SfSelect.vue
@@ -1,9 +1,6 @@
 <template>
   <div
     v-click-outside="checkPersistence"
-    :aria-expanded="open.toString()"
-    :aria-owns="'lbox_' + _uid"
-    :aria-label="label"
     :class="{
       'sf-select--is-active': isActive,
       'sf-select--is-selected': isSelected,
@@ -46,6 +43,8 @@
           <!--  sf-select__option -->
           <ul
             :aria-expanded="open.toString()"
+            :aria-owns="`lbox_${_uid}`"
+            :aria-label="label"
             :style="{ maxHeight }"
             role="listbox"
             class="sf-select__options"

--- a/packages/vue/src/components/molecules/SfSelect/SfSelect.vue
+++ b/packages/vue/src/components/molecules/SfSelect/SfSelect.vue
@@ -4,7 +4,6 @@
     :aria-expanded="open.toString()"
     :aria-owns="'lbox_' + _uid"
     :aria-label="label"
-    role="listbox"
     :class="{
       'sf-select--is-active': isActive,
       'sf-select--is-selected': isSelected,
@@ -48,6 +47,7 @@
           <ul
             :aria-expanded="open.toString()"
             :style="{ maxHeight }"
+            role="listbox"
             class="sf-select__options"
           >
             <slot />


### PR DESCRIPTION
# Related issue
Closes #1276 

# Scope of work
Listbox role has been moved to ul tag as it's our "select" for li tag (option role). As far as I know, we can't use native HTML elements due to problems with styling (especially with our design) 

# Screenshots of visual changes
No visual changes
