### PR TITLE
fix: story with error msg fixed

### DIFF
--- a/packages/vue/src/components/molecules/SfSelect/SfSelect.stories.js
+++ b/packages/vue/src/components/molecules/SfSelect/SfSelect.stories.js
@@ -178,7 +178,7 @@ storiesOf("Molecules|Select", module)
       };
     },
     template: `<div style="max-width: 30rem">
-      <SfComponentSelect
+      <SfSelect
         v-model="selected"
         :class="customClass"
         :label="label"
@@ -187,12 +187,14 @@ storiesOf("Molecules|Select", module)
         :disabled="disabled"
         :error-message="errorMessage"
         >
-        <SfComponentSelectOption v-for="(option, key) in options" :key="key" :value="option.value">
+        <SfSelectOption v-for="(option, key) in options" :key="key" :value="option.value">
           <SfProductOption :color="option.color" :label="option.label"></SfProductOption>
-        </SfComponentSelectOption>
-        <template #errorMessage>
-          CUSTOM ERROR MESSAGE
+        </SfSelectOption>
+        <template #error-message>
+          <span>
+            CUSTOM ERROR MESSAGE
+          </span>
         </template>
-      </SfComponentSelect>
+      </SfSelect>
     </div>`,
   }));


### PR DESCRIPTION
# Related issue
Closes #

# Scope of work
There were wrong components: SfComponentSelect instead SfSelect and SfComponentSelectOption instead SfSelectOption

# Checklist

- [ ] No commented blocks of code left
- [ ] Run tests and docs
- [ ] Self code-reviewed
- [ ] Changes documented 

If applicable:

- [ ] I followed [composition rules](https://docs.storefrontui.io/contributing/coding-guidelines.html#component-rules) for my component
- [ ] I tested the component in most common device sizes (can be tested in Storybook [from viewport addon in top menu](https://github.com/storybooks/storybook/tree/master/addons/viewport))
