### PR TITLE
chore: small tweaks in MegaMenu block example

### DIFF
--- a/apps/preview/nuxt/pages/showcases/MegaMenu/MegaMenuNavigation.vue
+++ b/apps/preview/nuxt/pages/showcases/MegaMenu/MegaMenuNavigation.vue
@@ -76,7 +76,7 @@
               :key="activeMenu.key"
               ref="megaMenuRef"
               :style="style"
-              class="hidden md:grid gap-x-6 grid-cols-4 bg-white shadow-lg p-6 left-0 right-0 outline-none z-10"
+              class="hidden md:grid gap-x-6 grid-cols-4 bg-white shadow-lg p-6 left-0 right-0 outline-none"
               tabindex="0"
               @mouseleave="close()"
               @keydown.esc="focusTrigger(index)"
@@ -117,8 +117,8 @@
       </nav>
 
       <!-- Mobile drawer -->
-      <div v-if="isOpen" class="md:hidden fixed inset-0 bg-neutral-500 bg-opacity-50 z-10" />
-      <SfDrawer ref="drawerRef" v-model="isOpen" placement="left" class="md:hidden bg-white w-[320px] overflow-y-auto z-10">
+      <div v-if="isOpen" class="md:hidden fixed inset-0 bg-neutral-500 bg-opacity-50" />
+      <SfDrawer ref="drawerRef" v-model="isOpen" placement="left" class="md:hidden bg-white w-[320px] overflow-y-auto">
         <nav>
           <div class="flex items-center justify-between p-4 border-b border-b-neutral-200 border-b-solid">
             <p class="typography-text-base font-medium">Browse products</p>


### PR DESCRIPTION
# Scope of work
While adapting the MegaMenu block example for our CMS integrations I've noticed two very small things.

1. [`key` used on the `li` element](https://github.com/vuestorefront/storefront-ui/pull/2779/commits/c2618ababf602983cb8960c5fc9c6196f7e825c7) instead of the wrapping `<template />` (which goes against what Vue docs suggests)
<img width="769" alt="image" src="https://github.com/vuestorefront/storefront-ui/assets/39009379/b28f209c-7078-4182-8a5b-f29cc0cb76e6">

2. [Dropdowns need `z-index`](https://github.com/vuestorefront/storefront-ui/pull/2779/commits/bbca95524b03b17f3c2c6075338929108080f83e). Otherwise they disappear under the DOM elements which follow the MegaMenu component 
<img width="1678" alt="image" src="https://github.com/vuestorefront/storefront-ui/assets/39009379/baa16d2f-d960-4e56-82a7-ba91437a8e75">

# Checklist

- [ ] Self code-reviewed
- [ ] Changes documented
- [ ] Semantic HTML
- [ ] SSR-friendly
- [ ] Caching friendly
- [ ] a11y for WCAG 2.0 AA
- [ ] examples created
- [ ] blocks created
- [ ] cypress tests created
