### PR TITLE
chore: update nuxt readme and docs, extend default content

### DIFF
--- a/.changeset/few-clocks-remember.md
+++ b/.changeset/few-clocks-remember.md
@@ -1,0 +1,5 @@
+---
+"@storefront-ui/nuxt": patch
+---
+
+[CHANGED] Update documentatnion/readme, extand default content path to `js` extension

--- a/apps/docs/components/content/2.getting-started/vue.md
+++ b/apps/docs/components/content/2.getting-started/vue.md
@@ -151,7 +151,7 @@ In order for Tailwind to properly detect the utility classes used in Storefront 
 import type { Config } from 'tailwindcss';
 
 export default <Config>{
-  content: ['./**/*.vue', './node_modules/@storefront-ui/vue/**/*.{js,mjs}'],
+  content: ['./**/*.vue'],
 };
 ```
 

--- a/packages/sfui/frameworks/nuxt/README.md
+++ b/packages/sfui/frameworks/nuxt/README.md
@@ -41,7 +41,7 @@ In order for Tailwind to properly detect the utility classes used in Storefront 
 import type { Config } from 'tailwindcss';
 
 export default <Config>{
-  content: ['./**/*.vue', './node_modules/@storefront-ui/vue/**/*.{js,mjs}'],
+  content: ['./**/*.vue'],
 };
 ```
 

--- a/packages/sfui/frameworks/nuxt/src/module.ts
+++ b/packages/sfui/frameworks/nuxt/src/module.ts
@@ -22,7 +22,7 @@ export default defineNuxtModule<ModuleOptions>({
   },
   // Default configuration options of the Nuxt module
   defaults: {
-    contentPath: './node_modules/@storefront-ui/vue/**/*.mjs',
+    contentPath: './node_modules/@storefront-ui/vue/**/*.{js,mjs}',
   },
   async setup(options, nuxt) {
     const { contentPath } = options;


### PR DESCRIPTION
# Related issue

<!-- paste a link to related issue -->

Closes #

# Scope of work

Update documentatnion/readme, extand default content path to `js` extension

# Screenshots of visual changes

<!-- if visual changes applied -->

# Checklist

- [ ] Self code-reviewed
- [ ] Changes documented
- [ ] Semantic HTML
- [ ] SSR-friendly
- [ ] Caching friendly
- [ ] a11y for WCAG 2.0 AA
- [ ] examples created
- [ ] blocks created
- [ ] cypress tests created
