### PR TITLE
feat: add automatic release notes generation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -301,11 +301,10 @@ jobs:
           # refresh token before Saturday, May 25, 2024
           NPM_TOKEN: ${{ secrets.NPM_RELEASE_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_RELEASE_TOKEN }}
-      - name: Create Release Pull Request
-        # Create release notes
-        uses: changesets/action@v1
+      - name: Create Release Notes
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: node releaseNotes.mjs
       - name: Create PR to v2-develop branch
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "@commitlint/cli": "^17.0.0",
     "@commitlint/config-conventional": "^17.0.0",
     "@frsource/frs-replace": "^4.1.1",
+    "@octokit/core": "^6.1.2",
     "@storefront-ui/typescript-config": "workspace:*",
     "@vue-storefront/prettier-config": "^2.0.0-rc.1",
     "babel-cli": "^6.26.0",
@@ -68,11 +69,15 @@
     "concurrently": "^8.2.2",
     "husky": "^9.0.11",
     "hygen": "^6.2.8",
+    "mdast-util-to-string": "^4.0.0",
     "prettier": "latest",
+    "remark-parse": "^11.0.0",
+    "remark-stringify": "^11.0.0",
     "rimraf": "^5.0.0",
     "tailwindcss": "^3.4.3",
     "turbo": "latest",
     "typescript": "^5.4.5",
+    "unified": "^11.0.4",
     "wait-on": "^7.0.1"
   },
   "engines": {

--- a/releaseNotes.mjs
+++ b/releaseNotes.mjs
@@ -1,0 +1,122 @@
+import { Octokit } from '@octokit/core';
+import { unified } from 'unified';
+import remarkParse from 'remark-parse';
+import remarkStringify from 'remark-stringify';
+import { toString } from 'mdast-util-to-string';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const OWNER = 'vuestorefront';
+const REPO = 'storefront-ui';
+const octokit = new Octokit({ auth: process.env['GITHUB_TOKEN'] });
+
+const BumpLevels = {
+  dep: 0,
+  patch: 1,
+  minor: 2,
+  major: 3,
+};
+
+// Implementation copied from changeset and its generation release notes https://github.com/changesets/action/blob/main/src/utils.ts#L37
+function getChangelogEntry(changelog, version) {
+  let ast = unified().use(remarkParse).parse(changelog);
+
+  let highestLevel = BumpLevels.dep;
+
+  let nodes = ast.children;
+  let headingStartInfo;
+  let endIndex;
+
+  for (let i = 0; i < nodes.length; i++) {
+    let node = nodes[i];
+    if (node.type === 'heading') {
+      let stringified = toString(node);
+      let match = stringified.toLowerCase().match(/(major|minor|patch)/);
+      if (match !== null) {
+        let level = BumpLevels[match[0]];
+        highestLevel = Math.max(level, highestLevel);
+      }
+      if (headingStartInfo === undefined && stringified === version) {
+        headingStartInfo = {
+          index: i,
+          depth: node.depth,
+        };
+        continue;
+      }
+      if (endIndex === undefined && headingStartInfo !== undefined && headingStartInfo.depth === node.depth) {
+        endIndex = i;
+        break;
+      }
+    }
+  }
+  if (headingStartInfo) {
+    ast.children = ast.children.slice(headingStartInfo.index + 1, endIndex);
+  }
+  return {
+    content: unified().use(remarkStringify).stringify(ast),
+    highestLevel: highestLevel,
+  };
+}
+
+const data = await octokit.request(`GET /repos/${OWNER}/${REPO}/commits`, {
+  owner: OWNER,
+  repo: REPO,
+  sha: 'v2',
+  headers: {
+    'X-GitHub-Api-Version': '2022-11-28',
+  },
+});
+
+const commitSha = data.data[0].sha;
+const commitBody = await octokit.request(`GET /repos/${OWNER}/${REPO}/commits/${commitSha}`, {
+  owner: OWNER,
+  repo: REPO,
+  ref: commitSha,
+  headers: {
+    'X-GitHub-Api-Version': '2022-11-28',
+  },
+});
+
+const allChangelogFiles = commitBody.data.files.filter((file) => file.filename.endsWith('CHANGELOG.md'));
+
+if (!allChangelogFiles.length) {
+  console.log('No CHANGELOG file has been found');
+} else {
+  await Promise.all(
+    allChangelogFiles.map(async (changelogFile) => {
+      const changelogFilePath = changelogFile.filename;
+      const updatedPackageDir = changelogFilePath.replace('/CHANGELOG.md', '');
+      const packageJsonPath = join(updatedPackageDir, 'package.json');
+
+      const changelogContent = readFileSync(changelogFilePath, 'utf-8');
+      const packageJsonContent = JSON.parse(readFileSync(packageJsonPath, 'utf-8'));
+
+      const pkgName = packageJsonContent.name;
+      const pkgVersion = packageJsonContent.version;
+      const tagName = `${pkgName}@${pkgVersion}`;
+
+      let changelogEntry = getChangelogEntry(changelogContent, pkgVersion);
+
+      try {
+        await octokit.request(`POST /repos/${OWNER}/${REPO}/releases`, {
+          owner: OWNER,
+          repo: REPO,
+          tag_name: tagName,
+          target_commitish: commitSha,
+          name: tagName,
+          body: changelogEntry.content,
+          draft: false,
+          prerelease: pkgVersion.includes('-'),
+          generate_release_notes: false,
+          headers: {
+            'X-GitHub-Api-Version': '2022-11-28',
+          },
+        });
+      } catch (e) {
+        console.log(e);
+      }
+
+      console.log(`Release notes for ${tagName} has been created 🎉`);
+    }),
+  );
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3639,6 +3639,86 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@octokit/auth-token@npm:^5.0.0":
+  version: 5.1.1
+  resolution: "@octokit/auth-token@npm:5.1.1"
+  checksum: b39516dda44aeced0326227c53aade621effe1d59c4b0f48ebe2b9fd32b5156e02705bcb2fb1bf48b11f26cc6aff1a0683c32c3d5424e0118dae6596e431d489
+  languageName: node
+  linkType: hard
+
+"@octokit/core@npm:^6.1.2":
+  version: 6.1.2
+  resolution: "@octokit/core@npm:6.1.2"
+  dependencies:
+    "@octokit/auth-token": ^5.0.0
+    "@octokit/graphql": ^8.0.0
+    "@octokit/request": ^9.0.0
+    "@octokit/request-error": ^6.0.1
+    "@octokit/types": ^13.0.0
+    before-after-hook: ^3.0.2
+    universal-user-agent: ^7.0.0
+  checksum: e794fb11b3942f55033f4cf6c0914953fd974587309498e8709c428660fa5c098334d83af5e41457dbe67d92d70a8b559c6cc00457d6c95290fa6c9e1d4bfc42
+  languageName: node
+  linkType: hard
+
+"@octokit/endpoint@npm:^10.0.0":
+  version: 10.1.1
+  resolution: "@octokit/endpoint@npm:10.1.1"
+  dependencies:
+    "@octokit/types": ^13.0.0
+    universal-user-agent: ^7.0.2
+  checksum: fde158f40dc9a88e92a8ac1d347a54599aa5715ec24045be9cb8ff8decb3c17b63c91eca1bab12dfe0e0cd37433127dd05cd05db14a719dca749bc56093aa915
+  languageName: node
+  linkType: hard
+
+"@octokit/graphql@npm:^8.0.0":
+  version: 8.1.1
+  resolution: "@octokit/graphql@npm:8.1.1"
+  dependencies:
+    "@octokit/request": ^9.0.0
+    "@octokit/types": ^13.0.0
+    universal-user-agent: ^7.0.0
+  checksum: 07239666b0ca38a7d8c581570b544ee9fd1a2616c8dd436af31879662b3345c44ed52e3d7b311840a1c5772a23f02caf7585aca56f36e50f38f0207a87577a9c
+  languageName: node
+  linkType: hard
+
+"@octokit/openapi-types@npm:^22.2.0":
+  version: 22.2.0
+  resolution: "@octokit/openapi-types@npm:22.2.0"
+  checksum: eca41feac2b83298e0d95e253ac1c5b6d65155ac57f65c5fd8d4a485d9728922d85ff4bee0e815a1f3a5421311db092bdb6da9d6104a1b1843d8b274bcad9630
+  languageName: node
+  linkType: hard
+
+"@octokit/request-error@npm:^6.0.1":
+  version: 6.1.1
+  resolution: "@octokit/request-error@npm:6.1.1"
+  dependencies:
+    "@octokit/types": ^13.0.0
+  checksum: cae7bc4078629a02edcf35977f496a4b943e730165f6d7828795073f99a1d884ac67343b02eff69e553a5057765e466d70ddd9d266787f505aa29018858ab06d
+  languageName: node
+  linkType: hard
+
+"@octokit/request@npm:^9.0.0":
+  version: 9.1.1
+  resolution: "@octokit/request@npm:9.1.1"
+  dependencies:
+    "@octokit/endpoint": ^10.0.0
+    "@octokit/request-error": ^6.0.1
+    "@octokit/types": ^13.1.0
+    universal-user-agent: ^7.0.2
+  checksum: 0c41654911c217eb2892ce6c9c273cc2139e5510b025c71e72e1528f0d8bad2a9e578e5b305595599f2e1cb630c1812cd7d9e4f6d16a63007a7d1745f1c682ce
+  languageName: node
+  linkType: hard
+
+"@octokit/types@npm:^13.0.0, @octokit/types@npm:^13.1.0":
+  version: 13.5.0
+  resolution: "@octokit/types@npm:13.5.0"
+  dependencies:
+    "@octokit/openapi-types": ^22.2.0
+  checksum: 8e92f2b145b3c28a35312f93714245824a7b6b7353caa88edfdc85fc2ed4108321ed0c3988001ea53449fbb212febe0e8e9582744e85c3574dabe9d0441af5a0
+  languageName: node
+  linkType: hard
+
 "@open-draft/deferred-promise@npm:^2.2.0":
   version: 2.2.0
   resolution: "@open-draft/deferred-promise@npm:2.2.0"
@@ -4705,6 +4785,7 @@ __metadata:
     "@commitlint/cli": ^17.0.0
     "@commitlint/config-conventional": ^17.0.0
     "@frsource/frs-replace": ^4.1.1
+    "@octokit/core": ^6.1.2
     "@storefront-ui/typescript-config": "workspace:*"
     "@vue-storefront/prettier-config": ^2.0.0-rc.1
     babel-cli: ^6.26.0
@@ -4713,11 +4794,15 @@ __metadata:
     concurrently: ^8.2.2
     husky: ^9.0.11
     hygen: ^6.2.8
+    mdast-util-to-string: ^4.0.0
     prettier: latest
+    remark-parse: ^11.0.0
+    remark-stringify: ^11.0.0
     rimraf: ^5.0.0
     tailwindcss: ^3.4.3
     turbo: latest
     typescript: ^5.4.5
+    unified: ^11.0.4
     wait-on: ^7.0.1
   languageName: unknown
   linkType: soft
@@ -8297,6 +8382,13 @@ __metadata:
   dependencies:
     tweetnacl: ^0.14.3
   checksum: 4edfc9fe7d07019609ccf797a2af28351736e9d012c8402a07120c4453a3b789a15f2ee1530dc49eee8f7eb9379331a8dd4b3766042b9e502f74a68e7f662291
+  languageName: node
+  linkType: hard
+
+"before-after-hook@npm:^3.0.2":
+  version: 3.0.2
+  resolution: "before-after-hook@npm:3.0.2"
+  checksum: 5f76a9d31909f7f1f7125b7e017ff018799308f5c1fc5a5bfeba9986149da77e6a5cdde0d151671cf374a7fa6452533237bb1de62dfd6c235c20e7c61cc9569d
   languageName: node
   linkType: hard
 
@@ -24940,6 +25032,13 @@ __metadata:
     unist-util-is: ^6.0.0
     unist-util-visit-parents: ^6.0.0
   checksum: 9ec42e618e7e5d0202f3c191cd30791b51641285732767ee2e6bcd035931032e3c1b29093f4d7fd0c79175bbc1f26f24f26ee49770d32be76f8730a652a857e6
+  languageName: node
+  linkType: hard
+
+"universal-user-agent@npm:^7.0.0, universal-user-agent@npm:^7.0.2":
+  version: 7.0.2
+  resolution: "universal-user-agent@npm:7.0.2"
+  checksum: 3f02cb6de0bb9fbaf379566bd0320d8e46af6e4358a2e88fce7e70687ed7b48b37f479d728bb22f4204a518e363f3038ac4841c033af1ee2253f6428a6c67e53
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Related issue

<!-- paste a link to related issue -->

Closes #

# Scope of work

Automatic release notes generation based on changelog generated by changsets 
It will looks like 
![image](https://github.com/vuestorefront/storefront-ui/assets/2566152/7359abec-addb-40af-bff1-c42f9e51acb1)


# Screenshots of visual changes

<!-- if visual changes applied -->

# Checklist

- [ ] Self code-reviewed
- [ ] Changes documented
- [ ] Semantic HTML
- [ ] SSR-friendly
- [ ] Caching friendly
- [ ] a11y for WCAG 2.0 AA
- [ ] examples created
- [ ] blocks created
- [ ] cypress tests created
