### PR TITLE
chore: fixup data-testid order

### DIFF
--- a/.changeset/sixty-mayflies-guess.md
+++ b/.changeset/sixty-mayflies-guess.md
@@ -1,0 +1,5 @@
+---
+'@storefront-ui/vue': patch
+---
+
+- **[FIXED]** allow to change default `data-testid` attribute on `SfButton` and `SfBadge` components.

--- a/packages/sfui/frameworks/vue/components/SfBadge/SfBadge.vue
+++ b/packages/sfui/frameworks/vue/components/SfBadge/SfBadge.vue
@@ -52,8 +52,8 @@ const displayValue = computed(() => {
         $attrs.class,
       )
     "
-    v-bind="attrsWithoutClass"
     data-testid="badge"
+    v-bind="attrsWithoutClass"
   >
     {{ displayValue }}
   </span>

--- a/packages/sfui/frameworks/vue/components/SfButton/SfButton.vue
+++ b/packages/sfui/frameworks/vue/components/SfButton/SfButton.vue
@@ -75,6 +75,7 @@ const type = computed(
 <template>
   <component
     :is="tagWithDefaults"
+    data-testid="button"
     v-bind="attrsWithoutClass"
     :type="type"
     :disabled="disabled"
@@ -87,7 +88,6 @@ const type = computed(
         $attrs.class,
       )
     "
-    data-testid="button"
   >
     <slot v-if="$slots.prefix" name="prefix" />
     <slot />


### PR DESCRIPTION
# Related issue

<!-- paste a link to related issue -->

Closes #

# Scope of work

<!-- describe what you did -->
data-testid attribute should be specified **before** v-bind attr on the elements so it's possible to overwrite`data-testid` from the outside

# Screenshots of visual changes

<!-- if visual changes applied -->

# Checklist

- [x] Self code-reviewed
- [x] Changes documented
- [x] Semantic HTML
- [x] SSR-friendly
- [x] Caching friendly
- [x] a11y for WCAG 2.0 AA
- [x] examples created
- [x] blocks created
- [x] cypress tests created
