### PR TITLE
fix: SfSelect: clicking on an option results in another being selected instead on MacOS

### DIFF
--- a/packages/shared/styles/components/molecules/SfSelect.scss
+++ b/packages/shared/styles/components/molecules/SfSelect.scss
@@ -56,13 +56,10 @@
       var(--font-family--secondary)
     ); 
   }
-  .sf-select__dropdown:active .sf-select__placeholder {
-    display: var(--select-placeholder-display, none);
-  }
   .sf-select__dropdown:active {
     --select-label-color: var(--c-text-muted);
     --select-dropdown-border-color: var(--c-primary);
-    --select-dropdown-color: var(--c-text-muted);
+    --select-dropdown-color: var(--c-link);
   }
   &__label .sf-select__dropdown:active {
     top: 0;


### PR DESCRIPTION
# Related issue
Closes #1455 

# Scope of work
Deleted display none for placeholder that was causing this bug and added a bit darker color for dropdown to differentiate from placeholder

# Screenshots of visual changes
![Zrzut ekranu z 2020-10-06 07-38-41](https://user-images.githubusercontent.com/46591755/95162920-046b3600-07a7-11eb-8ee0-2f1be75bc23c.png)


# Checklist

- [ ] No commented blocks of code left
- [ ] Run tests and docs
- [ ] Self code-reviewed
- [ ] Changes documented 

If applicable:

- [ ] I followed [composition rules](https://docs.storefrontui.io/contributing/coding-guidelines.html#component-rules) for my component
- [ ] I tested the component in most common device sizes (can be tested in Storybook [from viewport addon in top menu](https://github.com/storybooks/storybook/tree/master/addons/viewport))
