### PR TITLE
fix: offsetHeight of SfScrollable

### DIFF
--- a/packages/vue/src/components/molecules/SfScrollable/SfScrollable.vue
+++ b/packages/vue/src/components/molecules/SfScrollable/SfScrollable.vue
@@ -66,7 +66,7 @@ export default {
       this.contentEl = this.$refs.content.$el.querySelector(
         ".simplebar-content"
       );
-      if (typeof MutationObserver === "undefined") return;
+      if (typeof MutationObserver === "undefined" || !this.contentEl) return;
       const observer = new MutationObserver(this.sizeCalc);
       this.sizeCalc();
       observer.observe(this.contentEl, { childList: true });


### PR DESCRIPTION
# Related issue
<!-- paste a link to related issue -->
Closes #1329 

# Scope of work
<!-- describe what you did -->
An additional condition has been added that should fix the bug.

# Checklist

- [x] No commented blocks of code left
- [x] Run tests and docs
- [x] Self code-reviewed

If applicable:

- [x] I followed [composition rules](https://docs.storefrontui.io/contributing/coding-guidelines.html#component-rules) for my component
- [ ] I tested the component in most common device sizes (can be tested in Storybook [from viewport addon in top menu](https://github.com/storybooks/storybook/tree/master/addons/viewport))
 - [x] I accept [Individual Contributor License Agreement](https://github.com/DivanteLtd/next/blob/master/CLA.md)
