### PR TITLE
fix: sfselect background image url

### DIFF
--- a/packages/shared/styles/components/molecules/SfSelect.scss
+++ b/packages/shared/styles/components/molecules/SfSelect.scss
@@ -45,7 +45,8 @@
   &__option {           
     @include background(
       --select-option-background,
-      var(--c-white)
+      var(--_select-option-background-image),
+      var(--_select-option-background-color, var(--c-white))
     ); 
     @include font(
       --select-option-font,

--- a/packages/shared/styles/components/molecules/SfSelect.scss
+++ b/packages/shared/styles/components/molecules/SfSelect.scss
@@ -44,9 +44,9 @@
   }
   &__option {           
     @include background(
-      --select-option-background,
-      var(--_select-option-background-image),
-      var(--_select-option-background-color, var(--c-white))
+      --select-option-background,      
+      var(--_select-option-background-color, var(--c-white)),
+      var(--_select-option-background-image)
     ); 
     @include font(
       --select-option-font,


### PR DESCRIPTION
# Related issue

Closes #1409 

# Scope of work
Add background img url variable to SfSelectOption component to remove warn on nuxt. 

# Checklist

- [x] No commented blocks of code left
- [x] Run tests and docs
- [x] Self code-reviewed
- [x] Changes documented 
