### PR TITLE
fix: subsequent RC release trigger

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -257,7 +257,7 @@ jobs:
         run: yarn build:release
       - name: Publish release-candidate version
         # If this is any `v2-release/**` branch AND last commit is made by changeset action and its commit message is with "ci: release (rc)", this happens only after merging changesets changelog PR
-        if: "${{ startsWith( github.event.pull_request.head.ref, 'v2-release' ) && contains( steps.commit_message.outputs.result, 'ci: version packages (rc)' ) }}"
+        if: "${{ startsWith( github.event.pull_request.head.ref, 'v2-release' ) && contains( steps.commit_message.outputs.result, 'ci: version packages ' ) && contains( steps.commit_message.outputs.result, ' (rc)' ) }}"
         run: yarn workspaces foreach --no-private --from '@storefront-ui/*' npm publish --tag rc || true
         env:
           # Needs access to publish to npm


### PR DESCRIPTION
# Related issue

<!-- paste a link to related issue -->

Closes #

# Scope of work

This PR fixes issue when there is subsequent change in `release candidate` mode. 
Changeset then create PR with name `ci: version packages vreact-2.7.0.rc.0 (rc)` example [PR](https://github.com/vuestorefront/storefront-ui/pull/3158) therefore we cannot rely on commit message check `contains( steps.commit_message.outputs.result, 'ci: version packages (rc)' )`

# Screenshots of visual changes

<!-- if visual changes applied -->

# Checklist

- [ ] Self code-reviewed
- [ ] Changes documented
- [ ] Semantic HTML
- [ ] SSR-friendly
- [ ] Caching friendly
- [ ] a11y for WCAG 2.0 AA
- [ ] examples created
- [ ] blocks created
- [ ] cypress tests created
