### PR TITLE
Render the HTML of the description

### DIFF
--- a/packages/vue/src/components/organisms/SfProductCardHorizontal/SfProductCardHorizontal.vue
+++ b/packages/vue/src/components/organisms/SfProductCardHorizontal/SfProductCardHorizontal.vue
@@ -44,9 +44,7 @@
         </slot>
         <!--@slot Use this slot to replace description-->
         <slot name="description">
-          <p class="sf-product-card-horizontal__description desktop-only">
-            {{ description }}
-          </p>
+          <p class="sf-product-card-horizontal__description desktop-only" v-html="description"></p>
         </slot>
         <!--@slot Use this slot to place content inside configuration-->
         <div class="sf-product-card-horizontal__configuration">


### PR DESCRIPTION
Instead of rendering the raw code of the description, add a v-html to render the HTML code.

# Related issue
<!-- paste a link to related issue -->
Closes #

# Scope of work
<!-- describe what you did -->

# Screenshots of visual changes
<!-- if visual changes applied -->

# Checklist

- [x] No commented blocks of code left
- [x] Run tests and docs
- [x] Self code-reviewed
- [x] Changes documented 

If applicable:

- [x] I followed [composition rules](https://docs.storefrontui.io/contributing/coding-guidelines.html#component-rules) for my component
- [x] I tested the component in most common device sizes (can be tested in Storybook [from viewport addon in top menu](https://github.com/storybooks/storybook/tree/master/addons/viewport))
