### PR TITLE
fix: basic product slider showcase name

### DIFF
--- a/apps/preview/next/pages/showcases/ProductSlider/Basic.tsx
+++ b/apps/preview/next/pages/showcases/ProductSlider/Basic.tsx
@@ -59,7 +59,7 @@ function ButtonNext({ disabled, ...attributes }: { disabled?: boolean }) {
 
 ButtonNext.defaultProps = { disabled: false };
 
-export default function GalleryVertical() {
+export default function ProductSliderBasic() {
   return (
     <SfScrollable
       className="m-auto py-4 items-center w-full [&::-webkit-scrollbar]:hidden [-ms-overflow-style:none] [scrollbar-width:none]"
@@ -106,4 +106,4 @@ export default function GalleryVertical() {
 }
 // #endregion source
 
-GalleryVertical.getLayout = ShowcasePageLayout;
+ProductSliderBasic.getLayout = ShowcasePageLayout;


### PR DESCRIPTION
# Related issue

<!-- paste a link to related issue -->

Closes #

# Scope of work

Basic product slider component name has wrong name

# Screenshots of visual changes

<!-- if visual changes applied -->

# Checklist

- [ ] Self code-reviewed
- [ ] Changes documented
- [ ] Semantic HTML
- [ ] SSR-friendly
- [ ] Caching friendly
- [ ] a11y for WCAG 2.0 AA
- [ ] examples created
- [ ] blocks created
- [ ] cypress tests created
