### PR TITLE
fix: sfstep change lifecycle method to created

### DIFF
--- a/packages/vue/src/components/molecules/SfSteps/_internal/SfStep.vue
+++ b/packages/vue/src/components/molecules/SfSteps/_internal/SfStep.vue
@@ -33,7 +33,7 @@ export default {
       return this.internalName === this.name;
     },
   },
-  mounted() {
+  created() {
     this.stepsData.updateSteps(this.name);
   },
 };


### PR DESCRIPTION
# Related issue
<!-- paste a link to related issue -->
Closes #1389

# Scope of work
Change lifecycle method from mounted to created to let use it during SSR.  


# Screenshots of visual changes
no

# Checklist

- [x] No commented blocks of code left
- [x] Run tests and docs
- [x] Self code-reviewed
- [x] Changes documented 

If applicable:

- [ ] I followed [composition rules](https://docs.storefrontui.io/contributing/coding-guidelines.html#component-rules) for my component
- [ ] I tested the component in most common device sizes (can be tested in Storybook [from viewport addon in top menu](https://github.com/storybooks/storybook/tree/master/addons/viewport))
