### PR TITLE
chore: cleanup scripts

### DIFF
--- a/apps/preview/next/package.json
+++ b/apps/preview/next/package.json
@@ -30,7 +30,6 @@
     "@storefront-ui/react": "workspace:*",
     "@storefront-ui/shared": "workspace:*",
     "@storefront-ui/tailwind-config": "workspace:*",
-    "@storefront-ui/tests-shared": "workspace:*",
     "@storefront-ui/tw-plugin-peer-next": "workspace:*",
     "@storefront-ui/typography": "workspace:*",
     "@tailwindcss/typography": "^0.5.13",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "prepare": "husky",
     "build": "yarn update-browserlist-db && yarn generate-icons && yarn build:peer-next && turbo run build",
     "dev:docs": "yarn update-browserlist-db && turbo run dev:docs",
-    "dev": "yarn update-browserlist-db && yarn build:typography && yarn build:peer-next && yarn build:tailwind-config && yarn build:test-utils && yarn build:react && turbo run dev --parallel",
+    "dev": "yarn update-browserlist-db && yarn build:peer-next && yarn build:nuxt-module && yarn build:react && turbo run dev --parallel",
     "dev:shared": "turbo run dev:shared",
     "update-browserlist-db": "yarn dlx browserslist@latest",
     "lint": "yarn build:typography && yarn build:peer-next && yarn build:tailwind-config && yarn build:vue && turbo run lint",

--- a/packages/sfui/shared/package.json
+++ b/packages/sfui/shared/package.json
@@ -18,7 +18,6 @@
   "unpkg": "dist/index.umd.js",
   "types": "dist/index.d.ts",
   "scripts": {
-    "dev": "vite build --watch",
     "dev:shared": "vite build --watch",
     "build:shared": "vite build"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -4533,7 +4533,6 @@ __metadata:
     "@storefront-ui/react": "workspace:*"
     "@storefront-ui/shared": "workspace:*"
     "@storefront-ui/tailwind-config": "workspace:*"
-    "@storefront-ui/tests-shared": "workspace:*"
     "@storefront-ui/tw-plugin-peer-next": "workspace:*"
     "@storefront-ui/typography": "workspace:*"
     "@tailwindcss/typography": ^0.5.13


### PR DESCRIPTION
# Related issue

<!-- paste a link to related issue -->

Closes #

# Scope of work

Removal of duplicate of `yarn dev` in shared package
Not used `@storefront-ui/tests-shared` in next preview app
Cleanup/fix script `yarn dev` on root

# Screenshots of visual changes

<!-- if visual changes applied -->

# Checklist

- [ ] Self code-reviewed
- [ ] Changes documented
- [ ] Semantic HTML
- [ ] SSR-friendly
- [ ] Caching friendly
- [ ] a11y for WCAG 2.0 AA
- [ ] examples created
- [ ] blocks created
- [ ] cypress tests created
