### PR TITLE
fix: SfImage rootmargin error in storybook fixed on firefox

### DIFF
--- a/packages/vue/src/components/atoms/SfImage/SfImage.stories.js
+++ b/packages/vue/src/components/atoms/SfImage/SfImage.stories.js
@@ -55,7 +55,7 @@ storiesOf("Atoms|Image", module)
         default: boolean("lazy", true, "Props"),
       },
       rootMargin: {
-        default: text("rootMargin", "", "Props"),
+        default: text("rootMargin", "0px", "Props"),
       },
       threshold: {
         default: number("threshold", 0, {}, "Props"),
@@ -98,7 +98,7 @@ storiesOf("Atoms|Image", module)
         default: boolean("lazy", true, "Props"),
       },
       rootMargin: {
-        default: text("rootMargin", "", "Props"),
+        default: text("rootMargin", "0px", "Props"),
       },
       threshold: {
         default: number("threshold", 0, {}, "Props"),
@@ -131,7 +131,7 @@ storiesOf("Atoms|Image", module)
         default: boolean("lazy", true, "Props"),
       },
       rootMargin: {
-        default: text("rootMargin", "", "Props"),
+        default: text("rootMargin", "0px", "Props"),
       },
       threshold: {
         default: number("threshold", 0, {}, "Props"),
@@ -162,7 +162,7 @@ storiesOf("Atoms|Image", module)
         default: boolean("lazy", true, "Props"),
       },
       rootMargin: {
-        default: text("rootMargin", "", "Props"),
+        default: text("rootMargin", "0px", "Props"),
       },
       threshold: {
         default: number("threshold", 0, {}, "Props"),
@@ -199,7 +199,7 @@ storiesOf("Atoms|Image", module)
         default: boolean("lazy", true, "Props"),
       },
       rootMargin: {
-        default: text("rootMargin", "", "Props"),
+        default: text("rootMargin", "0px", "Props"),
       },
       threshold: {
         default: number("threshold", 0, {}, "Props"),


### PR DESCRIPTION
# Related issue

Closes #1310 

# Scope of work
Add rootMargin props to stories, because empty string causes error. 


# Checklist

- [x] No commented blocks of code left
- [x] Run tests and docs
- [x] Self code-reviewed
- [x] Changes documented 
