### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "nodejs"
+run = "npm start"

--- a/README.md
+++ b/README.md
@@ -78,3 +78,4 @@ Thank you! There would be no Storefront UI without you.
 
 Read [how to start](https://docs.storefrontui.io/contributing/become-a-contributor.html) and become a part of our amazing community ;)
 
+[![Run on Repl.it](https://repl.it/badge/github/DivanteLtd/storefront-ui)](https://repl.it/github/DivanteLtd/storefront-ui)


### PR DESCRIPTION
This pull request adds a  badge to the . This will allow users to easily run this repository in their browser, without having to set up an environment. You can learn more about Repl.it [here](https://repl.it).

# Related issue
<!-- paste a link to related issue -->
Closes #

# Scope of work
<!-- describe what you did -->

# Screenshots of visual changes
<!-- if visual changes applied -->

# Checklist

- [ ] No commented blocks of code left
- [ ] Run tests and docs
- [ ] Self code-reviewed

If applicable:

- [ ] I followed [composition rules](https://docs.storefrontui.io/contributing/coding-guidelines.html#component-rules) for my component
- [ ] I tested the component in most common device sizes (can be tested in Storybook [from viewport addon in top menu](https://github.com/storybooks/storybook/tree/master/addons/viewport))
 - [ ] I accept [Individual Contributor License Agreement](https://github.com/DivanteLtd/next/blob/master/CLA.md)
