### PR TITLE
fix: modal cuted on desktop

### DIFF
--- a/packages/shared/styles/components/molecules/SfModal.scss
+++ b/packages/shared/styles/components/molecules/SfModal.scss
@@ -15,6 +15,7 @@
     width: var(--modal-width);
     height: var(--modal-height);
     border: var(--modal-border);
+    max-height: var(--modal-max-height);
     background-color: var(--modal-background, var(--c-white));
     &::-webkit-scrollbar {
       width: 0;
@@ -44,6 +45,7 @@
     --modal-right: none;
     --modal-transform: translate3d(-50%, -50%, 0);
     --modal-height: auto;
+    --modal-max-height: 90%;
     --modal-content-padding: var(--spacer-sm) var(--spacer-lg);
   }
 }


### PR DESCRIPTION
# Related issue
Closes #1371 

# Scope of work
max-height added for modal

# Screenshots of visual changes

![Zrzut ekranu z 2020-08-21 15-22-20](https://user-images.githubusercontent.com/46591755/90895275-3163b500-e3c2-11ea-8f8f-0c7ba2f9b215.png)


# Checklist

- [ ] No commented blocks of code left
- [ ] Run tests and docs
- [ ] Self code-reviewed
- [ ] Changes documented 

If applicable:

- [ ] I followed [composition rules](https://docs.storefrontui.io/contributing/coding-guidelines.html#component-rules) for my component
- [ ] I tested the component in most common device sizes (can be tested in Storybook [from viewport addon in top menu](https://github.com/storybooks/storybook/tree/master/addons/viewport))
