### PR TITLE
fix: Footer menu opens without clicking on it

### DIFF
--- a/packages/vue/src/utilities/mobile-observer.js
+++ b/packages/vue/src/utilities/mobile-observer.js
@@ -2,6 +2,7 @@ import Vue from "vue";
 let observer;
 const isMobileMax = 1023;
 export const onMediaMatch = (e) => {
+  if (!e.matches) return;
   observer.isMobile = e.matches;
 };
 export const setupListener = () => {


### PR DESCRIPTION
# Related issue
Closes #1494

# Scope of work
There was an error about null assignment to isMoblie so we need to check if there is no null. 

# Screenshots of visual changes
No visual changes 

# Checklist

- [ ] No commented blocks of code left
- [ ] Run tests and docs
- [ ] Self code-reviewed
- [ ] Changes documented 

If applicable:

- [ ] I followed [composition rules](https://docs.storefrontui.io/contributing/coding-guidelines.html#component-rules) for my component
- [ ] I tested the component in most common device sizes (can be tested in Storybook [from viewport addon in top menu](https://github.com/storybooks/storybook/tree/master/addons/viewport))
