### PR TITLE
SfStoreLocator: Fixed the z-index of map element as it was stacking a…

### DIFF
--- a/packages/shared/styles/components/organisms/SfStoreLocator.scss
+++ b/packages/shared/styles/components/organisms/SfStoreLocator.scss
@@ -96,6 +96,7 @@
     // Workaround to known bug about min-height / height interaction in Chrome / Firefox
     position: absolute;
     height: 100%;
+    z-index: 0;
   }
   &__stores {
     padding: var(--store-locator-stores-padding, var(--spacer-sm));


### PR DESCRIPTION
The issue was in the stacking order of map in store locator component. Please see below screenshot.

![Screenshot 2020-07-02 at 2 33 20 PM](https://user-images.githubusercontent.com/34086621/86347444-ecea5180-bc7b-11ea-989e-cbaa04c6f102.png)

# Related issue
<!-- paste a link to related issue -->
Closes #

# Scope of work
Fixed the z-index property. Set it to 0.

# Screenshots of visual changes
![Screenshot 2020-07-02 at 3 52 38 PM](https://user-images.githubusercontent.com/34086621/86347620-2d49cf80-bc7c-11ea-9310-6e5cc4d61b83.png)

# Checklist

- [ ] No commented blocks of code left
- [ ] Run tests and docs
- [ ] Self code-reviewed

If applicable:

- [ ] I followed [composition rules](https://docs.storefrontui.io/contributing/coding-guidelines.html#component-rules) for my component
- [ ] I tested the component in most common device sizes (can be tested in Storybook [from viewport addon in top menu](https://github.com/storybooks/storybook/tree/master/addons/viewport))
 - [ ] I accept [Individual Contributor License Agreement](https://github.com/DivanteLtd/next/blob/master/CLA.md)
