### PR TITLE
fix: SfColorPicker opacity affects SfColor

### DIFF
--- a/packages/shared/styles/components/molecules/SfColorPicker.scss
+++ b/packages/shared/styles/components/molecules/SfColorPicker.scss
@@ -25,11 +25,16 @@
     align-items: center;
     justify-content: var(--color-picker-justify-content, center);
     padding: var(--color-picker-padding, var(--spacer-xs));
-    @include for-mobile {
-      background: var(--color-picker-background, var(--c-black));
+    &__overlay {
+      position: absolute;
+      width: 100%;
+      height: 100%;
+      --overlay-z-index: auto;
+      --overlay-background: rgba(var(--c-black-base), 0.8);
     }
   }
   &__label {
+    position: relative;
     flex: 0 0 100%;
     margin: var(--color-picker-label-margin, 0 0 var(--spacer-xs));
     color: var(--color-picker-label-color, var(--c-white));
@@ -42,7 +47,6 @@
     );
     text-align: center;
   }
-  &__colors,
   &__button {
     opacity: var(--color-picker-opacity, 0.8);
   }

--- a/packages/vue/src/components/molecules/SfColorPicker/SfColorPicker.vue
+++ b/packages/vue/src/components/molecules/SfColorPicker/SfColorPicker.vue
@@ -16,6 +16,10 @@
         </slot>
       </div>
       <div v-else key="color-picker-colors" class="sf-color-picker__colors">
+        <SfOverlay
+          :visible="isOpen"
+          class="sf-color-picker__colors__overlay smartphone-only"
+        />
         <!-- @slot Use this slot to replace label. -->
         <slot name="label" v-bind="{ label }">
           <div v-if="label" class="sf-color-picker__label smartphone-only">
@@ -43,9 +47,11 @@
 <script>
 import SfIcon from "../../atoms/SfIcon/SfIcon.vue";
 import SfButton from "../../atoms/SfButton/SfButton.vue";
+import SfOverlay from "../../atoms/SfOverlay/SfOverlay.vue";
+
 export default {
   name: "SfColorPicker",
-  components: { SfIcon, SfButton },
+  components: { SfIcon, SfButton, SfOverlay },
   props: {
     /**
      * ColorPicker is open


### PR DESCRIPTION
# Related issue
Closes #1497 

# Scope of work
Removed opacity that affected SfColor and SfOverlay added

# Screenshots of visual changes
No visual changes 

# Checklist

- [ ] No commented blocks of code left
- [ ] Run tests and docs
- [ ] Self code-reviewed
- [ ] Changes documented 

If applicable:

- [ ] I followed [composition rules](https://docs.storefrontui.io/contributing/coding-guidelines.html#component-rules) for my component
- [ ] I tested the component in most common device sizes (can be tested in Storybook [from viewport addon in top menu](https://github.com/storybooks/storybook/tree/master/addons/viewport))
