### PR TITLE
Added marker icon if picture is empty on SfStore component.

### DIFF
--- a/packages/vue/src/components/organisms/SfStoreLocator/_internal/SfStore.vue
+++ b/packages/vue/src/components/organisms/SfStoreLocator/_internal/SfStore.vue
@@ -6,15 +6,17 @@
         <span>{{ distance }}km</span> away from you
       </div>
     </slot>
-    <div class="sf-store__media" @click="centerOn(latlng)">
+    <div v-bind:class="{ 'sf-store__media': picture }" @click="centerOn(latlng)">
       <!-- @slot Use this slot to show media elements -->
       <slot name="media">
         <SfImage
+          v-if="picture"
           :src="picture"
           :alt="`${name} picture`"
           :width="82"
           :height="112"
         />
+        <SfIcon v-if="!picture" icon="marker" />
       </slot>
     </div>
     <div class="sf-store__info">


### PR DESCRIPTION
# Related issue
<!-- paste a link to related issue -->
Closes #1280 

# Scope of work
<!-- describe what you did -->

# Screenshots of visual changes
![Screenshot 2020-07-26 at 2 02 18 PM](https://user-images.githubusercontent.com/34086621/88474913-afaa7400-cf48-11ea-9365-37716969db33.png)


# Checklist

- [ ] No commented blocks of code left
- [ ] Run tests and docs
- [ ] Self code-reviewed

If applicable:

- [ ] I followed [composition rules](https://docs.storefrontui.io/contributing/coding-guidelines.html#component-rules) for my component
- [ ] I tested the component in most common device sizes (can be tested in Storybook [from viewport addon in top menu](https://github.com/storybooks/storybook/tree/master/addons/viewport))
 - [ ] I accept [Individual Contributor License Agreement](https://github.com/DivanteLtd/next/blob/master/CLA.md)
