### PR TITLE
docs: fix prerender

### DIFF
--- a/apps/docs/components/nuxt.config.ts
+++ b/apps/docs/components/nuxt.config.ts
@@ -41,6 +41,7 @@ export default defineNuxtConfig({
       },
     },
     prerender: {
+      routes: ['/'],
       crawlLinks: true,
       failOnError: false,
     },

--- a/apps/preview/nuxt/nuxt.config.ts
+++ b/apps/preview/nuxt/nuxt.config.ts
@@ -42,6 +42,12 @@ export default defineNuxtConfig({
         }
       : {}),
   },
+  nitro: {
+    prerender: {
+      routes: ['/'],
+      crawlLinks: true,
+    },
+  },
   vite: {
     plugins: [
       {


### PR DESCRIPTION
# Related issue

<!-- paste a link to related issue -->

Closes #

# Scope of work

The Prerender Crawler wasn't running because it had no start pages. 

After Changes (all links crawled and rendered)

<img width="389" alt="image" src="https://github.com/user-attachments/assets/5b74cea9-54db-4862-9298-03e699cbd255">


# Screenshots of visual changes

<!-- if visual changes applied -->

# Checklist

- [ ] Self code-reviewed
- [ ] Changes documented
- [ ] Semantic HTML
- [ ] SSR-friendly
- [ ] Caching friendly
- [ ] a11y for WCAG 2.0 AA
- [ ] examples created
- [ ] blocks created
- [ ] cypress tests created
