### PR TITLE
refactor: change test methods to class or find methods

### DIFF
--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -54,6 +54,7 @@
     "@storybook/addon-storysource": "^5.2.4",
     "@storybook/addon-viewport": "^5.1.9",
     "@storybook/vue": ">=5.3.0",
+    "@testing-library/jest-dom": "^5.11.1",
     "@types/jest": "^25.2.1",
     "@vue/babel-preset-app": "^4.3.1",
     "@vue/cli-plugin-babel": "^4.3.1",

--- a/packages/vue/src/components/atoms/SfArrow/SfArrow.spec.js
+++ b/packages/vue/src/components/atoms/SfArrow/SfArrow.spec.js
@@ -3,6 +3,6 @@ import SfArrow from "./SfArrow.vue";
 describe("SfArrow.vue", () => {
   it("renders a component", () => {
     const component = shallowMount(SfArrow);
-    expect(component.contains(".sf-arrow")).toBe(true);
+    expect(component.classes("sf-arrow")).toBe(true);
   });
 });

--- a/packages/vue/src/components/atoms/SfBadge/SfBadge.spec.js
+++ b/packages/vue/src/components/atoms/SfBadge/SfBadge.spec.js
@@ -3,14 +3,14 @@ import SfBadge from "./SfBadge.vue";
 describe("SfBadge.vue", () => {
   it("renders a badge", () => {
     const component = shallowMount(SfBadge);
-    expect(component.contains(".sf-badge")).toBe(true);
+    expect(component.classes("sf-badge")).toBe(true);
   });
   it("renders a badge with css modifier", () => {
     const component = shallowMount({
       components: { SfBadge },
       template: `<SfBadge class="sf-badge--warning" />`,
     });
-    expect(component.contains(".sf-badge--warning")).toBe(true);
+    expect(component.classes("sf-badge--warning")).toBe(true);
   });
   it("renders a badge content via default slot", () => {
     const content = "sfbadge content";

--- a/packages/vue/src/components/atoms/SfBreadcrumbs/SfBreadcrumbs.spec.js
+++ b/packages/vue/src/components/atoms/SfBreadcrumbs/SfBreadcrumbs.spec.js
@@ -6,7 +6,7 @@ const propsData = {
 describe("SfBreadcrumbs.vue", () => {
   it("renders a nav", () => {
     const component = shallowMount(SfBreadcrumbs, { propsData });
-    expect(component.contains("nav")).toBe(true);
+    expect(component.classes("sf-breadcrumbs")).toBe(true);
   });
   it("renders breadcrumbs text", () => {
     const msg = "HelloWorld";

--- a/packages/vue/src/components/atoms/SfBullets/SfBullets.spec.js
+++ b/packages/vue/src/components/atoms/SfBullets/SfBullets.spec.js
@@ -7,6 +7,6 @@ describe("SfBullets.vue", () => {
         total: 3,
       },
     });
-    expect(component.contains(".sf-bullets")).toBe(true);
+    expect(component.classes("sf-bullets")).toBe(true);
   });
 });

--- a/packages/vue/src/components/atoms/SfButton/SfButton.spec.js
+++ b/packages/vue/src/components/atoms/SfButton/SfButton.spec.js
@@ -3,7 +3,7 @@ import SfButton from "./SfButton.vue";
 describe("SfButton.vue", () => {
   it("renders a button", () => {
     const component = shallowMount(SfButton);
-    expect(component.contains("button")).toBe(true);
+    expect(component.classes("sf-button")).toBe(true);
   });
   it("renders default prop text when passed", () => {
     const msg = "HelloWorld";

--- a/packages/vue/src/components/atoms/SfChevron/SfChevron.spec.js
+++ b/packages/vue/src/components/atoms/SfChevron/SfChevron.spec.js
@@ -3,7 +3,7 @@ import SfChevron from "./SfChevron.vue";
 describe.only("SfChevron.vue", () => {
   it("renders a chevron", () => {
     const component = shallowMount(SfChevron);
-    expect(component.contains(".sf-chevron")).toBe(true);
+    expect(component.classes("sf-chevron")).toBe(true);
   });
   it("renders slot with other content", () => {
     const component = shallowMount(SfChevron, {
@@ -11,6 +11,6 @@ describe.only("SfChevron.vue", () => {
         default: "<div class='sf-chevron__chevron'>Some content</div>",
       },
     });
-    expect(component.contains(".sf-chevron__chevron")).toBe(true);
+    expect(component.find(".sf-chevron__chevron").exists()).toBe(true);
   });
 });

--- a/packages/vue/src/components/atoms/SfCircleIcon/SfCircleIcon.spec.js
+++ b/packages/vue/src/components/atoms/SfCircleIcon/SfCircleIcon.spec.js
@@ -3,6 +3,6 @@ import SfCircleIcon from "./SfCircleIcon.vue";
 describe.only("SfCircleIcon.vue", () => {
   it("renders a button", () => {
     const component = shallowMount(SfCircleIcon);
-    expect(component.contains(".sf-circle-icon")).toBe(true);
+    expect(component.classes("sf-circle-icon")).toBe(true);
   });
 });

--- a/packages/vue/src/components/atoms/SfColor/SfColor.spec.js
+++ b/packages/vue/src/components/atoms/SfColor/SfColor.spec.js
@@ -3,6 +3,6 @@ import SfColor from "./SfColor.vue";
 describe("SfColor", () => {
   it("renders a component", () => {
     const component = shallowMount(SfColor);
-    expect(component.contains(".sf-color")).toBe(true);
+    expect(component.classes("sf-color")).toBe(true);
   });
 });

--- a/packages/vue/src/components/atoms/SfDivider/SfDivider.spec.js
+++ b/packages/vue/src/components/atoms/SfDivider/SfDivider.spec.js
@@ -3,6 +3,6 @@ import SfDivider from "./SfDivider.vue";
 describe("SfDivider.vue", () => {
   it("renders a component", () => {
     const component = shallowMount(SfDivider);
-    expect(component.contains(".sf-divider")).toBe(true);
+    expect(component.classes("sf-divider")).toBe(true);
   });
 });

--- a/packages/vue/src/components/atoms/SfHeading/SfHeading.spec.js
+++ b/packages/vue/src/components/atoms/SfHeading/SfHeading.spec.js
@@ -3,6 +3,6 @@ import SfHeading from "./SfHeading.vue";
 describe("SfHeading.vue", () => {
   it("renders a component", () => {
     const component = shallowMount(SfHeading);
-    expect(component.contains(".sf-heading")).toBe(true);
+    expect(component.classes("sf-heading")).toBe(true);
   });
 });

--- a/packages/vue/src/components/atoms/SfIcon/SfIcon.spec.js
+++ b/packages/vue/src/components/atoms/SfIcon/SfIcon.spec.js
@@ -3,7 +3,7 @@ import SfIcon from "./SfIcon.vue";
 describe("SfIcon.vue", () => {
   it("renders a component", () => {
     const component = shallowMount(SfIcon);
-    expect(component.contains(".sf-icon")).toBe(true);
+    expect(component.classes("sf-icon")).toBe(true);
   });
   it("renders path when passed", () => {
     const path =
@@ -22,7 +22,7 @@ describe("SfIcon.vue", () => {
         size: size,
       },
     });
-    expect(component.contains(`.size-${size}`)).toBe(true);
+    expect(component.classes(`size-${size}`)).toBe(true);
   });
   it("renders sf-color when passed", () => {
     const color = "green-primary";
@@ -31,7 +31,7 @@ describe("SfIcon.vue", () => {
         color: color,
       },
     });
-    expect(component.contains(`.color-${color}`)).toBe(true);
+    expect(component.classes(`color-${color}`)).toBe(true);
   });
   it("renders viewBox default when not passed", () => {
     const color = "green-primary";

--- a/packages/vue/src/components/atoms/SfImage/SfImage.spec.js
+++ b/packages/vue/src/components/atoms/SfImage/SfImage.spec.js
@@ -3,6 +3,6 @@ import SfImage from "./SfImage.vue";
 describe("SfImage.vue", () => {
   it("renders a component", () => {
     const component = shallowMount(SfImage, { propsData: {} });
-    expect(component.contains(".sf-image")).toBe(true);
+    expect(component.classes("sf-image")).toBe(true);
   });
 });

--- a/packages/vue/src/components/atoms/SfInput/SfInput.spec.js
+++ b/packages/vue/src/components/atoms/SfInput/SfInput.spec.js
@@ -3,7 +3,7 @@ import SfInput from "./SfInput.vue";
 describe("SfInput.vue", () => {
   it("renders a input", () => {
     const component = shallowMount(SfInput);
-    expect(component.contains(".sf-input")).toBe(true);
+    expect(component.classes("sf-input")).toBe(true);
   });
   it("renders label text when passed", () => {
     const label = "HelloWorld";

--- a/packages/vue/src/components/atoms/SfLink/SfLink.spec.js
+++ b/packages/vue/src/components/atoms/SfLink/SfLink.spec.js
@@ -4,6 +4,6 @@ import SfLink from "./SfLink.vue";
 describe("SfLink.vue", () => {
   it("renders a component", () => {
     const component = shallowMount(SfLink);
-    expect(component.contains(".sf-link")).toBe(true);
+    expect(component.classes("sf-link")).toBe(true);
   });
 });

--- a/packages/vue/src/components/atoms/SfLoader/SfLoader.spec.js
+++ b/packages/vue/src/components/atoms/SfLoader/SfLoader.spec.js
@@ -3,6 +3,6 @@ import SfLoader from "./SfLoader.vue";
 describe("SfLoader.vue", () => {
   it("renders a component", () => {
     const component = shallowMount(SfLoader);
-    expect(component.contains(".sf-loader")).toBe(true);
+    expect(component.classes("sf-loader")).toBe(true);
   });
 });

--- a/packages/vue/src/components/atoms/SfOverlay/SfOverlay.spec.js
+++ b/packages/vue/src/components/atoms/SfOverlay/SfOverlay.spec.js
@@ -7,6 +7,6 @@ describe("SfOverlay.vue", () => {
         visible: true,
       },
     });
-    expect(component.contains(".sf-overlay")).toBe(true);
+    expect(component.find(".sf-overlay").exists()).toBe(true);
   });
 });

--- a/packages/vue/src/components/atoms/SfPrice/SfPrice.spec.js
+++ b/packages/vue/src/components/atoms/SfPrice/SfPrice.spec.js
@@ -3,7 +3,7 @@ import SfPrice from "./SfPrice.vue";
 describe("SfPrice.vue", () => {
   it("renders a component", () => {
     const component = shallowMount(SfPrice);
-    expect(component.contains(".sf-price")).toBe(true);
+    expect(component.classes("sf-price")).toBe(true);
   });
   it("renders regular and special price props passed as String", () => {
     const regPrice = "$3,99";
@@ -15,8 +15,8 @@ describe("SfPrice.vue", () => {
       },
     });
     expect(
-      component.contains(".sf-price__old") &&
-        component.contains(".sf-price__special")
+      component.find(".sf-price__old").exists() &&
+        component.find(".sf-price__special").exists()
     ).toBe(true);
   });
   it("renders regular and special price props passed as Number", () => {
@@ -29,8 +29,8 @@ describe("SfPrice.vue", () => {
       },
     });
     expect(
-      component.contains(".sf-price__old") &&
-        component.contains(".sf-price__special")
+      component.find(".sf-price__old").exists() &&
+        component.find(".sf-price__special").exists()
     ).toBe(true);
   });
   it("renders an old price via slot", () => {
@@ -39,7 +39,7 @@ describe("SfPrice.vue", () => {
         old: "<del class='old'>text</del>",
       },
     });
-    expect(component.contains(".old")).toBe(true);
+    expect(component.find(".old").exists()).toBe(true);
   });
   it("renders a special price via slot", () => {
     const component = shallowMount(SfPrice, {
@@ -48,6 +48,6 @@ describe("SfPrice.vue", () => {
       },
     });
     expect(component.find(".sf-price__special").exists()).toBe(false);
-    expect(component.contains(".special")).toBe(true);
+    expect(component.find(".special").exists()).toBe(true);
   });
 });

--- a/packages/vue/src/components/atoms/SfProperty/SfProperty.spec.js
+++ b/packages/vue/src/components/atoms/SfProperty/SfProperty.spec.js
@@ -3,7 +3,7 @@ import SfProperty from "./SfProperty.vue";
 describe("SfProperty.vue", () => {
   it("renders a component", () => {
     const component = shallowMount(SfProperty);
-    expect(component.contains(".sf-property")).toBe(true);
+    expect(component.classes("sf-property")).toBe(true);
   });
   it("renders a div with correct class", () => {
     const component = shallowMount(SfProperty);

--- a/packages/vue/src/components/atoms/SfQuantitySelector/SfQuantitySelector.spec.js
+++ b/packages/vue/src/components/atoms/SfQuantitySelector/SfQuantitySelector.spec.js
@@ -3,6 +3,6 @@ import SfQuantitySelector from "./SfQuantitySelector.vue";
 describe("SfQuantitySelector.vue", () => {
   it("renders a component", () => {
     const component = shallowMount(SfQuantitySelector);
-    expect(component.contains(".sf-quantity-selector")).toBe(true);
+    expect(component.classes("sf-quantity-selector")).toBe(true);
   });
 });

--- a/packages/vue/src/components/atoms/SfRating/SfRating.spec.js
+++ b/packages/vue/src/components/atoms/SfRating/SfRating.spec.js
@@ -3,7 +3,7 @@ import SfRating from "./SfRating.vue";
 describe("SfRating.vue", () => {
   it("renders a component", () => {
     const component = shallowMount(SfRating);
-    expect(component.contains(".sf-rating")).toBe(true);
+    expect(component.classes("sf-rating")).toBe(true);
   });
   it("render multiple stars when max is increased", () => {
     const score = 4;

--- a/packages/vue/src/components/molecules/SfAddToCart/SfAddToCart.spec.js
+++ b/packages/vue/src/components/molecules/SfAddToCart/SfAddToCart.spec.js
@@ -3,6 +3,6 @@ import SfAddToCart from "./SfAddToCart.vue";
 describe("SfAddToCart.vue", () => {
   it("renders a component", () => {
     const component = shallowMount(SfAddToCart);
-    expect(component.contains(".sf-add-to-cart")).toBe(true);
+    expect(component.classes("sf-add-to-cart")).toBe(true);
   });
 });

--- a/packages/vue/src/components/molecules/SfAlert/SfAlert.spec.js
+++ b/packages/vue/src/components/molecules/SfAlert/SfAlert.spec.js
@@ -3,7 +3,7 @@ import SfAlert from "./SfAlert.vue";
 describe("SfAlert.vue", () => {
   it("renders an alert", () => {
     const component = shallowMount(SfAlert);
-    expect(component.contains(".sf-alert")).toBe(true);
+    expect(component.classes("sf-alert")).toBe(true);
   });
   it("renders an alert with css modifier", () => {
     const component = shallowMount(SfAlert, {
@@ -11,7 +11,7 @@ describe("SfAlert.vue", () => {
         type: "warning",
       },
     });
-    expect(component.contains(".color-warning")).toBe(true);
+    expect(component.find(".color-warning").exists()).toBe(true);
   });
   it("renders an alert message when passed via props", () => {
     const message = "Hello World";
@@ -20,7 +20,7 @@ describe("SfAlert.vue", () => {
         message,
       },
     });
-    expect(component.contains(".sf-alert__message")).toBe(true);
+    expect(component.find(".sf-alert__message").exists()).toBe(true);
     expect(component.find(".sf-alert__message").text()).toMatch(message);
   });
   it("renders an alert icon when passed via slot", () => {
@@ -29,7 +29,7 @@ describe("SfAlert.vue", () => {
         icon: "<img class='slotImg' src='/assets/img.jpg' />",
       },
     });
-    expect(component.contains(".slotImg")).toBe(true);
+    expect(component.find(".slotImg").exists()).toBe(true);
   });
   it("renders an alert message when passed via slot", () => {
     const component = shallowMount(SfAlert, {
@@ -37,6 +37,6 @@ describe("SfAlert.vue", () => {
         message: "<p class='slotMessage'>text</p>",
       },
     });
-    expect(component.contains(".slotMessage")).toBe(true);
+    expect(component.find(".slotMessage").exists()).toBe(true);
   });
 });

--- a/packages/vue/src/components/molecules/SfBanner/SfBanner.spec.js
+++ b/packages/vue/src/components/molecules/SfBanner/SfBanner.spec.js
@@ -4,7 +4,7 @@ import SfBanner from "./SfBanner.vue";
 describe("SfBanner.vue", () => {
   it("renders a banner", () => {
     const component = shallowMount(SfBanner);
-    expect(component.contains(".sf-banner")).toBe(true);
+    expect(component.classes("sf-banner")).toBe(true);
   });
   it("renders title slot text when passed", () => {
     const title = "HelloWorld";

--- a/packages/vue/src/components/molecules/SfBar/SfBar.spec.js
+++ b/packages/vue/src/components/molecules/SfBar/SfBar.spec.js
@@ -3,6 +3,6 @@ import SfBar from "@/components/molecules/SfBar/SfBar.vue";
 describe("SfBar.vue", () => {
   it("renders a component", () => {
     const component = shallowMount(SfBar);
-    expect(component.contains(".sf-bar")).toBe(true);
+    expect(component.classes("sf-bar")).toBe(true);
   });
 });

--- a/packages/vue/src/components/molecules/SfCallToAction/SfCallToAction.spec.js
+++ b/packages/vue/src/components/molecules/SfCallToAction/SfCallToAction.spec.js
@@ -3,7 +3,7 @@ import SfCallToAction from "./SfCallToAction.vue";
 describe("SfCallToAction.vue", () => {
   it("renders a section", () => {
     const component = shallowMount(SfCallToAction);
-    expect(component.contains("section")).toBe(true);
+    expect(component.classes("sf-call-to-action")).toBe(true);
   });
   it("renders title text when passed", () => {
     const msg = "HelloWorld";

--- a/packages/vue/src/components/molecules/SfCharacteristic/SfCharacteristic.spec.js
+++ b/packages/vue/src/components/molecules/SfCharacteristic/SfCharacteristic.spec.js
@@ -3,7 +3,7 @@ import SfCharacteristic from "./SfCharacteristic.vue";
 describe.only("SfCharacteristic.vue", () => {
   it("renders a characteristic", () => {
     const component = shallowMount(SfCharacteristic);
-    expect(component.contains(".sf-characteristic")).toBe(true);
+    expect(component.classes("sf-characteristic")).toBe(true);
   });
   it("renders slot with icon when passed", () => {
     const icon = "<svg class='sf-characteristic'></svg>";
@@ -12,7 +12,7 @@ describe.only("SfCharacteristic.vue", () => {
         icon,
       },
     });
-    expect(component.contains(".sf-characteristic")).toBe(true);
+    expect(component.classes("sf-characteristic")).toBe(true);
   });
   it("renders slot with icon when passed", () => {
     const title = "<p class='sf-characteristic__title'></p>";
@@ -21,7 +21,7 @@ describe.only("SfCharacteristic.vue", () => {
         title,
       },
     });
-    expect(component.contains(".sf-characteristic__title")).toBe(true);
+    expect(component.find(".sf-characteristic__title").exists()).toBe(true);
   });
   it("renders slot with icon when passed", () => {
     const description = "<p class='sf-characteristic__description'></p>";
@@ -30,6 +30,8 @@ describe.only("SfCharacteristic.vue", () => {
         description,
       },
     });
-    expect(component.contains(".sf-characteristic__description")).toBe(true);
+    expect(component.find(".sf-characteristic__description").exists()).toBe(
+      true
+    );
   });
 });

--- a/packages/vue/src/components/molecules/SfCheckbox/SfCheckbox.spec.js
+++ b/packages/vue/src/components/molecules/SfCheckbox/SfCheckbox.spec.js
@@ -3,7 +3,7 @@ import SfCheckbox from "./SfCheckbox.vue";
 describe("SfCheckbox.vue", () => {
   it("renders a checkbox", () => {
     const component = shallowMount(SfCheckbox);
-    expect(component.contains("input[type='checkbox']")).toBe(true);
+    expect(component.find(".sf-checkbox__input").exists()).toBe(true);
   });
   it("renders label text when passed", () => {
     const msg = "HelloWorld";

--- a/packages/vue/src/components/molecules/SfDropdown/SfDropdown.spec.js
+++ b/packages/vue/src/components/molecules/SfDropdown/SfDropdown.spec.js
@@ -7,6 +7,6 @@ describe("SfDropdown.vue", () => {
         isOpen: true,
       },
     });
-    expect(component.contains(".sf-dropdown")).toBe(true);
+    expect(component.classes("sf-dropdown")).toBe(true);
   });
 });

--- a/packages/vue/src/components/molecules/SfFilter/SfFilter.spec.js
+++ b/packages/vue/src/components/molecules/SfFilter/SfFilter.spec.js
@@ -3,6 +3,6 @@ import SfFilter from "./SfFilter.vue";
 describe("SfFilter.vue", () => {
   it("renders a component", () => {
     const component = shallowMount(SfFilter);
-    expect(component.contains(".sf-filter")).toBe(true);
+    expect(component.classes("sf-filter")).toBe(true);
   });
 });

--- a/packages/vue/src/components/molecules/SfGallery/SfGallery.spec.js
+++ b/packages/vue/src/components/molecules/SfGallery/SfGallery.spec.js
@@ -3,6 +3,6 @@ import SfGallery from "./SfGallery.vue";
 describe("SfGallery.vue", () => {
   it("renders a component", () => {
     const component = shallowMount(SfGallery);
-    expect(component.contains(".sf-gallery")).toBe(true);
+    expect(component.classes("sf-gallery")).toBe(true);
   });
 });

--- a/packages/vue/src/components/molecules/SfMenuItem/SfMenuItem.spec.js
+++ b/packages/vue/src/components/molecules/SfMenuItem/SfMenuItem.spec.js
@@ -3,7 +3,7 @@ import SfMenuItem from "./SfMenuItem.vue";
 describe("SfMenuItem.vue", () => {
   it("renders a component", () => {
     const component = shallowMount(SfMenuItem);
-    expect(component.contains(".sf-menu-item")).toBe(true);
+    expect(component.classes("sf-menu-item")).toBe(true);
   });
   it("renders a div with correct class", () => {
     const component = shallowMount(SfMenuItem);

--- a/packages/vue/src/components/molecules/SfModal/SfModal.spec.js
+++ b/packages/vue/src/components/molecules/SfModal/SfModal.spec.js
@@ -3,6 +3,6 @@ import SfModal from "./SfModal.vue";
 describe("SfModal.vue", () => {
   it("renders a component", () => {
     const component = shallowMount(SfModal);
-    expect(component.contains(".sf-modal")).toBe(true);
+    expect(component.classes("sf-modal")).toBe(true);
   });
 });

--- a/packages/vue/src/components/molecules/SfNotification/SfNotification.spec.js
+++ b/packages/vue/src/components/molecules/SfNotification/SfNotification.spec.js
@@ -7,7 +7,7 @@ describe("SfNotification.vue", () => {
         visible: true,
       },
     });
-    expect(component.contains(".sf-notification")).toBe(true);
+    expect(component.find(".sf-notification").exists()).toBe(true);
   });
   it("renders the message when passed via props", () => {
     const message = "Hello World";
@@ -26,7 +26,7 @@ describe("SfNotification.vue", () => {
         icon: "info",
       },
     });
-    expect(component.contains(".sf-notification__icon")).toBe(true);
+    expect(component.find(".sf-notification__icon").exists()).toBe(true);
   });
   it("renders an alert icon when passed via slot", () => {
     const component = shallowMount(SfNotification, {
@@ -37,7 +37,7 @@ describe("SfNotification.vue", () => {
         icon: "<img class='slotImg' src='/assets/img.jpg' />",
       },
     });
-    expect(component.contains(".slotImg")).toBe(true);
+    expect(component.find(".slotImg").exists()).toBe(true);
   });
   it("renders an alert message when passed via slot", () => {
     const component = shallowMount(SfNotification, {
@@ -48,6 +48,6 @@ describe("SfNotification.vue", () => {
         message: "<p class='slotMessage'>text</p>",
       },
     });
-    expect(component.contains(".slotMessage")).toBe(true);
+    expect(component.find(".slotMessage").exists()).toBe(true);
   });
 });

--- a/packages/vue/src/components/molecules/SfPagination/SfPagination.spec.js
+++ b/packages/vue/src/components/molecules/SfPagination/SfPagination.spec.js
@@ -4,6 +4,6 @@ import SfPagination from "./SfPagination.vue";
 describe("SfPagination.vue", () => {
   it("renders a pagination", () => {
     const component = shallowMount(SfPagination);
-    expect(component.contains("nav")).toBe(true);
+    expect(component.classes("sf-pagination")).toBe(true);
   });
 });

--- a/packages/vue/src/components/molecules/SfProductOption/SfProductionOption.spec.js
+++ b/packages/vue/src/components/molecules/SfProductOption/SfProductionOption.spec.js
@@ -3,6 +3,6 @@ import SfProductOption from "./SfProductOption.vue";
 describe("SfProductOption.vue", () => {
   it("renders a component", () => {
     const component = shallowMount(SfProductOption);
-    expect(component.contains(".sf-product-option")).toBe(true);
+    expect(component.classes("sf-product-option")).toBe(true);
   });
 });

--- a/packages/vue/src/components/molecules/SfRadio/SfRadio.spec.js
+++ b/packages/vue/src/components/molecules/SfRadio/SfRadio.spec.js
@@ -3,6 +3,6 @@ import SfRadio from "./SfRadio.vue";
 describe("SfRadio.vue", () => {
   it("renders a component", () => {
     const component = shallowMount(SfRadio);
-    expect(component.contains(".sf-radio")).toBe(true);
+    expect(component.classes("sf-radio")).toBe(true);
   });
 });

--- a/packages/vue/src/components/molecules/SfReview/SfReview.spec.js
+++ b/packages/vue/src/components/molecules/SfReview/SfReview.spec.js
@@ -3,6 +3,6 @@ import SfReview from "./SfReview.vue";
 describe("SfReview.vue", () => {
   it("renders a component", () => {
     const component = shallowMount(SfReview);
-    expect(component.contains(".sf-review")).toBe(true);
+    expect(component.classes("sf-review")).toBe(true);
   });
 });

--- a/packages/vue/src/components/molecules/SfScrollable/SfScrollable.spec.js
+++ b/packages/vue/src/components/molecules/SfScrollable/SfScrollable.spec.js
@@ -3,6 +3,6 @@ import SfScrollable from "./SfScrollable.vue";
 describe("SfScrollable.vue", () => {
   it("renders a component", () => {
     const component = shallowMount(SfScrollable);
-    expect(component.contains(".sf-scrollable")).toBe(true);
+    expect(component.classes("sf-scrollable")).toBe(true);
   });
 });

--- a/packages/vue/src/components/molecules/SfSearchBar/SfSearchBar.spec.js
+++ b/packages/vue/src/components/molecules/SfSearchBar/SfSearchBar.spec.js
@@ -3,7 +3,7 @@ import SfSearchBar from "./SfSearchBar.vue";
 describe.only("SfSearchBar.vue", () => {
   it("renders a search bar", () => {
     const component = shallowMount(SfSearchBar);
-    expect(component.contains(".sf-search-bar")).toBe(true);
+    expect(component.classes("sf-search-bar")).toBe(true);
   });
   it("renders slot with icon when passed", () => {
     const icon = "<svg class='sf-search-bar__icon'></svg>";
@@ -12,7 +12,7 @@ describe.only("SfSearchBar.vue", () => {
         icon,
       },
     });
-    expect(component.contains(".sf-search-bar__icon")).toBe(true);
+    expect(component.find(".sf-search-bar__icon").exists()).toBe(true);
   });
   it("renders slot with clear icon when passed", () => {
     const icon = "<span class='sf-search-bar__clear-icon'></span>";
@@ -21,7 +21,7 @@ describe.only("SfSearchBar.vue", () => {
         icon,
       },
     });
-    expect(component.contains(".sf-search-bar__clear-icon")).toBe(true);
+    expect(component.find(".sf-search-bar__clear-icon").exists()).toBe(true);
   });
   it("renders placeholder props when passed", () => {
     const placeholder = "Search for...";

--- a/packages/vue/src/components/molecules/SfSection/SfSection.spec.js
+++ b/packages/vue/src/components/molecules/SfSection/SfSection.spec.js
@@ -3,6 +3,6 @@ import SfSection from "./SfSection.vue";
 describe("SfSection.vue", () => {
   it("renders a component", () => {
     const component = shallowMount(SfSection);
-    expect(component.contains(".sf-section")).toBe(true);
+    expect(component.classes("sf-section")).toBe(true);
   });
 });

--- a/packages/vue/src/components/molecules/SfSelect/SfSelect.spec.js
+++ b/packages/vue/src/components/molecules/SfSelect/SfSelect.spec.js
@@ -3,6 +3,6 @@ import SfSelect from "./SfSelect.vue";
 describe("SfSelect.vue", () => {
   it("renders a component", () => {
     const component = shallowMount(SfSelect);
-    expect(component.contains(".sf-select")).toBe(true);
+    expect(component.classes("sf-select")).toBe(true);
   });
 });

--- a/packages/vue/src/components/molecules/SfSelect/_internal/SfSelectOption.spec.js
+++ b/packages/vue/src/components/molecules/SfSelect/_internal/SfSelectOption.spec.js
@@ -3,6 +3,6 @@ import SfSelectOption from "./SfSelectOption.vue";
 describe("SfSelectOption.vue", () => {
   it("renders a component", () => {
     const component = shallowMount(SfSelectOption);
-    expect(component.contains(".sf-select-option")).toBe(true);
+    expect(component.classes("sf-select-option")).toBe(true);
   });
 });

--- a/packages/vue/src/components/molecules/SfSlidingSection/SfSlidingSection.spec.js
+++ b/packages/vue/src/components/molecules/SfSlidingSection/SfSlidingSection.spec.js
@@ -3,6 +3,6 @@ import SfSlidingSection from "./SfSlidingSection.vue";
 describe("SfSlidingSection.vue", () => {
   it("renders a component", () => {
     const component = shallowMount(SfSlidingSection);
-    expect(component.contains(".sf-sliding-section")).toBe(true);
+    expect(component.classes("sf-sliding-section")).toBe(true);
   });
 });

--- a/packages/vue/src/components/molecules/SfSteps/SfSteps.spec.js
+++ b/packages/vue/src/components/molecules/SfSteps/SfSteps.spec.js
@@ -7,6 +7,6 @@ describe("SfSteps.vue", () => {
         steps: ["one", "two"],
       },
     });
-    expect(component.contains(".sf-steps")).toBe(true);
+    expect(component.classes("sf-steps")).toBe(true);
   });
 });

--- a/packages/vue/src/components/molecules/SfSteps/_internal/SfStep.spec.js
+++ b/packages/vue/src/components/molecules/SfSteps/_internal/SfStep.spec.js
@@ -25,6 +25,6 @@ describe("SfStep.vue", () => {
         };
       },
     });
-    expect(component.contains(".sf-step")).toBe(true);
+    expect(component.classes("sf-step")).toBe(true);
   });
 });

--- a/packages/vue/src/components/molecules/SfSticky/SfSticky.spec.js
+++ b/packages/vue/src/components/molecules/SfSticky/SfSticky.spec.js
@@ -3,6 +3,6 @@ import SfSticky from "./SfSticky.vue";
 describe("SfSticky.vue", () => {
   it("renders a component", () => {
     const component = shallowMount(SfSticky);
-    expect(component.contains(".sf-sticky")).toBe(true);
+    expect(component.classes("sf-sticky")).toBe(true);
   });
 });

--- a/packages/vue/src/components/organisms/SfAccordion/SfAccordion.spec.js
+++ b/packages/vue/src/components/organisms/SfAccordion/SfAccordion.spec.js
@@ -3,6 +3,6 @@ import SfAccordion from "./SfAccordion.vue";
 describe("SfAccordion.vue", () => {
   it("renders a component", () => {
     const component = shallowMount(SfAccordion);
-    expect(component.contains(".sf-accordion")).toBe(true);
+    expect(component.classes("sf-accordion")).toBe(true);
   });
 });

--- a/packages/vue/src/components/organisms/SfAccordion/_internal/SfAccordionItem.spec.js
+++ b/packages/vue/src/components/organisms/SfAccordion/_internal/SfAccordionItem.spec.js
@@ -3,6 +3,6 @@ import SfAccordionItem from "./SfAccordionItem.vue";
 describe("SfAccordionItem.vue", () => {
   it("renders a component", () => {
     const component = shallowMount(SfAccordionItem);
-    expect(component.contains(".sf-accordion-item")).toBe(true);
+    expect(component.classes("sf-accordion-item")).toBe(true);
   });
 });

--- a/packages/vue/src/components/organisms/SfBannerGrid/SfBannerGrid.spec.js
+++ b/packages/vue/src/components/organisms/SfBannerGrid/SfBannerGrid.spec.js
@@ -3,6 +3,6 @@ import SfBannerGrid from "./SfBannerGrid.vue";
 describe("SfBannerGrid.vue", () => {
   it("renders a component", () => {
     const component = shallowMount(SfBannerGrid);
-    expect(component.contains(".sf-banner-grid")).toBe(true);
+    expect(component.classes("sf-banner-grid")).toBe(true);
   });
 });

--- a/packages/vue/src/components/organisms/SfBottomNavigation/SfBottomNavigation.spec.js
+++ b/packages/vue/src/components/organisms/SfBottomNavigation/SfBottomNavigation.spec.js
@@ -3,6 +3,6 @@ import SfBottomNavigation from "./SfBottomNavigation.vue";
 describe("SfBottomNavigation.vue", () => {
   it("renders a component", () => {
     const component = shallowMount(SfBottomNavigation);
-    expect(component.contains(".sf-bottom-navigation")).toBe(true);
+    expect(component.classes("sf-bottom-navigation")).toBe(true);
   });
 });

--- a/packages/vue/src/components/organisms/SfBottomNavigation/_internal/SfBottomNavigationItem.spec.js
+++ b/packages/vue/src/components/organisms/SfBottomNavigation/_internal/SfBottomNavigationItem.spec.js
@@ -3,6 +3,6 @@ import SfBottomNavigationItem from "./SfBottomNavigationItem.vue";
 describe("SfBottomNavigationItem.vue", () => {
   it("renders a component", () => {
     const component = shallowMount(SfBottomNavigationItem);
-    expect(component.contains(".sf-bottom-navigation-item")).toBe(true);
+    expect(component.classes("sf-bottom-navigation-item")).toBe(true);
   });
 });

--- a/packages/vue/src/components/organisms/SfCarousel/SfCarousel.spec.js
+++ b/packages/vue/src/components/organisms/SfCarousel/SfCarousel.spec.js
@@ -3,6 +3,6 @@ import SfCarousel from "./SfCarousel.vue";
 describe("SfCarousel.vue", () => {
   it("renders a component", () => {
     const component = shallowMount(SfCarousel);
-    expect(component.contains(".sf-carousel")).toBe(true);
+    expect(component.classes("sf-carousel")).toBe(true);
   });
 });

--- a/packages/vue/src/components/organisms/SfCarousel/_internal/SfCarouselItem.spec.js
+++ b/packages/vue/src/components/organisms/SfCarousel/_internal/SfCarouselItem.spec.js
@@ -3,6 +3,6 @@ import SfCarouselItem from "./SfCarouselItem.vue";
 describe("SfCarouselItem.vue", () => {
   it("renders a component", () => {
     const component = shallowMount(SfCarouselItem);
-    expect(component.contains(".sf-carousel-item")).toBe(true);
+    expect(component.classes("sf-carousel-item")).toBe(true);
   });
 });

--- a/packages/vue/src/components/organisms/SfCollectedProduct/SfCollectedProduct.spec.js
+++ b/packages/vue/src/components/organisms/SfCollectedProduct/SfCollectedProduct.spec.js
@@ -8,6 +8,6 @@ describe("SfCollectedProduct.vue", () => {
         title,
       },
     });
-    expect(component.contains(".sf-collected-product")).toBe(true);
+    expect(component.classes("sf-collected-product")).toBe(true);
   });
 });

--- a/packages/vue/src/components/organisms/SfContentPages/SfContentPages.spec.js
+++ b/packages/vue/src/components/organisms/SfContentPages/SfContentPages.spec.js
@@ -15,6 +15,6 @@ describe("SfContentPages.vue", () => {
         },
       },
     });
-    expect(component.contains(".sf-content-pages")).toBe(true);
+    expect(component.classes("sf-content-pages")).toBe(true);
   });
 });

--- a/packages/vue/src/components/organisms/SfContentPages/_internal/SfContentCategory.spec.js
+++ b/packages/vue/src/components/organisms/SfContentPages/_internal/SfContentCategory.spec.js
@@ -6,6 +6,6 @@ describe("SfContentCategory.vue", () => {
     const component = shallowMount(SfContentCategory, {
       parentComponent: SfContentPages,
     });
-    expect(component.contains(".sf-content-category")).toBe(true);
+    expect(component.classes("sf-content-category")).toBe(true);
   });
 });

--- a/packages/vue/src/components/organisms/SfContentPages/_internal/SfContentPage.spec.js
+++ b/packages/vue/src/components/organisms/SfContentPages/_internal/SfContentPage.spec.js
@@ -18,6 +18,6 @@ describe("SfContentPage.vue", () => {
         },
       },
     });
-    expect(component.contains(".sf-content-page")).toBe(true);
+    expect(component.classes("sf-content-page")).toBe(true);
   });
 });

--- a/packages/vue/src/components/organisms/SfFooter/SfFooter.spec.js
+++ b/packages/vue/src/components/organisms/SfFooter/SfFooter.spec.js
@@ -4,6 +4,6 @@ import SfFooter from "@/components/organisms/SfFooter/SfFooter.vue";
 describe("SfFooter.vue", () => {
   it("renders a component", () => {
     const component = shallowMount(SfFooter);
-    expect(component.contains(".sf-footer")).toBe(true);
+    expect(component.classes("sf-footer")).toBe(true);
   });
 });

--- a/packages/vue/src/components/organisms/SfFooter/_internal/SfFooterColumn.spec.js
+++ b/packages/vue/src/components/organisms/SfFooter/_internal/SfFooterColumn.spec.js
@@ -7,6 +7,6 @@ describe("SfFooterColumn.vue", () => {
     const component = shallowMount(SfFooterColumn, {
       parentComponent: SfFooter,
     });
-    expect(component.contains(".sf-footer-column")).toBe(true);
+    expect(component.classes("sf-footer-column")).toBe(true);
   });
 });

--- a/packages/vue/src/components/organisms/SfGroupedProduct/SfGroupedProduct.spec.js
+++ b/packages/vue/src/components/organisms/SfGroupedProduct/SfGroupedProduct.spec.js
@@ -3,6 +3,6 @@ import SfGroupedProduct from "@/components/organisms/SfGroupedProduct/SfGroupedP
 describe("SfGroupedProduct.vue", () => {
   it("renders a component", () => {
     const component = shallowMount(SfGroupedProduct);
-    expect(component.contains(".sf-grouped-product")).toBe(true);
+    expect(component.classes("sf-grouped-product")).toBe(true);
   });
 });

--- a/packages/vue/src/components/organisms/SfGroupedProduct/_internal/SfGroupedProductionItem.spec.js
+++ b/packages/vue/src/components/organisms/SfGroupedProduct/_internal/SfGroupedProductionItem.spec.js
@@ -3,6 +3,6 @@ import SfGroupedProductItem from "./SfGroupedProductItem.vue";
 describe("SfGroupedProductItem.vue", () => {
   it("renders a component", () => {
     const component = shallowMount(SfGroupedProductItem);
-    expect(component.contains(".sf-grouped-product-item")).toBe(true);
+    expect(component.classes("sf-grouped-product-item")).toBe(true);
   });
 });

--- a/packages/vue/src/components/organisms/SfHeader/SfHeader.spec.js
+++ b/packages/vue/src/components/organisms/SfHeader/SfHeader.spec.js
@@ -3,6 +3,6 @@ import SfHeader from "./SfHeader.vue";
 describe("SfHeader.vue", () => {
   it("renders a component", () => {
     const component = shallowMount(SfHeader);
-    expect(component.contains("header")).toBe(true);
+    expect(component.classes("sf-header")).toBe(true);
   });
 });

--- a/packages/vue/src/components/organisms/SfHeader/_internal/SfHeaderNavigationItem.spec.js
+++ b/packages/vue/src/components/organisms/SfHeader/_internal/SfHeaderNavigationItem.spec.js
@@ -3,6 +3,6 @@ import SfHeaderNavigationItem from "./SfHeaderNavigationItem.vue";
 describe("SfHeaderNavigationItem.vue", () => {
   it("renders a component", () => {
     const component = shallowMount(SfHeaderNavigationItem);
-    expect(component.contains(".sf-header-navigation-item")).toBe(true);
+    expect(component.classes("sf-header-navigation-item")).toBe(true);
   });
 });

--- a/packages/vue/src/components/organisms/SfHero/SfHero.spec.js
+++ b/packages/vue/src/components/organisms/SfHero/SfHero.spec.js
@@ -55,7 +55,7 @@ describe("SfHero.vue", () => {
       component.destroy();
     });
     it("renders a component", () => {
-      expect(component.contains(".sf-hero")).toBe(true);
+      expect(component.classes("sf-hero")).toBe(true);
     });
     it("renders three SfHeroItem components when passed three items", () => {
       expect(component.findAll(SfHeroItem)).toHaveLength(items.length);

--- a/packages/vue/src/components/organisms/SfHero/_internal/SfHeroItem.spec.js
+++ b/packages/vue/src/components/organisms/SfHero/_internal/SfHeroItem.spec.js
@@ -24,7 +24,7 @@ describe("SfHeroItem.vue", () => {
       component.destroy();
     });
     it("renders a component", () => {
-      expect(component.contains(".sf-hero-item")).toBe(true);
+      expect(component.classes("sf-hero-item")).toBe(true);
     });
     it("renders title correctly", () => {
       expect(component.text()).toContain(title);
@@ -33,7 +33,7 @@ describe("SfHeroItem.vue", () => {
       expect(component.text()).toContain(subtitle);
     });
     it("renders SfButton correctly", () => {
-      expect(component.find(SfButton).text()).toContain(buttonText);
+      expect(component.findComponent(SfButton).text()).toContain(buttonText);
     });
   });
   describe("with items passed through slots", () => {

--- a/packages/vue/src/components/organisms/SfList/SfList.spec.js
+++ b/packages/vue/src/components/organisms/SfList/SfList.spec.js
@@ -3,7 +3,7 @@ import SfList from "./SfList.vue";
 describe("SfList.vue", () => {
   it("renders a component", () => {
     const component = shallowMount(SfList);
-    expect(component.contains(".sf-list")).toBe(true);
+    expect(component.classes("sf-list")).toBe(true);
   });
   // todo: test defautl slot, test if SfListItem is rendered
 });

--- a/packages/vue/src/components/organisms/SfList/_internal/SfListItem.spec.js
+++ b/packages/vue/src/components/organisms/SfList/_internal/SfListItem.spec.js
@@ -3,6 +3,6 @@ import SfListItem from "./SfListItem.vue";
 describe("SfListItem.vue", () => {
   it("renders a component", () => {
     const component = shallowMount(SfListItem);
-    expect(component.contains(".sf-list__item")).toBe(true);
+    expect(component.classes("sf-list__item")).toBe(true);
   });
 });

--- a/packages/vue/src/components/organisms/SfMegaMenu/SfMegaMenu.spec.js
+++ b/packages/vue/src/components/organisms/SfMegaMenu/SfMegaMenu.spec.js
@@ -6,6 +6,6 @@ describe("SfMegaMenu.vue", () => {
     const component = shallowMount(SfMegaMenu, {
       propsData: { visible: true },
     });
-    expect(component.contains(".sf-mega-menu")).toBe(true);
+    expect(component.find(".sf-mega-menu").exists()).toBe(true);
   });
 });

--- a/packages/vue/src/components/organisms/SfProductCard/SfProductCard.spec.js
+++ b/packages/vue/src/components/organisms/SfProductCard/SfProductCard.spec.js
@@ -1,5 +1,6 @@
 import { shallowMount } from "@vue/test-utils";
 import SfProductCard from "./SfProductCard.vue";
+import "@testing-library/jest-dom";
 const title = "Product A";
 const wishlistIconButtonClass = ".sf-product-card__wishlist-icon";
 const clickEventName = "click:wishlist";
@@ -11,8 +12,7 @@ describe("SfProductCard.vue", () => {
       },
     });
     expect(component.exists()).toBe(true);
-    expect(component.isVueInstance()).toBe(true);
-    expect(component.isVisible()).toBe(true);
+    expect(component.find(".sf-product-card").element).toBeVisible();
   });
 });
 describe("SfProductCard.vue: Wish list icon button", () => {
@@ -23,8 +23,7 @@ describe("SfProductCard.vue: Wish list icon button", () => {
       },
     });
     expect(component.exists()).toBe(true);
-    expect(component.isVueInstance()).toBe(true);
-    expect(component.isVisible()).toBe(true);
+    expect(component.find(".sf-product-card").element).toBeVisible();
   });
   it("has correct CSS class for container", () => {
     const component = shallowMount(SfProductCard, {

--- a/packages/vue/src/components/organisms/SfProductCardHorizontal/SfProductCardHorizontal.spec.js
+++ b/packages/vue/src/components/organisms/SfProductCardHorizontal/SfProductCardHorizontal.spec.js
@@ -3,6 +3,6 @@ import SfProductCardHorizontal from "./SfProductCardHorizontal.vue";
 describe("SfProductCardHorizontal.vue", () => {
   it("renders a component", () => {
     const component = shallowMount(SfProductCardHorizontal);
-    expect(component.contains(".sf-product-card-horizontal")).toBe(true);
+    expect(component.classes("sf-product-card-horizontal")).toBe(true);
   });
 });

--- a/packages/vue/src/components/organisms/SfSidebar/SfSidebar.spec.js
+++ b/packages/vue/src/components/organisms/SfSidebar/SfSidebar.spec.js
@@ -7,6 +7,6 @@ describe("SfSidebar.vue", () => {
         visible: true,
       },
     });
-    expect(component.contains(".sf-sidebar")).toBe(true);
+    expect(component.classes("sf-sidebar")).toBe(true);
   });
 });

--- a/packages/vue/src/components/organisms/SfStoreLocator/SfStoreLocator.spec.js
+++ b/packages/vue/src/components/organisms/SfStoreLocator/SfStoreLocator.spec.js
@@ -3,7 +3,7 @@ import SfStoreLocator from "./SfStoreLocator.vue";
 describe("SfStoreLocator.vue", () => {
   it("renders a component", () => {
     const component = shallowMount(SfStoreLocator, {});
-    expect(component.contains(".sf-store-locator")).toBe(true);
+    expect(component.classes("sf-store-locator")).toBe(true);
   });
   it("emits on event when vue2-leaflet is loaded", (done) => {
     const component = shallowMount(SfStoreLocator, {

--- a/packages/vue/src/components/organisms/SfStoreLocator/_internal/SfStore.spec.js
+++ b/packages/vue/src/components/organisms/SfStoreLocator/_internal/SfStore.spec.js
@@ -25,6 +25,6 @@ describe("SfStore.vue", () => {
         };
       },
     });
-    expect(component.contains(".sf-store")).toBe(true);
+    expect(component.classes("sf-store")).toBe(true);
   });
 });

--- a/packages/vue/src/components/organisms/SfTable/SfTable.spec.js
+++ b/packages/vue/src/components/organisms/SfTable/SfTable.spec.js
@@ -3,6 +3,6 @@ import SfTable from "./SfTable.vue";
 describe("SfTable.vue", () => {
   it("renders a component", () => {
     const component = shallowMount(SfTable);
-    expect(component.contains(".sf-table")).toBe(true);
+    expect(component.classes("sf-table")).toBe(true);
   });
 });

--- a/packages/vue/src/components/organisms/SfTable/_internal/SfTableData.spec.js
+++ b/packages/vue/src/components/organisms/SfTable/_internal/SfTableData.spec.js
@@ -3,6 +3,6 @@ import SfTableData from "./SfTableData.vue";
 describe("SfTableData.vue", () => {
   it("renders a component", () => {
     const component = shallowMount(SfTableData);
-    expect(component.contains(".sf-table__data")).toBe(true);
+    expect(component.classes("sf-table__data")).toBe(true);
   });
 });

--- a/packages/vue/src/components/organisms/SfTable/_internal/SfTableHeader.spec.js
+++ b/packages/vue/src/components/organisms/SfTable/_internal/SfTableHeader.spec.js
@@ -3,6 +3,6 @@ import SfTableHeader from "./SfTableHeader.vue";
 describe("SfTableHeader.vue", () => {
   it("renders a component", () => {
     const component = shallowMount(SfTableHeader);
-    expect(component.contains(".sf-table__header")).toBe(true);
+    expect(component.classes("sf-table__header")).toBe(true);
   });
 });

--- a/packages/vue/src/components/organisms/SfTable/_internal/SfTableHeading.spec.js
+++ b/packages/vue/src/components/organisms/SfTable/_internal/SfTableHeading.spec.js
@@ -10,6 +10,6 @@ describe("SfTableHeading.vue", () => {
         };
       },
     });
-    expect(component.contains(".sf-table__heading")).toBe(true);
+    expect(component.classes("sf-table__heading")).toBe(true);
   });
 });

--- a/packages/vue/src/components/organisms/SfTable/_internal/SfTableRow.spec.js
+++ b/packages/vue/src/components/organisms/SfTable/_internal/SfTableRow.spec.js
@@ -10,6 +10,6 @@ describe("SfTableRow.vue", () => {
         };
       },
     });
-    expect(component.contains(".sf-table__row")).toBe(true);
+    expect(component.classes("sf-table__row")).toBe(true);
   });
 });

--- a/packages/vue/src/components/organisms/SfTabs/SfTabs.spec.js
+++ b/packages/vue/src/components/organisms/SfTabs/SfTabs.spec.js
@@ -3,7 +3,7 @@ import SfTabs from "./SfTabs.vue";
 describe("SfTabs.vue", () => {
   it("renders a tabs", () => {
     const component = shallowMount(SfTabs);
-    expect(component.contains(".sf-tabs")).toBe(true);
+    expect(component.classes("sf-tabs")).toBe(true);
   });
   it("checks if Tab slot is passed correctly", () => {
     const component = shallowMount(SfTabs, {

--- a/packages/vue/src/components/organisms/SfTabs/_internal/SfTab.spec.js
+++ b/packages/vue/src/components/organisms/SfTabs/_internal/SfTab.spec.js
@@ -3,6 +3,6 @@ import SfTab from "./SfTab.vue";
 describe("SfTab.vue", () => {
   it("renders a component", () => {
     const component = shallowMount(SfTab);
-    expect(component.contains(".sf-tabs__title")).toBe(true);
+    expect(component.find(".sf-tabs__title").exists()).toBe(true);
   });
 });

--- a/packages/vue/src/components/organisms/SfTopBar/SfTopBar.spec.js
+++ b/packages/vue/src/components/organisms/SfTopBar/SfTopBar.spec.js
@@ -3,7 +3,7 @@ import SfTopBar from "./SfTopBar.vue";
 describe("SfTopBar", () => {
   it("renders a container element", () => {
     const component = shallowMount(SfTopBar, {});
-    expect(component.contains(".sf-top-bar")).toBe(true);
+    expect(component.classes("sf-top-bar")).toBe(true);
   });
   // Left slot check
   it("renders left slot content when passed", () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -810,10 +810,25 @@
     "@babel/types" "^7.4.4"
     esutils "^2.0.2"
 
+"@babel/runtime-corejs3@^7.10.2":
+  version "7.10.5"
+  resolved "https://registry.yarnpkg.com/@babel/runtime-corejs3/-/runtime-corejs3-7.10.5.tgz#a57fe6c13045ca33768a2aa527ead795146febe1"
+  integrity sha512-RMafpmrNB5E/bwdSphLr8a8++9TosnyJp98RZzI6VOx2R2CCMpsXXXRvmI700O9oEKpXdZat6oEK68/F0zjd4A==
+  dependencies:
+    core-js-pure "^3.0.0"
+    regenerator-runtime "^0.13.4"
+
 "@babel/runtime@^7.0.0", "@babel/runtime@^7.1.2", "@babel/runtime@^7.3.1", "@babel/runtime@^7.4.4", "@babel/runtime@^7.5.0", "@babel/runtime@^7.5.5", "@babel/runtime@^7.6.3", "@babel/runtime@^7.7.2", "@babel/runtime@^7.8.4", "@babel/runtime@^7.8.7", "@babel/runtime@^7.9.2", "@babel/runtime@^7.9.6":
   version "7.10.2"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.10.2.tgz#d103f21f2602497d38348a32e008637d506db839"
   integrity sha512-6sF3uQw2ivImfVIl62RZ7MXhO2tap69WeWK57vAaimT6AZbE4FbqjdEJIN1UqoD6wI6B+1n9UiagafH1sxjOtg==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
+"@babel/runtime@^7.10.2":
+  version "7.10.5"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.10.5.tgz#303d8bd440ecd5a491eae6117fd3367698674c5c"
+  integrity sha512-otddXKhdNn7d0ptoFRHtMLa8LqDxLYwTjB4nYgM1yy5N6gU/MUf8zqyyLltCH3yAVitBzmwK4us+DD0l/MauAg==
   dependencies:
     regenerator-runtime "^0.13.4"
 
@@ -2922,6 +2937,22 @@
   dependencies:
     defer-to-connect "^1.0.1"
 
+"@testing-library/jest-dom@^5.11.1":
+  version "5.11.1"
+  resolved "https://registry.yarnpkg.com/@testing-library/jest-dom/-/jest-dom-5.11.1.tgz#b9541d7625cec9e5feb647f49a96c43f7c055cdd"
+  integrity sha512-NHOHjDwyBoqM7mXjNLieSp/6vJ17DILzhNTw7+RarluaBkyWRzWgFj+d6xnd1adMBlwfQSeR2FWGTxHXCxeMSA==
+  dependencies:
+    "@babel/runtime" "^7.9.2"
+    "@types/testing-library__jest-dom" "^5.9.1"
+    aria-query "^4.2.2"
+    chalk "^3.0.0"
+    css "^3.0.0"
+    css.escape "^1.5.1"
+    jest-diff "^25.1.0"
+    jest-matcher-utils "^25.1.0"
+    lodash "^4.17.15"
+    redent "^3.0.0"
+
 "@types/anymatch@*":
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/@types/anymatch/-/anymatch-1.3.1.tgz#336badc1beecb9dacc38bea2cf32adf627a8421a"
@@ -3032,6 +3063,14 @@
   dependencies:
     "@types/istanbul-lib-coverage" "*"
     "@types/istanbul-lib-report" "*"
+
+"@types/jest@*":
+  version "26.0.5"
+  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-26.0.5.tgz#23a8eecf4764a770ea8d3a0d1ea16b96c822035d"
+  integrity sha512-heU+7w8snfwfjtcj2H458aTx3m5unIToOJhx75ebHilBiiQ39OIdA18WkG4LP08YKeAoWAGvWg8s+22w/PeJ6w==
+  dependencies:
+    jest-diff "^25.2.1"
+    pretty-format "^25.2.1"
 
 "@types/jest@^24.0.19":
   version "24.9.1"
@@ -3159,6 +3198,13 @@
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/@types/tapable/-/tapable-1.0.5.tgz#9adbc12950582aa65ead76bffdf39fe0c27a3c02"
   integrity sha512-/gG2M/Imw7cQFp8PGvz/SwocNrmKFjFsm5Pb8HdbHkZ1K8pmuPzOX4VeVoiEecFCVf4CsN1r3/BRvx+6sNqwtQ==
+
+"@types/testing-library__jest-dom@^5.9.1":
+  version "5.9.1"
+  resolved "https://registry.yarnpkg.com/@types/testing-library__jest-dom/-/testing-library__jest-dom-5.9.1.tgz#aba5ee062b7880f69c212ef769389f30752806e5"
+  integrity sha512-yYn5EKHO3MPEMSOrcAb1dLWY+68CG29LiXKsWmmpVHqoP5+ZRiAVLyUHvPNrO2dABDdUGZvavMsaGpWNjM6N2g==
+  dependencies:
+    "@types/jest" "*"
 
 "@types/uglify-js@*":
   version "3.9.2"
@@ -4111,6 +4157,14 @@ argparse@^1.0.7:
   integrity sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==
   dependencies:
     sprintf-js "~1.0.2"
+
+aria-query@^4.2.2:
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/aria-query/-/aria-query-4.2.2.tgz#0d2ca6c9aceb56b8977e9fed6aed7e15bbd2f83b"
+  integrity sha512-o/HelwhuKpTj/frsOsbNLNgnNGVIFsVP/SW2BSF14gVl7kAfMOJ6/8wUAUvG1R1NHKrfG+2sHZTu0yauT1qBrA==
+  dependencies:
+    "@babel/runtime" "^7.10.2"
+    "@babel/runtime-corejs3" "^7.10.2"
 
 arr-diff@^4.0.0:
   version "4.0.0"
@@ -6207,7 +6261,7 @@ core-js-compat@^3.6.2, core-js-compat@^3.6.5:
     browserslist "^4.8.5"
     semver "7.0.0"
 
-core-js-pure@^3.0.1:
+core-js-pure@^3.0.0, core-js-pure@^3.0.1:
   version "3.6.5"
   resolved "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.6.5.tgz#c79e75f5e38dbc85a662d91eea52b8256d53b813"
   integrity sha512-lacdXOimsiD0QyNf9BC/mxivNJ/ybBGJXQFKzRekp1WTHoVUWsUHEn+2T8GJAzzIhyOuXA+gOxCVN3l+5PLPUA==
@@ -6461,6 +6515,11 @@ css-what@^3.2.1:
   resolved "https://registry.yarnpkg.com/css-what/-/css-what-3.3.0.tgz#10fec696a9ece2e591ac772d759aacabac38cd39"
   integrity sha512-pv9JPyatiPaQ6pf4OvD/dbfm0o5LviWmwxNWzblYf/1u9QZd0ihV+PMwy5jdQWQ3349kZmKEx9WXuSka2dM4cg==
 
+css.escape@^1.5.1:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/css.escape/-/css.escape-1.5.1.tgz#42e27d4fa04ae32f931a4b4d4191fa9cddee97cb"
+  integrity sha1-QuJ9T6BK4y+TGktNQZH6nN3ul8s=
+
 css@^2.0.0, css@^2.1.0:
   version "2.2.4"
   resolved "https://registry.yarnpkg.com/css/-/css-2.2.4.tgz#c646755c73971f2bba6a601e2cf2fd71b1298929"
@@ -6470,6 +6529,15 @@ css@^2.0.0, css@^2.1.0:
     source-map "^0.6.1"
     source-map-resolve "^0.5.2"
     urix "^0.1.0"
+
+css@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/css/-/css-3.0.0.tgz#4447a4d58fdd03367c516ca9f64ae365cee4aa5d"
+  integrity sha512-DG9pFfwOrzc+hawpmqX/dHYHJG+Bsdb0klhyi1sDneOgGOXy9wQIC8hzyVp1e4NRYDBdxcylvywPkkXCHAzTyQ==
+  dependencies:
+    inherits "^2.0.4"
+    source-map "^0.6.1"
+    source-map-resolve "^0.6.0"
 
 cssesc@^3.0.0:
   version "3.0.0"
@@ -10242,7 +10310,7 @@ jest-diff@^24.3.0, jest-diff@^24.9.0:
     jest-get-type "^24.9.0"
     pretty-format "^24.9.0"
 
-jest-diff@^25.2.1, jest-diff@^25.5.0:
+jest-diff@^25.1.0, jest-diff@^25.2.1, jest-diff@^25.5.0:
   version "25.5.0"
   resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-25.5.0.tgz#1dd26ed64f96667c068cef026b677dfa01afcfa9"
   integrity sha512-z1kygetuPiREYdNIumRpAHY6RXiGmp70YHptjdaxTWGmA085W3iCnXNx0DhflK3vwrKmrRWyY1wUpkPMVxMK7A==
@@ -10467,7 +10535,7 @@ jest-matcher-utils@^24.9.0:
     jest-get-type "^24.9.0"
     pretty-format "^24.9.0"
 
-jest-matcher-utils@^25.5.0:
+jest-matcher-utils@^25.1.0, jest-matcher-utils@^25.5.0:
   version "25.5.0"
   resolved "https://registry.yarnpkg.com/jest-matcher-utils/-/jest-matcher-utils-25.5.0.tgz#fbc98a12d730e5d2453d7f1ed4a4d948e34b7867"
   integrity sha512-VWI269+9JS5cpndnpCwm7dy7JtGQT30UHfrnM3mXl22gHGt/b7NkjBqXfbhZ8V4B7ANUsjK18PlSBmG0YH7gjw==
@@ -15816,6 +15884,14 @@ source-map-resolve@^0.5.0, source-map-resolve@^0.5.2:
     resolve-url "^0.2.1"
     source-map-url "^0.4.0"
     urix "^0.1.0"
+
+source-map-resolve@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/source-map-resolve/-/source-map-resolve-0.6.0.tgz#3d9df87e236b53f16d01e58150fc7711138e5ed2"
+  integrity sha512-KXBr9d/fO/bWo97NXsPIAW1bFSBOuCnjbNTBMO7N59hsv5i9yzRDfcYwwt0l04+VqnKC+EwzvJZIP/qkuMgR/w==
+  dependencies:
+    atob "^2.1.2"
+    decode-uri-component "^0.2.0"
 
 source-map-support@^0.5.6, source-map-support@~0.5.12:
   version "0.5.19"


### PR DESCRIPTION
# Related issue
<!-- paste a link to related issue -->
Closes #1288 #1328 

# Scope of work
<!-- describe what you did -->

I changed the current test methods to ones that are not deprecated

# Checklist

- [x] No commented blocks of code left
- [x] Run tests and docs
- [x] Self code-reviewed

If applicable:

- [x] I followed [composition rules](https://docs.storefrontui.io/contributing/coding-guidelines.html#component-rules) for my component
- [ ] I tested the component in most common device sizes (can be tested in Storybook [from viewport addon in top menu](https://github.com/storybooks/storybook/tree/master/addons/viewport))
 - [x] I accept [Individual Contributor License Agreement](https://github.com/DivanteLtd/next/blob/master/CLA.md)
