### PR TITLE
hotfix: change pull off components docs

### DIFF
--- a/packages/vue/docs/pull-off-components.md
+++ b/packages/vue/docs/pull-off-components.md
@@ -5,7 +5,9 @@ With just one command you can have all components and their styles, so that no n
 
 ## Required
 
-Storefront UI added as a dependency to your project
+* Storefront UI added as a dependency to your project.
+
+* `fse` package added to your project with `npm install fse -D` or `yarn add fse -D` .
 
 ## How to copy components
 


### PR DESCRIPTION
# Related issue

# Scope of work
Add information to pull off components docs  about adding fse package as dependency in order to run copy-components script properly. 

# Checklist

- [ ] No commented blocks of code left
- [ ] Run tests and docs
- [ ] Self code-reviewed
- [ ] Changes documented 

If applicable:

- [ ] I followed [composition rules](https://docs.storefrontui.io/contributing/coding-guidelines.html#component-rules) for my component
- [ ] I tested the component in most common device sizes (can be tested in Storybook [from viewport addon in top menu](https://github.com/storybooks/storybook/tree/master/addons/viewport))
