### PR TITLE
feat: SfAccordion add prop option to open all items by default

### DIFF
--- a/packages/vue/src/components/organisms/SfAccordion/SfAccordion.stories.js
+++ b/packages/vue/src/components/organisms/SfAccordion/SfAccordion.stories.js
@@ -146,4 +146,74 @@ storiesOf("Organisms|Accordion", module)
         </SfList>
       </SfAccordionItem>
     </SfAccordion>`,
+  }))
+  .add("All open", () => ({
+    components: { SfAccordion, SfList, SfMenuItem },
+    props: {
+      open: {
+        default: text("open", "all", "Props"),
+      },
+      multiple: {
+        default: boolean("multiple", true, "Props"),
+      },
+      showChevron: {
+        default: boolean("showChevron", false, "Props"),
+      },
+      transition: {
+        default: text("transition", "sf-expand", "Props"),
+      },
+    },
+    data() {
+      return {
+        accordions: [
+          {
+            header: "Clothing",
+            items: [
+              { label: "All", count: "280" },
+              { label: "Skirts", count: "11" },
+              { label: "Dresses", count: "32" },
+            ],
+          },
+          {
+            header: "Accessories",
+            items: [
+              { label: "All", count: "80" },
+              { label: "Belts", count: "101" },
+              { label: "Bag", count: "2" },
+            ],
+          },
+          {
+            header: "Shoes",
+            items: [
+              { label: "All", count: "2" },
+              { label: "Trainers", count: "22" },
+              { label: "Sandals", count: "55" },
+            ],
+          },
+        ],
+      };
+    },
+    template: `<SfAccordion 
+        :open="open" 
+        :multiple="multiple"
+        :show-chevron="showChevron"
+        :transition="transition">
+      <SfAccordionItem 
+        v-for="accordion in accordions" 
+        :key="accordion.header" 
+        :header="accordion.header"
+      >
+        <SfList>
+          <SfListItem
+            v-for="item in accordion.items"
+            :key="item.label"
+            >
+            <SfMenuItem 
+              :label="item.label" 
+              :count="item.count"
+            />
+          </SfListItem>
+        </SfList>
+      </SfAccordionItem>
+      </SfAccordion>`,
   }));

--- a/packages/vue/src/components/organisms/SfAccordion/SfAccordion.vue
+++ b/packages/vue/src/components/organisms/SfAccordion/SfAccordion.vue
@@ -16,7 +16,7 @@ export default {
   name: "SfAccordion",
   props: {
     /**
-     * Opens an accordion item based on title
+     * Opens an accordion item based on title. If 'all' string is passed than all items will be open by default.
      */
     open: {
       type: [String, Array],

--- a/packages/vue/src/components/organisms/SfAccordion/SfAccordion.vue
+++ b/packages/vue/src/components/organisms/SfAccordion/SfAccordion.vue
@@ -16,7 +16,7 @@ export default {
   name: "SfAccordion",
   props: {
     /**
-     * Opens an accordion item based on title. If 'all' string is passed than all items will be open by default.
+     * Opens an accordion item based on title. If 'all' string is passed then all items will be open by default.
      */
     open: {
       type: [String, Array],

--- a/packages/vue/src/components/organisms/SfAccordion/SfAccordion.vue
+++ b/packages/vue/src/components/organisms/SfAccordion/SfAccordion.vue
@@ -74,6 +74,10 @@ export default {
           return;
         }
         // <- TODO remove in 1.0.0
+        if (this.open === "all") {
+          this.multiple = true;
+          this.openHeader = this.$children.map((child) => child.header);
+        }
         this.$children.forEach((child) => {
           child.isOpen = Array.isArray(this.openHeader)
             ? this.openHeader.includes(child.header)


### PR DESCRIPTION
# Related issue
Closes #1307

# Scope of work
SfAccordion - when you pass 'all'  to open prop all the items should be open by default. Appropriate story was added. 

# Screenshots of visual changes
![image](https://user-images.githubusercontent.com/32042425/88110398-72db2780-cbac-11ea-9407-1bda43b4fe91.png)


# Checklist

- [x] No commented blocks of code left
- [x] Run tests and docs
- [x] Self code-reviewed
