### PR TITLE
fix: fonts in SfTextarea and add SfTextarea to form example

### DIFF
--- a/packages/shared/styles/components/atoms/SfTextarea.scss
+++ b/packages/shared/styles/components/atoms/SfTextarea.scss
@@ -37,7 +37,7 @@
         --textarea-label-required: " *";
       }
     }
-     &:placeholder-shown {
+    &:placeholder-shown {
       & ~ * {
         --textarea-label-padding: 0;
         --textarea-label-transform: translate3d(0, -1rem, 0);
@@ -70,7 +70,7 @@
     --textarea-border-color: var(--c-text);
     --textarea-color: var(--c-text);
     --textarea-label-top: 0;
-    --textarea-label-font-size: var(--font-xs);
+    --textarea-label-font-size: var(--font-size--xs);
     --textarea-label-transform: translate3d(0, -1rem, 0);
     --textarea-label-padding: 0;
   }
@@ -80,7 +80,7 @@
   }
   &__error-message {
     color: var(--textarea-error-message-color, var(--c-danger));
-    min-height: calc(var(--font-xs) * 1.2);
+    min-height: calc(var(--font-size--xs) * 1.2);
     @include font(
       --textarea-error-message-font,
       var(--font-weight--medium),

--- a/packages/shared/styles/components/atoms/SfTextarea.scss
+++ b/packages/shared/styles/components/atoms/SfTextarea.scss
@@ -7,10 +7,10 @@
     color: var(--textarea-color);
     @include font(
       --textarea-font,
-      var(--font-normal),
-      var(--font-base),
+      var(--font-weight--normal),
+      var(--font-size--base),
       1,
-      var(--font-family-secondary)
+      var(--font-family--secondary)
     );
     height: var(--textarea-height);
     width: var(--textarea-width);
@@ -37,14 +37,21 @@
         --textarea-label-required: " *";
       }
     }
+     &:placeholder-shown {
+      & ~ * {
+        --textarea-label-padding: 0;
+        --textarea-label-transform: translate3d(0, -1rem, 0);
+        --textarea-label-font-size: var(--font-xs);
+      }
+    }
   }
   &__label {
     @include font(
       --textarea-label-font,
-      var(--font-normal),
-      var(--font-base),
+      var(--font-weight--normal),
+      var(--font-size--base),
       1,
-      var(--font-family-secondary)
+      var(--font-family--secondary)
     );
     position: var(--textarea-label-position, absolute);
     padding: var(--textarea-label-padding, var(--spacer-sm));
@@ -77,10 +84,10 @@
     min-height: calc(var(--font-xs) * 1.2);
     @include font(
       --textarea-error-message-font,
-      var(--font-medium),
-      var(--font-xs),
+      var(--font-weight--medium),
+      var(--font-size--xs),
       1.2,
-      var(--font-family-secondary)
+      var(--font-family--secondary)
     );
   }
 }

--- a/packages/shared/styles/components/atoms/SfTextarea.scss
+++ b/packages/shared/styles/components/atoms/SfTextarea.scss
@@ -22,7 +22,7 @@
         --textarea-label-padding: 0;
         --textarea-label-color: var(--c-primary);
         --textarea-label-transform: translate3d(0, -1rem, 0);
-        --textarea-label-font-size: var(--font-xs);
+        --textarea-label-font-size: var(--font-size--xs);
       }
     }
     &:disabled {
@@ -41,7 +41,6 @@
       & ~ * {
         --textarea-label-padding: 0;
         --textarea-label-transform: translate3d(0, -1rem, 0);
-        --textarea-label-font-size: var(--font-xs);
       }
     }
   }

--- a/packages/vue/src/examples/others/form/Form.vue
+++ b/packages/vue/src/examples/others/form/Form.vue
@@ -101,6 +101,24 @@
         error-message="Please choose your country."
         @blur="emailBlur = false"
       />
+      <SfTextarea
+        v-model="message"
+        class="form__element"
+        label="Message"
+        name="message"
+        cols="80"
+        rows="25"
+        maxlength="400"
+        minlength="10"
+        wrap="soft"
+        :readonly="true"
+        placeholder="type a message"
+        required
+        :valid="messageBlur || validMessage(message)"
+        error-message="Please type minimum 10 characters and maximum 400."
+        @blur="messageBlur = false"
+      >
+      </SfTextarea>
       <div class="form__action">
         <SfButton type="submit" @click.prevent="submit">Submit</SfButton>
         <SfButton
@@ -113,13 +131,19 @@
   </div>
 </template>
 <script>
-import { SfInput, SfComponentSelect, SfButton } from "@storefront-ui/vue";
+import {
+  SfInput,
+  SfComponentSelect,
+  SfButton,
+  SfTextarea,
+} from "@storefront-ui/vue";
 export default {
   name: "Default",
   components: {
     SfButton,
     SfInput,
     SfComponentSelect,
+    SfTextarea,
   },
   data() {
     return {
@@ -194,6 +218,8 @@ export default {
         "United Kingdom",
         "Vatican City",
       ],
+      message: "",
+      messageBlur: true,
     };
   },
   methods: {
@@ -207,6 +233,7 @@ export default {
       this.countryBlur = false;
       this.phoneNumberBlur = false;
       this.emailBlur = false;
+      this.messageBlur = false;
       if (
         this.validEmail(this.email) &&
         this.validPhoneNumber(this.phoneNumber) &&
@@ -216,7 +243,8 @@ export default {
         this.validApartment(this.apartment) &&
         this.validCity(this.city) &&
         this.validZipCode(this.zipCode) &&
-        this.validCountry(this.country)
+        this.validCountry(this.country) &&
+        this.validMessage(this.message)
       ) {
         this.valid = true;
       }
@@ -252,6 +280,9 @@ export default {
       const regex = /(.+)@(.+){2,}\.(.+){2,}/;
       return regex.test(email.toLowerCase());
     },
+    validMessage(message) {
+      return !!message && message.length > 10 && message.length <= 400;
+    },
     submit() {
       this.validate();
       if (this.valid) {
@@ -268,6 +299,7 @@ export default {
       this.lastName = "";
       this.firstName = "";
       this.apartment = "";
+      this.message = "";
     },
   },
 };


### PR DESCRIPTION
# Related issue

Closes #1500 

# Scope of work
Adjust the font properties to new ones and add SfTextarea to the Form example. 

# Screenshots of visual changes
![image](https://user-images.githubusercontent.com/32042425/97236417-6686ec00-17e5-11eb-8996-76b45f443f29.png)


# Checklist

- [x] No commented blocks of code left
- [x] Run tests and docs
- [x] Self code-reviewed
- [ ] Changes documented 

If applicable:

- [ ] I followed [composition rules](https://docs.storefrontui.io/contributing/coding-guidelines.html#component-rules) for my component
- [ ] I tested the component in most common device sizes (can be tested in Storybook [from viewport addon in top menu](https://github.com/storybooks/storybook/tree/master/addons/viewport))
