### PR TITLE
#2022 - SfCollectedProduct - More actions

### DIFF
--- a/packages/vue/src/components/organisms/SfCollectedProduct/SfCollectedProduct.stories.js
+++ b/packages/vue/src/components/organisms/SfCollectedProduct/SfCollectedProduct.stories.js
@@ -78,6 +78,26 @@ export default {
         },
       },
     },
+    hasMoreActions: {
+      control: "boolean",
+      table: {
+        category: "Props",
+        defaultValue: {
+          summary: true,
+        },
+      },
+      description: "More actions button visibility",
+    },
+    hasRemove: {
+      control: "boolean",
+      table: {
+        category: "Props",
+        defaultValue: {
+          summary: true,
+        },
+      },
+      description: "Remove button visibility",
+    },
     input: { action: "Quantity changed", table: { category: "Events" } },
     "click:remove": {
       action: "Remove product clicked",
@@ -107,6 +127,8 @@ const Template = (args, { argTypes }) => ({
     :link="link"
     :regular-price="regularPrice"
     :special-price="specialPrice"
+    :hasMoreActions="hasMoreActions"
+    :hasRemove="hasRemove"
   />`,
 });
 
@@ -143,6 +165,8 @@ export const UseActionsSlot = (args, { argTypes }) => ({
     :link="link"
     :regular-price="regularPrice"
     :special-price="specialPrice"
+    :special-price="specialPrice"
+    :hasMoreActions="hasMoreActions"
   >
     <template #actions>
       CUSTOM ACTIONS
@@ -165,6 +189,8 @@ export const UseConfigurationSlot = (args, { argTypes }) => ({
     :link="link"
     :regular-price="regularPrice"
     :special-price="specialPrice"
+    :special-price="specialPrice"
+    :hasMoreActions="hasMoreActions"
   >
     <template #configuration>
       CUSTOM CONFIGURATION
@@ -187,6 +213,8 @@ export const UseImageSlot = (args, { argTypes }) => ({
     :link="link"
     :regular-price="regularPrice"
     :special-price="specialPrice"
+    :special-price="specialPrice"
+    :hasMoreActions="hasMoreActions"
   >
     <template #image>
       CUSTOM IMAGE
@@ -209,6 +237,8 @@ export const UseInputSlot = (args, { argTypes }) => ({
     :link="link"
     :regular-price="regularPrice"
     :special-price="specialPrice"
+    :special-price="specialPrice"
+    :hasMoreActions="hasMoreActions"
   >
     <template #input>
       CUSTOM INPUT
@@ -231,6 +261,8 @@ export const UseTitleSlot = (args, { argTypes }) => ({
     :link="link"
     :regular-price="regularPrice"
     :special-price="specialPrice"
+    :special-price="specialPrice"
+    :hasMoreActions="hasMoreActions"
   >
     <template #title>
       CUSTOM TITLE
@@ -253,6 +285,8 @@ export const UsePriceSlot = (args, { argTypes }) => ({
     :link="link"
     :regular-price="regularPrice"
     :special-price="specialPrice"
+    :special-price="specialPrice"
+    :hasMoreActions="hasMoreActions"
   >
     <template #price>
       CUSTOM PRICE

--- a/packages/vue/src/components/organisms/SfCollectedProduct/SfCollectedProduct.vue
+++ b/packages/vue/src/components/organisms/SfCollectedProduct/SfCollectedProduct.vue
@@ -56,37 +56,42 @@
       </slot>
     </div>
     <slot name="remove" v-bind="{ removeHandler }">
-      <SfCircleIcon
-        icon="cross"
-        aria-label="Remove"
-        class="
-          sf-circle-icon--small
-          sf-collected-product__remove sf-collected-product__remove--circle-icon
-        "
-        @click="removeHandler"
-      />
-      <SfButton
-        class="
-          sf-button--text
-          sf-collected-product__remove sf-collected-product__remove--text
-        "
-        data-testid="collected-product-desktop-remove"
-        @click="removeHandler"
-        >Remove</SfButton
-      >
+      <template v-if="hasRemove">
+        <SfCircleIcon
+          icon="cross"
+          aria-label="Remove"
+          class="
+            sf-circle-icon--small
+            sf-collected-product__remove
+            sf-collected-product__remove--circle-icon
+          "
+          @click="removeHandler"
+        />
+        <SfButton
+          class="
+            sf-button--text
+            sf-collected-product__remove sf-collected-product__remove--text
+          "
+          data-testid="collected-product-desktop-remove"
+          @click="removeHandler"
+          >Remove</SfButton
+        >
+      </template>
     </slot>
     <slot name="more-actions" v-bind="{ actionsHandler }">
-      <SfButton
-        aria-label="More actions"
-        class="
-          sf-button--pure
-          sf-collected-product__more-actions
-          smartphone-only
-        "
-        @click="actionsHandler"
-      >
-        <SfIcon icon="more" size="18px" />
-      </SfButton>
+      <template v-if="hasMoreActions">
+        <SfButton
+          aria-label="More actions"
+          class="
+            sf-button--pure
+            sf-collected-product__more-actions
+            smartphone-only
+          "
+          @click="actionsHandler"
+        >
+          <SfIcon icon="more" size="18px" />
+        </SfButton>
+      </template>
     </slot>
   </div>
 </template>
@@ -171,6 +176,14 @@ export default {
     link: {
       type: [String, Object],
       default: "",
+    },
+    hasRemove: {
+      type: Boolean,
+      default: true,
+    },
+    hasMoreActions: {
+      type: Boolean,
+      default: true,
     },
   },
   computed: {

--- a/packages/vue/src/stories/releases/v0.11.x/v0.11.1/v0.11.1.stories.mdx
+++ b/packages/vue/src/stories/releases/v0.11.x/v0.11.1/v0.11.1.stories.mdx
@@ -11,6 +11,7 @@ import { Meta } from "@storybook/addon-docs/blocks";
 
 - SfGallery, SfSearchBar, SfSlidingSection, SfHeader, SfProductCard: add aria-label to icon only / image only SfButton
 - SfCollectedProduct: added event handler for more actions button
+- SfCollectedProduct: added visibility props for more actions and remove button
 
 ## 🐛 Fixes
 


### PR DESCRIPTION
# Related issue
Closes #2022

# Scope of work
- to hide more actions default button new prop was added
- to keep consistency also a prop for hiding remove button 

# Screenshots of visual changes
with hasMoreActions set to true:
<img width="513" alt="Zrzut ekranu 2021-10-15 o 12 54 54" src="https://user-images.githubusercontent.com/41487496/137477859-a978c062-360b-4e7e-ad4a-29d5b0cf9681.png">
with hasMoreActions set to false:
<img width="491" alt="Zrzut ekranu 2021-10-15 o 12 54 40" src="https://user-images.githubusercontent.com/41487496/137477952-2ce02577-f712-4a89-a202-77c488152b7b.png">

# Checklist

- [ ] No commented blocks of code left
- [ ] Run tests and docs
- [ ] Self code-reviewed
- [ ] Changes documented 

If applicable:

- [ ] I followed [composition rules](https://docs.storefrontui.io/?path=/story/introduction-contributing-guide-code-guidelines--page) for my component
- [ ] I tested the component in most common device sizes (can be tested in Storybook [from viewport addon in top menu](https://github.com/storybooks/storybook/tree/master/addons/viewport))
