### PR TITLE
fix: SfInput has a border radius and inner shadow on iOS/Safari 

### DIFF
--- a/packages/shared/styles/components/atoms/SfInput.scss
+++ b/packages/shared/styles/components/atoms/SfInput.scss
@@ -75,8 +75,12 @@
   }
   &__wrapper,
   input {
+    border-radius: 0;
     width: 100%;
     height: 100%;
+    -webkit-appearance: none;
+    -moz-appearance: none;
+    appearance: none;
   }
   &__wrapper {
     position: relative;


### PR DESCRIPTION
# Related issue
Closes #1323 

# Scope of work
border-radius and appearance none added to input