### PR TITLE
fix: up modifier fixed in SfDropdown

### DIFF
--- a/packages/shared/styles/components/molecules/SfDropdown.scss
+++ b/packages/shared/styles/components/molecules/SfDropdown.scss
@@ -55,7 +55,6 @@
       --dropdown-bottom: 0;
       .sf-dropdown__container {
         --dropdown-container-position: absolute;
-        // --dropdown-container-top: auto;
         --dropdown-container-bottom: 3.125rem;
       }
     }

--- a/packages/shared/styles/components/molecules/SfDropdown.scss
+++ b/packages/shared/styles/components/molecules/SfDropdown.scss
@@ -5,7 +5,9 @@
   bottom: var(--dropdown-bottom);
   transform: var(--dropdown-transform);  
   &__container {
-    position: relative;
+    position: var(--dropdown-container-position, relative);
+    top: var(--dropdown-container-top);
+    bottom: var(--dropdown-container-bottom);
     width: var(--dropdown-container-width, 100%);
     z-index: 1;
     background: var(--dropdown-background, var(--c-white));
@@ -50,11 +52,12 @@
   }
   &--up {
     @include for-desktop {
-      --dropdown-position: absolute;
-      --dropdown-top: auto;
       --dropdown-bottom: 0;
-      --dropdown-transform: translate(0, -100%);
-      --dropdown-box-shadow: 0px -4px 11px rgba(var(--c-dark-base), 0.1);
+      .sf-dropdown__container {
+        --dropdown-container-position: absolute;
+        // --dropdown-container-top: auto;
+        --dropdown-container-bottom: 3.125rem;
+      }
     }
   }
   &-enter-active {


### PR DESCRIPTION
# Related issue
 w/o issue 

# Scope of work
Modifier --up adjusted to new SfDropdown

# Screenshots of visual changes
![Zrzut ekranu z 2020-09-22 16-34-28](https://user-images.githubusercontent.com/46591755/93897187-11415180-fcf2-11ea-9785-4154284d52a4.png)


# Checklist

- [ ] No commented blocks of code left
- [ ] Run tests and docs
- [ ] Self code-reviewed
- [ ] Changes documented 

If applicable:

- [ ] I followed [composition rules](https://docs.storefrontui.io/contributing/coding-guidelines.html#component-rules) for my component
- [ ] I tested the component in most common device sizes (can be tested in Storybook [from viewport addon in top menu](https://github.com/storybooks/storybook/tree/master/addons/viewport))
