### PR TITLE
feat:  batch up for components 

### DIFF
--- a/apps/preview/next/pages/showcases/Breadcrumbs/Breadcrumbs.tsx
+++ b/apps/preview/next/pages/showcases/Breadcrumbs/Breadcrumbs.tsx
@@ -26,7 +26,7 @@ export function Showcase() {
 
   return (
     <nav className="inline-flex font-normal font-body typography-text-sm">
-      <ol className="flex items-center w-auto leading-none group md:flex-wrap">
+      <ol className="flex items-center w-auto leading-none md:flex-wrap">
         <li className="flex items-center sm:hidden text-neutral-500">
           <SfDropdown
             trigger={

--- a/apps/preview/nuxt/pages/showcases/Breadcrumbs/Breadcrumbs.vue
+++ b/apps/preview/nuxt/pages/showcases/Breadcrumbs/Breadcrumbs.vue
@@ -1,6 +1,6 @@
 <template>
   <nav class="inline-flex items-center text-sm font-normal font-body">
-    <ol class="flex w-auto leading-none group md:flex-wrap">
+    <ol class="flex w-auto leading-none md:flex-wrap">
       <li class="flex items-center sm:hidden text-neutral-500">
         <SfDropdown v-model="dropdownOpened" strategy="absolute" placement="bottom-start" @update:model-value="close">
           <template #trigger>

--- a/packages/sfui/frameworks/react/components/SfAccordionItem/SfAccordionItem.tsx
+++ b/packages/sfui/frameworks/react/components/SfAccordionItem/SfAccordionItem.tsx
@@ -5,7 +5,7 @@ import classNames from 'classnames';
 import type { SfAccordionItemProps } from '@storefront-ui/react';
 
 const SfAccordionItem = forwardRef<HTMLDetailsElement, SfAccordionItemProps>((props, ref) => {
-  const { open, onToggle, children, summary, summaryClassName, ...attributes } = props;
+  const { open, onToggle, children, summary, summaryClassName, summaryAttrs, ...attributes } = props;
 
   const handleClick = (event: MouseEvent<HTMLElement>) => {
     event.preventDefault();
@@ -15,6 +15,7 @@ const SfAccordionItem = forwardRef<HTMLDetailsElement, SfAccordionItemProps>((pr
   return (
     <details ref={ref} open={open} data-testid="accordion-item" {...attributes}>
       <summary
+        {...summaryAttrs}
         onClick={handleClick}
         className={classNames(
           summaryClassName,

--- a/packages/sfui/frameworks/react/components/SfAccordionItem/types.ts
+++ b/packages/sfui/frameworks/react/components/SfAccordionItem/types.ts
@@ -1,4 +1,4 @@
-import type { ReactNode, PropsWithChildren, DetailsHTMLAttributes } from 'react';
+import type { ReactNode, PropsWithChildren, DetailsHTMLAttributes, HTMLAttributes } from 'react';
 
 export interface SfAccordionItemProps
   extends Omit<DetailsHTMLAttributes<HTMLDetailsElement>, 'onToggle'>,
@@ -6,4 +6,5 @@ export interface SfAccordionItemProps
   onToggle?: (isOpen: boolean) => void;
   summary?: ReactNode;
   summaryClassName?: string;
+  summaryAttrs?: HTMLAttributes<HTMLElement>;
 }

--- a/packages/sfui/frameworks/react/components/SfDropdown/SfDropdown.tsx
+++ b/packages/sfui/frameworks/react/components/SfDropdown/SfDropdown.tsx
@@ -4,7 +4,15 @@ import { useDropdown } from '@storefront-ui/react';
 import type { SfDropdownProps } from '@storefront-ui/react';
 
 export default function SfDropdown(props: SfDropdownProps) {
-  const { children, trigger, open: isOpen = false, className, style: containerStyle, ...dropdownOptions } = props;
+  const {
+    children,
+    trigger,
+    open: isOpen = false,
+    className,
+    style: containerStyle,
+    wrapperClass,
+    ...dropdownOptions
+  } = props;
   const { refs, style: dropdownStyle } = useDropdown({ isOpen, ...dropdownOptions });
 
   return (
@@ -16,7 +24,13 @@ export default function SfDropdown(props: SfDropdownProps) {
     >
       {trigger}
       {isOpen && (
-        <div ref={refs.setFloating} style={dropdownStyle} aria-hidden={!isOpen} data-testid="dropdown-content">
+        <div
+          ref={refs.setFloating}
+          style={dropdownStyle}
+          aria-hidden={!isOpen}
+          data-testid="dropdown-content"
+          className={wrapperClass}
+        >
           {children}
         </div>
       )}

--- a/packages/sfui/frameworks/react/components/SfDropdown/types.ts
+++ b/packages/sfui/frameworks/react/components/SfDropdown/types.ts
@@ -4,4 +4,5 @@ import type { UseDropdownOptions, PropsWithStyle } from '@storefront-ui/react';
 export interface SfDropdownProps extends Omit<UseDropdownOptions, 'isOpen'>, PropsWithStyle, PropsWithChildren {
   open?: boolean;
   trigger: ReactNode;
+  wrapperClass?: string;
 }

--- a/packages/sfui/frameworks/react/components/SfListItem/SfListItem.tsx
+++ b/packages/sfui/frameworks/react/components/SfListItem/SfListItem.tsx
@@ -22,6 +22,8 @@ const SfListItem = polymorphicForwardRef<typeof defaultListItemTag, SfListItemPr
     as,
     childrenTag,
     children,
+    prefixClassName,
+    suffixClassName,
     ...attributes
   } = props;
 
@@ -45,11 +47,15 @@ const SfListItem = polymorphicForwardRef<typeof defaultListItemTag, SfListItemPr
       {...attributes}
     >
       {slotPrefix && (
-        <ChildrenTag className={disabled ? 'text-disabled-500' : 'text-neutral-500'}>{slotPrefix}</ChildrenTag>
+        <ChildrenTag className={classNames(disabled ? 'text-disabled-500' : 'text-neutral-500', prefixClassName)}>
+          {slotPrefix}
+        </ChildrenTag>
       )}
       <ChildrenTag className="flex flex-col w-full min-w-0">{children}</ChildrenTag>
       {slotSuffix && (
-        <ChildrenTag className={disabled ? 'text-disabled-500' : 'text-neutral-500'}>{slotSuffix}</ChildrenTag>
+        <ChildrenTag className={classNames(disabled ? 'text-disabled-500' : 'text-neutral-500', suffixClassName)}>
+          {slotSuffix}
+        </ChildrenTag>
       )}
     </Tag>
   );

--- a/packages/sfui/frameworks/react/components/SfListItem/types.ts
+++ b/packages/sfui/frameworks/react/components/SfListItem/types.ts
@@ -11,4 +11,6 @@ export interface SfListItemProps extends PropsWithChildren, PropsWithStyle {
   slotPrefix?: ReactNode;
   role?: string;
   childrenTag?: ElementType;
+  prefixClassName?: string;
+  suffixClassName?: string;
 }

--- a/packages/sfui/frameworks/react/hooks/useTooltip/useTooltip.ts
+++ b/packages/sfui/frameworks/react/hooks/useTooltip/useTooltip.ts
@@ -76,6 +76,7 @@ export function useTooltip(options?: UseTooltipOptions) {
       floating: floatingStyle,
       arrow: arrowStyle(),
     },
+    middlewareData,
     isOpen,
     open,
     close,

--- a/packages/sfui/frameworks/vue/components/SfAccordionItem/SfAccordionItem.vue
+++ b/packages/sfui/frameworks/vue/components/SfAccordionItem/SfAccordionItem.vue
@@ -1,5 +1,6 @@
 <script lang="ts" setup>
 import { ClassProp } from '@storefront-ui/vue';
+import { type HTMLAttributes, type PropType } from 'vue';
 
 defineProps({
   modelValue: {
@@ -7,6 +8,10 @@ defineProps({
     default: false,
   },
   summaryClass: ClassProp,
+  summaryAttrs: {
+    type: Object as PropType<HTMLAttributes>,
+    default: () => ({}),
+  },
 });
 
 defineEmits<{
@@ -19,6 +24,7 @@ defineEmits<{
 <template>
   <details :open="modelValue" data-testid="accordion-item">
     <summary
+      v-bind="summaryAttrs"
       :class="[
         summaryClass,
         'list-none [&::-webkit-details-marker]:hidden cursor-pointer focus-visible:outline focus-visible:outline-offset focus-visible:rounded-sm',

--- a/packages/sfui/frameworks/vue/components/SfDropdown/SfDropdown.vue
+++ b/packages/sfui/frameworks/vue/components/SfDropdown/SfDropdown.vue
@@ -1,7 +1,7 @@
 <script lang="ts" setup>
 import { type PropType, toRefs } from 'vue';
 import type { Middleware } from '@floating-ui/vue';
-import { useDropdown, type SfPopoverPlacement, type SfPopoverStrategy } from '@storefront-ui/vue';
+import { ClassProp, useDropdown, type SfPopoverPlacement, type SfPopoverStrategy } from '@storefront-ui/vue';
 
 const props = defineProps({
   modelValue: {
@@ -20,6 +20,7 @@ const props = defineProps({
     type: String as PropType<`${SfPopoverStrategy}` | undefined>,
     default: undefined,
   },
+  wrapperClass: ClassProp,
 });
 
 const emit = defineEmits<{
@@ -48,6 +49,7 @@ const {
       :style="dropdownStyle"
       :aria-hidden="!modelValue || undefined"
       data-testid="dropdown-content"
+      :class="wrapperClass"
     >
       <slot />
     </div>

--- a/packages/sfui/frameworks/vue/components/SfListItem/SfListItem.vue
+++ b/packages/sfui/frameworks/vue/components/SfListItem/SfListItem.vue
@@ -8,7 +8,7 @@ export const sizeClasses = {
 
 <script setup lang="ts">
 import { type PropType, type ConcreteComponent } from 'vue';
-import { SfListItemSize } from '@storefront-ui/vue';
+import { ClassProp, SfListItemSize } from '@storefront-ui/vue';
 
 defineProps({
   size: {
@@ -31,6 +31,8 @@ defineProps({
     type: String,
     default: 'span',
   },
+  prefixClass: ClassProp,
+  suffixClass: ClassProp,
 });
 </script>
 
@@ -45,13 +47,21 @@ defineProps({
     :disabled="disabled"
     data-testid="list-item"
   >
-    <component :is="childrenTag" v-if="$slots.prefix" :class="disabled ? 'text-disabled-500' : 'text-neutral-500'">
+    <component
+      :is="childrenTag"
+      v-if="$slots.prefix"
+      :class="[prefixClass, disabled ? 'text-disabled-500' : 'text-neutral-500']"
+    >
       <slot name="prefix" />
     </component>
     <component :is="childrenTag" class="flex flex-col w-full min-w-0">
       <slot />
     </component>
-    <component :is="childrenTag" v-if="$slots.suffix" :class="disabled ? 'text-disabled-500' : 'text-neutral-500'">
+    <component
+      :is="childrenTag"
+      v-if="$slots.suffix"
+      :class="[suffixClass, disabled ? 'text-disabled-500' : 'text-neutral-500']"
+    >
       <slot name="suffix" />
     </component>
   </component>

--- a/packages/sfui/frameworks/vue/composables/useTooltip/useTooltip.ts
+++ b/packages/sfui/frameworks/vue/composables/useTooltip/useTooltip.ts
@@ -77,6 +77,7 @@ export function useTooltip<ReferenceEl extends ReferenceElement = ReferenceEleme
       floating: floatingStyle.value,
       arrow: arrowStyle(),
     })),
+    middlewareData,
     isOpen,
     open,
     close,


### PR DESCRIPTION
# Related issue

<!-- paste a link to related issue -->

Closes #

# Scope of work

Batch of found issues potential ways to update 
- adding additional wrapper class props or attr prop so component could be easily used without need of copying 
- useTooltip does not expose `middlewareData` useful for dynamic assigning of placement
- removal of unused `group` class in Breadcrumbs block 

# Screenshots of visual changes

<!-- if visual changes applied -->

# Checklist

- [ ] Self code-reviewed
- [ ] Changes documented
- [ ] Semantic HTML
- [ ] SSR-friendly
- [ ] Caching friendly
- [ ] a11y for WCAG 2.0 AA
- [ ] examples created
- [ ] blocks created
- [ ] cypress tests created
