### PR TITLE
docs: fix documentation broken links and snippets formatting

### DIFF
--- a/packages/vue/docs/contributing/github-guidelines.md
+++ b/packages/vue/docs/contributing/github-guidelines.md
@@ -344,7 +344,7 @@ git push origin <your-branch-name>
 ```
 
 :::danger STAGE THE WRONG FILE?
-If there is a staged file that wasn't supposed to be staged in the commit, you can **unstage** it by using `checkout` command. See [Troubleshootings - Unstaged unwanted file(s)](#unstaged-unwanted-file(s)) for more information.
+If there is a staged file that wasn't supposed to be staged in the commit, you can **unstage** it by using `checkout` command. See [Troubleshootings - Unstage unwanted file(s)](#unstage-unwanted-file-s) for more information.
 :::
 
 #### By VSCode UI

--- a/packages/vue/docs/design/color-palette.md
+++ b/packages/vue/docs/design/color-palette.md
@@ -35,7 +35,7 @@ If we add this mixin in the desired component:
 
 ```scss
 .sf-button {
-    @include color-modifiers('--button');
+  @include color-modifiers('--button');
 }
 ```
 
@@ -64,12 +64,12 @@ This mixin is based on the CSS variables of the component. To make it work, we n
 
 ```scss
 :root {
-    --button-color: #ffffff;
-    --button-background-color: #000000;
-    --button-border-color: #000000;
-    --button-hover-color: #000000;
-    --button-hover-background-color: #ffffff;
-    --button-hover-border-color: #ffffff;
+  --button-color: #ffffff;
+  --button-background-color: #000000;
+  --button-border-color: #000000;
+  --button-hover-color: #000000;
+  --button-hover-background-color: #ffffff;
+  --button-hover-border-color: #ffffff;
 }
 .sf-button {
   color: var(--button-color);

--- a/packages/vue/docs/design/color-palette.md
+++ b/packages/vue/docs/design/color-palette.md
@@ -92,7 +92,7 @@ In order to maximize ease of use for `SfIcon` in rendering custom SVG icons, we 
 
 ### Use with classes
 
-Each color used from this list for the icon will be converted to a proper color class, following the syntax `sf-icon--color-<color>`. For example `sf-icon--color-green-primary`. These classes for colors are defined [here](https://github.com/DivanteLtd/storefront-ui/blob/develop/packages/shared/styles/components/SfIcon.scss)
+Each color used from this list for the icon will be converted to a proper color class, following the syntax `sf-icon--color-<color>`. For example `sf-icon--color-green-primary`. These classes for colors are defined [here](https://github.com/DivanteLtd/storefront-ui/blob/develop/packages/shared/styles/components/atoms/SfIcon.scss)
 
 You can apply any color from the list above to an icon, simply by passing the color's label to `color` prop, e.g
 ```html


### PR DESCRIPTION
# Related issue
<!-- paste a link to related issue -->
Closes #1309 

# Scope of work
Fixes documentation broken links a snippets formatting

# Screenshots of visual changes
<!-- if visual changes applied -->

# Checklist

- [x] No commented blocks of code left
- [x] Run tests and docs
- [x] Self code-reviewed

If applicable:

- [x] I followed [composition rules](https://docs.storefrontui.io/contributing/coding-guidelines.html#component-rules) for my component
- [x] I tested the component in most common device sizes (can be tested in Storybook [from viewport addon in top menu](https://github.com/storybooks/storybook/tree/master/addons/viewport))
 - [x] I accept [Individual Contributor License Agreement](https://github.com/DivanteLtd/next/blob/master/CLA.md)
