### PR TITLE
fix: color and background for remove btn in SfCollectedProduct

### DIFF
--- a/packages/shared/styles/components/organisms/SfCollectedProduct.scss
+++ b/packages/shared/styles/components/organisms/SfCollectedProduct.scss
@@ -25,6 +25,10 @@
       top: var(--collected-product-remove-top);
       display: var(--collected-product-remove-circle-icon-display, none);
       transform: var(--collected-product-remove-circle-icon-transform);
+      background: var(--c-primary);
+      .sf-icon {
+        --icon-color: var(--c-white);
+      }
     }
     &--text {
       bottom: var(--collected-product-remove-bottom, var(--spacer-xs));


### PR DESCRIPTION
# Related issue
Closes #1486 

# Scope of work
added background and color for icon in remove btn

# Screenshots of visual changes

# Checklist

- [ ] No commented blocks of code left
- [ ] Run tests and docs
- [ ] Self code-reviewed
- [ ] Changes documented 

If applicable:

- [ ] I followed [composition rules](https://docs.storefrontui.io/contributing/coding-guidelines.html#component-rules) for my component
- [ ] I tested the component in most common device sizes (can be tested in Storybook [from viewport addon in top menu](https://github.com/storybooks/storybook/tree/master/addons/viewport))
