### PR TITLE
fix: SfSelect stories remove SfProductOption

### DIFF
--- a/packages/vue/src/components/molecules/SfSelect/SfSelect.stories.js
+++ b/packages/vue/src/components/molecules/SfSelect/SfSelect.stories.js
@@ -5,7 +5,7 @@ import {
   boolean,
   optionsKnob as options,
 } from "@storybook/addon-knobs";
-import { SfSelect, SfProductOption } from "@storefront-ui/vue";
+import { SfSelect } from "@storefront-ui/vue";
 const optionsList = [
   { value: "amaranth", color: "#E52B50", label: "Amaranth" },
   { value: "amber", color: "#FFBF00", label: "Amber" },
@@ -20,7 +20,7 @@ const knobOptionsList = optionsList.reduce(
 storiesOf("Molecules|Select", module)
   .addDecorator(withKnobs)
   .add("Common", () => ({
-    components: { SfSelect, SfProductOption },
+    components: { SfSelect },
     props: {
       customClass: {
         default: options(
@@ -71,12 +71,12 @@ storiesOf("Molecules|Select", module)
         style="max-width: 30rem; margin: 10px;"
       >
         <SfSelectOption v-for="(option, key) in options" :key="key" :value="option.value">
-          <SfProductOption :color="option.color" :label="option.label"></SfProductOption>
+          <span :color="option.color" :label="option.label">{{option.value}}</span>
         </SfSelectOption>
       </SfSelect>`,
   }))
   .add("[slot] label", () => ({
-    components: { SfSelect, SfProductOption },
+    components: { SfSelect },
     props: {
       customClass: {
         default: options(
@@ -127,7 +127,7 @@ storiesOf("Molecules|Select", module)
         :placeholder="placeholder"    
         >
         <SfSelectOption v-for="(option, key) in options" :key="key" :value="option.value">
-          <SfProductOption :color="option.color" :label="option.label"></SfProductOption>
+          <span :color="option.color" :label="option.label">{{option.value}</span>
         </SfSelectOption>
         <template #label>
           CUSTOM LABEL
@@ -136,7 +136,7 @@ storiesOf("Molecules|Select", module)
     </div>`,
   }))
   .add("[slot] errorMessage", () => ({
-    components: { SfSelect, SfProductOption },
+    components: { SfSelect },
     props: {
       customClass: {
         default: options(
@@ -185,7 +185,7 @@ storiesOf("Molecules|Select", module)
         :disabled="disabled"
         >
         <SfSelectOption v-for="(option, key) in options" :key="key" :value="option.value">
-          <SfProductOption :color="option.color" :label="option.label"></SfProductOption>
+          <span :color="option.color" :label="option.label">{{option.value}</span>
         </SfSelectOption>
         <template #errorMessage>
           <span>

--- a/packages/vue/src/components/molecules/SfSelect/SfSelect.stories.js
+++ b/packages/vue/src/components/molecules/SfSelect/SfSelect.stories.js
@@ -71,7 +71,7 @@ storiesOf("Molecules|Select", module)
         style="max-width: 30rem; margin: 10px;"
       >
         <SfSelectOption v-for="(option, key) in options" :key="key" :value="option.value">
-          <span :color="option.color" :label="option.label">{{option.value}}</span>
+        {{option.label}}
         </SfSelectOption>
       </SfSelect>`,
   }))
@@ -127,7 +127,7 @@ storiesOf("Molecules|Select", module)
         :placeholder="placeholder"    
         >
         <SfSelectOption v-for="(option, key) in options" :key="key" :value="option.value">
-          <span :color="option.color" :label="option.label">{{option.value}</span>
+          {{option.label}}
         </SfSelectOption>
         <template #label>
           CUSTOM LABEL
@@ -185,7 +185,7 @@ storiesOf("Molecules|Select", module)
         :disabled="disabled"
         >
         <SfSelectOption v-for="(option, key) in options" :key="key" :value="option.value">
-          <span :color="option.color" :label="option.label">{{option.value}</span>
+          {{option.label}}
         </SfSelectOption>
         <template #errorMessage>
           <span>


### PR DESCRIPTION
# Related issue
Closes #1507 

# Scope of work
Replace SfProductOption with span inside SfSelect to aviod possible SSR mismatch error. 

# Screenshots of visual changes

# Checklist

- [x] No commented blocks of code left
- [x] Run tests and docs
- [x] Self code-reviewed
- [ ] Changes documented 

If applicable:

- [ ] I followed [composition rules](https://docs.storefrontui.io/contributing/coding-guidelines.html#component-rules) for my component
- [ ] I tested the component in most common device sizes (can be tested in Storybook [from viewport addon in top menu](https://github.com/storybooks/storybook/tree/master/addons/viewport))
