### PR TITLE
fix: button text modifier color changed 

### DIFF
--- a/packages/shared/styles/components/atoms/SfButton.scss
+++ b/packages/shared/styles/components/atoms/SfButton.scss
@@ -127,7 +127,7 @@
     --button-border-width: 0;
     --button-padding: 0;
     --button-background: transparent;
-    --button-color: var(--c-info);
+    --button-color: var(--c-text);
     --button-text-transform: none;
     --button-text-decoration: underline;
     --button-font-size: var(--font-size--sm);
@@ -136,7 +136,7 @@
     display: inline;
     &:hover {
       --button-background: transparent;
-      --button-color: var(--c-black);
+      --button-color: var(--c-primary);
     }
     &:active {
       --button-color: var(--c-gray);


### PR DESCRIPTION
# Related issue
Closes #

# Scope of work
Buttons as text has the same color as link

# Screenshots of visual changes
![Zrzut ekranu z 2020-10-15 14-11-24](https://user-images.githubusercontent.com/46591755/96121437-5bcc7d00-0ef0-11eb-8815-e0a9784fc1e2.png)


# Checklist

- [ ] No commented blocks of code left
- [ ] Run tests and docs
- [ ] Self code-reviewed
- [ ] Changes documented 

If applicable:

- [ ] I followed [composition rules](https://docs.storefrontui.io/contributing/coding-guidelines.html#component-rules) for my component
- [ ] I tested the component in most common device sizes (can be tested in Storybook [from viewport addon in top menu](https://github.com/storybooks/storybook/tree/master/addons/viewport))
