### PR TITLE
fix: SfArrow in SfHero component covers other pointer actions

### DIFF
--- a/packages/shared/styles/components/organisms/SfHero.scss
+++ b/packages/shared/styles/components/organisms/SfHero.scss
@@ -87,7 +87,11 @@
     justify-content: var(--hero-controls-justify-content, space-between);
     width: var(--hero-controls-width, 100%);
     padding: var(--hero-controls-padding, 0 var(--spacer-sm));
-  }
+    pointer-events: none;
+    &__arrow {
+      pointer-events: all;
+    }
+   }
   &__bullets {
     position: absolute;
     bottom: var(--hero-bullets-bottom, var(--spacer-xl));

--- a/packages/vue/src/components/organisms/SfHero/SfHero.vue
+++ b/packages/vue/src/components/organisms/SfHero/SfHero.vue
@@ -13,7 +13,7 @@
       <slot name="prev" v-bind="{ go: () => go('prev') }">
         <div @click="go('prev')">
           <SfArrow
-            class="sf-arrow sf-arrow--transparent"
+            class="sf-arrow sf-arrow--transparent sf-hero__controls__arrow"
             aria-label="previous"
           />
         </div>
@@ -22,7 +22,7 @@
       <slot name="next" v-bind="{ go: () => go('next') }">
         <div @click="go('next')">
           <SfArrow
-            class="sf-arrow sf-arrow--right sf-arrow--transparent"
+            class="sf-arrow sf-arrow--right sf-arrow--transparent sf-hero__controls__arrow"
             aria-label="next"
           />
         </div>


### PR DESCRIPTION
# Related issue
Closes #1279 

# Scope of work
Controls wrapper has pointer-events none and arrows have all pointer-events

# Screenshots of visual changes
No visual changes
