### PR TITLE
feat(tooltip): improve tooltip accessibility [ES-2025]

### DIFF
--- a/.changeset/blue-hats-care.md
+++ b/.changeset/blue-hats-care.md
@@ -1,0 +1,7 @@
+---
+'@storefront-ui/vue': minor
+---
+
+- **[ADDED]** Support for setting `id` attribute on the content in `SfTooltip` component.
+- **[ADDED]** Possibility to open tooltip programatically via `modelValue` prop.
+- **[ADDED]** `useTooltip` now closes tooltip on `Escape` keypress.

--- a/.changeset/great-geckos-dance.md
+++ b/.changeset/great-geckos-dance.md
@@ -1,0 +1,11 @@
+---
+'@storefront-ui/vue': major
+---
+
+- **[CHANGED][BREAKING]** Use `useId` method coming from `vue` package instead of custom implementation. To migrate:
+1. Update your `vue` dependency version to at least 3.5.0.
+2. Update every `useId` usage as follows:
+```diff
+-import { useId } from '@storefront-ui/vue';
++import { useId } from 'vue';
+```

--- a/.changeset/tricky-rats-buy.md
+++ b/.changeset/tricky-rats-buy.md
@@ -1,0 +1,7 @@
+---
+'@storefront-ui/react': minor
+---
+
+- **[ADDED]** Support for passing `id` and `data-testid` attributes to `SfTooltip` component.
+- **[ADDED]** Possibility to open tooltip programatically via `open` prop.
+- **[ADDED]** `useTooltip` now closes tooltip on `Escape` keypress.

--- a/apps/docs/components/content/_components/tooltip.md
+++ b/apps/docs/components/content/_components/tooltip.md
@@ -20,6 +20,8 @@ Learn more about `useTooltip` composable in the [Composables > useTooltip docs](
 
 ### Basic Usage
 
+The tooltip appears on hover and is useful for displaying extra information to desktop users. For accessibility, always set the `id` prop on `SfTooltip` and use the same value for the `aria-describedby` attribute on the child element.
+
 <Showcase showcase-name="Tooltip/BasicTooltip">
 
 ::vue-only
@@ -27,6 +29,21 @@ Learn more about `useTooltip` composable in the [Composables > useTooltip docs](
 ::
 ::react-only
 <<<../../../../preview/next/pages/showcases/Tooltip/BasicTooltip.tsx
+::
+
+</Showcase>
+
+### Focusable Tooltip content
+
+For improved accessibility and better support for mobile users, ensure the tooltip’s trigger element is focusable. You can do this by applying a `tabindex` attribute or by using a natively focusable element such as a `button` or `input`. Also, handle the `focus` and `blur` events on the trigger to control the tooltip’s visibility. See the showcase below for a implementation example.
+
+<Showcase showcase-name="Tooltip/FocusableTooltip">
+
+::vue-only
+<<<../../../../preview/nuxt/pages/showcases/Tooltip/FocusableTooltip.vue
+::
+::react-only
+<<<../../../../preview/next/pages/showcases/Tooltip/FocusableTooltip.tsx
 ::
 
 </Showcase>
@@ -48,6 +65,7 @@ By default, this component sets `role="tooltip"`.
 | Prop name | Type                                                     | Default value | Possible values |
 | --------- | -------------------------------------------------------- | ------------- | --------------- |
 | `label`\*   | `string`                                                 |               |                 |
+| `modelValue` | `boolean`                                                | `false`       |                 |
 | `showArrow` | `boolean`                                                | `false`       |                 |
 | `placement` | `SfPopoverPlacement`                                    |               |                 |
 | `arrowSize` | `${number}px` &#124; `${number}em` &#124; `${number}rem` |               |                 |
@@ -56,6 +74,7 @@ By default, this component sets `role="tooltip"`.
 | Prop name | Type                                                     | Default value | Possible values |
 | --------- | -------------------------------------------------------- | ------------- | --------------- |
 | `label`\*   | `string`                                                 |               |                 |
+| `open` | `boolean`                                                | `false`       |                 |
 | `showArrow` | `boolean`                                                | `false`       |                 |
 | `placement` | `SfPopoverPlacement`                                    |               |                 |
 | `arrowSize` | `${number}px` &#124; `${number}em` &#124; `${number}rem` |               |                 |

--- a/apps/preview/next/pages/showcases/Tooltip/BasicTooltip.tsx
+++ b/apps/preview/next/pages/showcases/Tooltip/BasicTooltip.tsx
@@ -1,11 +1,15 @@
 import { ShowcasePageLayout } from '../../showcases';
 // #region source
+import { useId } from 'react';
 import { SfTooltip } from '@storefront-ui/react';
 
 export default function BasicTooltip() {
+  const id = useId();
+  const tooltipId = `${id}-tooltip`;
+
   return (
-    <SfTooltip label="This is a tooltip!">
-      <span>Hover me!</span>
+    <SfTooltip label="This is a tooltip!" id={tooltipId}>
+      <span aria-describedby={tooltipId}>Hover me!</span>
     </SfTooltip>
   );
 }

--- a/apps/preview/next/pages/showcases/Tooltip/FocusableTooltip.tsx
+++ b/apps/preview/next/pages/showcases/Tooltip/FocusableTooltip.tsx
@@ -1,0 +1,21 @@
+import { ShowcasePageLayout } from '../../showcases';
+// #region source
+import { useId } from 'react';
+import { SfTooltip, useDisclosure } from '@storefront-ui/react';
+
+export default function BasicTooltip() {
+  const id = useId();
+  const tooltipId = `${id}-tooltip`;
+  const { isOpen, open, close } = useDisclosure();
+
+  return (
+    <SfTooltip label="This is a tooltip!" id={tooltipId} open={isOpen} showArrow placement="right">
+      <span aria-describedby={tooltipId} onFocus={open} onBlur={close} tabIndex={0}>
+        Hover or focus me!
+      </span>
+    </SfTooltip>
+  );
+}
+
+// #endregion source
+BasicTooltip.getLayout = ShowcasePageLayout;

--- a/apps/preview/nuxt/pages/showcases/Combobox/ComboboxBasic.vue
+++ b/apps/preview/nuxt/pages/showcases/Combobox/ComboboxBasic.vue
@@ -107,7 +107,7 @@
 </template>
 
 <script lang="ts" setup>
-import { ref, watch } from 'vue';
+import { ref, watch, useId } from 'vue';
 import { offset } from '@floating-ui/vue';
 import { unrefElement } from '@vueuse/core';
 import {
@@ -118,7 +118,6 @@ import {
   useDisclosure,
   useDropdown,
   useTrapFocus,
-  useId,
 } from '@storefront-ui/vue';
 
 const inputModel = ref('');

--- a/apps/preview/nuxt/pages/showcases/FormFields/FormFieldsRequired.vue
+++ b/apps/preview/nuxt/pages/showcases/FormFields/FormFieldsRequired.vue
@@ -284,7 +284,7 @@
 </template>
 
 <script lang="ts" setup>
-import { ref, type Ref, watch } from 'vue';
+import { ref, type Ref, watch, useId } from 'vue';
 import {
   SfSwitch,
   SfInput,
@@ -298,7 +298,6 @@ import {
   SfIconExpandMore,
   SfListItem,
   SfIconCheck,
-  useId,
   useTrapFocus,
 } from '@storefront-ui/vue';
 import { unrefElement } from '@vueuse/core';

--- a/apps/preview/nuxt/pages/showcases/ProductCard/Details.vue
+++ b/apps/preview/nuxt/pages/showcases/ProductCard/Details.vue
@@ -112,7 +112,7 @@
 </template>
 
 <script lang="ts" setup>
-import { ref } from 'vue';
+import { ref, useId } from 'vue';
 import {
   SfButton,
   SfCounter,
@@ -127,7 +127,6 @@ import {
   SfIconShoppingCart,
   SfIconAdd,
   SfIconRemove,
-  useId,
   SfIconShoppingCartCheckout,
 } from '@storefront-ui/vue';
 import { clamp } from '@storefront-ui/shared';

--- a/apps/preview/nuxt/pages/showcases/ProductCard/ProductCardHorizontal.vue
+++ b/apps/preview/nuxt/pages/showcases/ProductCard/ProductCardHorizontal.vue
@@ -84,8 +84,8 @@
 </template>
 
 <script lang="ts" setup>
-import { ref } from 'vue';
-import { SfLink, SfButton, SfIconSell, SfIconAdd, SfIconRemove, SfIconDelete, useId } from '@storefront-ui/vue';
+import { ref, useId } from 'vue';
+import { SfLink, SfButton, SfIconSell, SfIconAdd, SfIconRemove, SfIconDelete } from '@storefront-ui/vue';
 import { clamp } from '@storefront-ui/shared';
 import { useCounter } from '@vueuse/core';
 

--- a/apps/preview/nuxt/pages/showcases/QuantitySelector/OutOfStock.vue
+++ b/apps/preview/nuxt/pages/showcases/QuantitySelector/OutOfStock.vue
@@ -23,8 +23,8 @@
 </template>
 
 <script lang="ts" setup>
-import { ref } from 'vue';
-import { SfButton, SfIconAdd, SfIconRemove, useId } from '@storefront-ui/vue';
+import { ref, useId } from 'vue';
+import { SfButton, SfIconAdd, SfIconRemove } from '@storefront-ui/vue';
 
 const min = ref(1);
 const max = ref(10);

--- a/apps/preview/nuxt/pages/showcases/QuantitySelector/QuantitySelector.vue
+++ b/apps/preview/nuxt/pages/showcases/QuantitySelector/QuantitySelector.vue
@@ -40,10 +40,10 @@
 </template>
 
 <script lang="ts" setup>
-import { ref } from 'vue';
+import { ref, useId } from 'vue';
 import { clamp } from '@storefront-ui/shared';
 import { useCounter } from '@vueuse/core';
-import { SfButton, SfIconAdd, SfIconRemove, useId } from '@storefront-ui/vue';
+import { SfButton, SfIconAdd, SfIconRemove } from '@storefront-ui/vue';
 
 const min = ref(1);
 const max = ref(10);

--- a/apps/preview/nuxt/pages/showcases/QuantitySelector/Rounded.vue
+++ b/apps/preview/nuxt/pages/showcases/QuantitySelector/Rounded.vue
@@ -34,9 +34,9 @@
 </template>
 
 <script lang="ts" setup>
-import { ref } from 'vue';
+import { ref, useId } from 'vue';
 import { useCounter } from '@vueuse/core';
-import { SfButton, SfIconAdd, SfIconRemove, useId } from '@storefront-ui/vue';
+import { SfButton, SfIconAdd, SfIconRemove } from '@storefront-ui/vue';
 import { clamp } from '@storefront-ui/shared';
 
 const min = ref(1);

--- a/apps/preview/nuxt/pages/showcases/RatingButton/Basic.vue
+++ b/apps/preview/nuxt/pages/showcases/RatingButton/Basic.vue
@@ -6,8 +6,8 @@
 </template>
 
 <script lang="ts" setup>
-import { ref } from 'vue';
-import { SfRatingButton, useId } from '@storefront-ui/vue';
+import { ref, useId } from 'vue';
+import { SfRatingButton } from '@storefront-ui/vue';
 const labelId = useId();
 const modelValue = ref();
 </script>

--- a/apps/preview/nuxt/pages/showcases/RatingButton/CustomIcon.vue
+++ b/apps/preview/nuxt/pages/showcases/RatingButton/CustomIcon.vue
@@ -21,8 +21,8 @@
 </template>
 
 <script lang="ts" setup>
-import { ref } from 'vue';
-import { SfRatingButton, SfIconFavorite, SfIconFavoriteFilled, useId } from '@storefront-ui/vue';
+import { ref, useId } from 'vue';
+import { SfRatingButton, SfIconFavorite, SfIconFavoriteFilled } from '@storefront-ui/vue';
 const labelId = useId();
 const modelValue = ref(2);
 </script>

--- a/apps/preview/nuxt/pages/showcases/RatingButton/MaxNumber.vue
+++ b/apps/preview/nuxt/pages/showcases/RatingButton/MaxNumber.vue
@@ -6,8 +6,8 @@
 </template>
 
 <script lang="ts" setup>
-import { ref } from 'vue';
-import { SfRatingButton, useId } from '@storefront-ui/vue';
+import { ref, useId } from 'vue';
+import { SfRatingButton } from '@storefront-ui/vue';
 const labelId = useId();
 const modelValue = ref(5);
 </script>

--- a/apps/preview/nuxt/pages/showcases/RatingForms/ProductRating.vue
+++ b/apps/preview/nuxt/pages/showcases/RatingForms/ProductRating.vue
@@ -39,8 +39,8 @@
 </template>
 
 <script lang="ts" setup>
-import { ref } from 'vue';
-import { SfModal, SfButton, SfIconClose, useDisclosure, SfRatingButton, useId } from '@storefront-ui/vue';
+import { ref, useId } from 'vue';
+import { SfModal, SfButton, SfIconClose, useDisclosure, SfRatingButton } from '@storefront-ui/vue';
 
 const { isOpen, open, close } = useDisclosure({ initialValue: true });
 const modelValue = ref();

--- a/apps/preview/nuxt/pages/showcases/RatingForms/ProductRatingWithReview.vue
+++ b/apps/preview/nuxt/pages/showcases/RatingForms/ProductRatingWithReview.vue
@@ -48,8 +48,8 @@
 </template>
 
 <script lang="ts" setup>
-import { ref, computed } from 'vue';
-import { SfButton, SfRatingButton, SfInput, useId } from '@storefront-ui/vue';
+import { ref, computed, useId } from 'vue';
+import { SfButton, SfRatingButton, SfInput } from '@storefront-ui/vue';
 
 const ratingLabelId = useId();
 const ratingModelValue = ref();

--- a/apps/preview/nuxt/pages/showcases/SelectDropdown/SelectDropdownDisabled.vue
+++ b/apps/preview/nuxt/pages/showcases/SelectDropdown/SelectDropdownDisabled.vue
@@ -59,7 +59,7 @@
 </template>
 
 <script lang="ts" setup>
-import { ref, type Ref } from 'vue';
+import { ref, type Ref, useId } from 'vue';
 import { unrefElement } from '@vueuse/core';
 import {
   useDropdown,
@@ -67,7 +67,6 @@ import {
   SfIconExpandMore,
   SfListItem,
   SfIconCheck,
-  useId,
   useTrapFocus,
 } from '@storefront-ui/vue';
 

--- a/apps/preview/nuxt/pages/showcases/SelectDropdown/SelectDropdownError.vue
+++ b/apps/preview/nuxt/pages/showcases/SelectDropdown/SelectDropdownError.vue
@@ -59,7 +59,7 @@
 </template>
 
 <script lang="ts" setup>
-import { ref, computed, type Ref } from 'vue';
+import { ref, computed, type Ref, useId } from 'vue';
 import { unrefElement } from '@vueuse/core';
 import {
   useDropdown,
@@ -67,7 +67,6 @@ import {
   SfIconExpandMore,
   SfListItem,
   SfIconCheck,
-  useId,
   useTrapFocus,
 } from '@storefront-ui/vue';
 

--- a/apps/preview/nuxt/pages/showcases/SelectDropdown/SelectDropdownPreselected.vue
+++ b/apps/preview/nuxt/pages/showcases/SelectDropdown/SelectDropdownPreselected.vue
@@ -53,7 +53,7 @@
 </template>
 
 <script lang="ts" setup>
-import { ref, type Ref } from 'vue';
+import { ref, type Ref, useId } from 'vue';
 import { unrefElement } from '@vueuse/core';
 import {
   useDropdown,
@@ -61,7 +61,6 @@ import {
   SfIconExpandMore,
   SfListItem,
   SfIconCheck,
-  useId,
   useTrapFocus,
 } from '@storefront-ui/vue';
 

--- a/apps/preview/nuxt/pages/showcases/SelectDropdown/SelectDropdownWithPlaceholder.vue
+++ b/apps/preview/nuxt/pages/showcases/SelectDropdown/SelectDropdownWithPlaceholder.vue
@@ -53,7 +53,7 @@
 </template>
 
 <script lang="ts" setup>
-import { ref, type Ref } from 'vue';
+import { ref, type Ref, useId } from 'vue';
 import { unrefElement } from '@vueuse/core';
 import {
   useDropdown,
@@ -61,7 +61,6 @@ import {
   SfIconExpandMore,
   SfListItem,
   SfIconCheck,
-  useId,
   useTrapFocus,
 } from '@storefront-ui/vue';
 

--- a/apps/preview/nuxt/pages/showcases/Tooltip/BasicTooltip.vue
+++ b/apps/preview/nuxt/pages/showcases/Tooltip/BasicTooltip.vue
@@ -1,9 +1,15 @@
 <template>
   <div class="mt-12">
-    <SfTooltip label="This is a tooltip!"> Hover me! </SfTooltip>
+    <SfTooltip label="This is a tooltip!" :id="tooltipId">
+      <span :aria-describedby="tooltipId"> Hover me! </span>
+    </SfTooltip>
   </div>
 </template>
 
 <script setup lang="ts">
+import { useId } from 'vue';
 import { SfTooltip } from '@storefront-ui/vue';
+
+const id = useId();
+const tooltipId = `${id}-tooltip`;
 </script>

--- a/apps/preview/nuxt/pages/showcases/Tooltip/FocusableTooltip.vue
+++ b/apps/preview/nuxt/pages/showcases/Tooltip/FocusableTooltip.vue
@@ -1,0 +1,14 @@
+<template>
+  <SfTooltip label="This is a tooltip!" :id="tooltipId" v-model="isOpen" show-arrow placement="right">
+    <span :aria-describedby="tooltipId" @focus="open" @blur="close" tabindex="0"> Hover or focus me! </span>
+  </SfTooltip>
+</template>
+
+<script setup lang="ts">
+import { useId } from 'vue';
+import { SfTooltip, useDisclosure } from '@storefront-ui/vue';
+
+const id = useId();
+const tooltipId = `${id}-tooltip`;
+const { isOpen, open, close } = useDisclosure();
+</script>

--- a/packages/sfui/frameworks/nuxt/src/module.ts
+++ b/packages/sfui/frameworks/nuxt/src/module.ts
@@ -56,8 +56,7 @@ export default defineNuxtModule<ModuleOptions>({
       if (key.startsWith('Sf') && (storefrontUi[key].__name || storefrontUi[key].name)) {
         components.push(key);
       } else if (key.startsWith('use')) {
-        // `useId` is already available in nuxtjs, we omit `useId` because of duplication warning
-        if (key !== 'useId') composables.push(key);
+        composables.push(key);
       }
     });
 

--- a/packages/sfui/frameworks/react/components/SfBadge/SfBadge.tsx
+++ b/packages/sfui/frameworks/react/components/SfBadge/SfBadge.tsx
@@ -19,18 +19,16 @@ export default function SfBadge({
   return (
     <span
       className={twMerge(
-        twMerge(
-          'block absolute py-0.5 px-1 bg-negative-700 font-medium text-white text-[8px] leading-[8px] rounded-xl',
-          {
-            'min-w-[12px] min-h-[12px]': !isDot,
-            'w-[10px] h-[10px]': isDot,
-            'top-0 right-0 -translate-x-0.5 translate-y-0.5': placement === 'top-right',
-            'top-0 left-0 translate-x-0.5 translate-y-0.5': placement === 'top-left',
-            'bottom-0 right-0 -translate-x-0.5 -translate-y-0.5': placement === 'bottom-right',
-            'bottom-0 left-0 translate-x-0.5 -translate-y-0.5': placement === 'bottom-left',
-          },
-          className,
-        ),
+        'block absolute py-0.5 px-1 bg-negative-700 font-medium text-white text-[8px] leading-[8px] rounded-xl',
+        {
+          'min-w-[12px] min-h-[12px]': !isDot,
+          'w-[10px] h-[10px]': isDot,
+          'top-0 right-0 -translate-x-0.5 translate-y-0.5': placement === 'top-right',
+          'top-0 left-0 translate-x-0.5 translate-y-0.5': placement === 'top-left',
+          'bottom-0 right-0 -translate-x-0.5 -translate-y-0.5': placement === 'bottom-right',
+          'bottom-0 left-0 translate-x-0.5 -translate-y-0.5': placement === 'bottom-left',
+        },
+        className,
       )}
       data-testid="badge"
       {...attributes}

--- a/packages/sfui/frameworks/react/components/SfTooltip/SfTooltip.tsx
+++ b/packages/sfui/frameworks/react/components/SfTooltip/SfTooltip.tsx
@@ -1,18 +1,35 @@
 'use client';
 import { useTooltip } from '@storefront-ui/react';
 import type { SfTooltipProps } from '@storefront-ui/react';
+import { useEffect } from 'react';
 
 export default function SfTooltip(props: SfTooltipProps) {
-  const { children, label, className, style, showArrow, ...tooltipOptions } = props;
-  const { isOpen, getTriggerProps, getTooltipProps, getArrowProps } = useTooltip(tooltipOptions);
+  const {
+    children,
+    label,
+    className,
+    style,
+    open: openProp,
+    showArrow,
+    id,
+    'data-testid': dataTestid,
+    ...tooltipOptions
+  } = props;
+  const { isOpen, open, close, getTriggerProps, getTooltipProps, getArrowProps } = useTooltip(tooltipOptions);
+
+  useEffect(() => {
+    if (openProp) open();
+    else close();
+  }, [openProp, open, close]);
 
   return (
-    <span {...getTriggerProps({ className, style })} data-testid="tooltip">
+    <span data-testid={dataTestid ?? 'tooltip'} {...getTriggerProps({ className, style })}>
       {children}
       {label && isOpen && (
         <div
           {...getTooltipProps({
             role: 'tooltip',
+            id,
             className: 'bg-black px-2 py-1.5 rounded-md text-white text-xs w-max max-w-[360px] drop-shadow-sm',
           })}
         >

--- a/packages/sfui/frameworks/react/components/SfTooltip/types.ts
+++ b/packages/sfui/frameworks/react/components/SfTooltip/types.ts
@@ -2,6 +2,9 @@ import type { PropsWithChildren } from 'react';
 import type { UseTooltipOptions, PropsWithStyle } from '@storefront-ui/react';
 
 export interface SfTooltipProps extends UseTooltipOptions, PropsWithChildren, PropsWithStyle {
+  id?: string;
+  'data-testid'?: string;
   label: string;
   showArrow?: boolean;
+  open?: boolean;
 }

--- a/packages/sfui/frameworks/react/hooks/useTooltip/useTooltip.ts
+++ b/packages/sfui/frameworks/react/hooks/useTooltip/useTooltip.ts
@@ -9,6 +9,7 @@ import {
   useDisclosure,
 } from '@storefront-ui/react';
 import type { UseTooltipOptions } from '@storefront-ui/react';
+import { useKey } from 'react-use';
 
 export function useTooltip(options?: UseTooltipOptions) {
   const {
@@ -66,6 +67,8 @@ export function useTooltip(options?: UseTooltipOptions) {
     ref: arrowRef,
     style: { ...userProps.style, ...arrowStyle() },
   }));
+
+  useKey('Escape', close, { target: refs.reference.current }, [close, refs.reference]);
 
   return {
     refs: {

--- a/packages/sfui/frameworks/vue/components/SfChip/SfChip.vue
+++ b/packages/sfui/frameworks/vue/components/SfChip/SfChip.vue
@@ -5,9 +5,8 @@ const sizeClasses = {
 };
 </script>
 <script lang="ts" setup>
-import { type PropType, type InputHTMLAttributes } from 'vue';
-import { toRefs, computed } from 'vue';
-import { useId, SfChipSize, useSlotsRef, twMerge, useTwMergeRoot } from '@storefront-ui/vue';
+import { type PropType, type InputHTMLAttributes, useId, toRefs, computed } from 'vue';
+import { SfChipSize, useSlotsRef, twMerge, useTwMergeRoot } from '@storefront-ui/vue';
 
 const props = defineProps({
   size: {

--- a/packages/sfui/frameworks/vue/components/SfTooltip/SfTooltip.vue
+++ b/packages/sfui/frameworks/vue/components/SfTooltip/SfTooltip.vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-import { type PropType, toRefs } from 'vue';
+import { type PropType, toRefs, watch } from 'vue';
 import type { Middleware } from '@floating-ui/vue';
 import { useTooltip, type SfPopoverPlacement, type SfPopoverStrategy } from '@storefront-ui/vue';
 
@@ -24,16 +24,38 @@ const props = defineProps({
     type: String,
     required: true,
   },
+  id: {
+    type: String,
+    default: undefined,
+  },
+  modelValue: {
+    type: Boolean,
+    default: false,
+  },
 });
 
-const { placement, middleware, strategy } = toRefs(props);
-const { isOpen, triggerProps, tooltipProps, arrowProps } = useTooltip({ placement, middleware, strategy });
+const emit = defineEmits<{
+  (event: 'update:modelValue', open: boolean): void;
+}>();
+
+const { placement, middleware, strategy, modelValue } = toRefs(props);
+const { isOpen, close, open, triggerProps, tooltipProps, arrowProps } = useTooltip({ placement, middleware, strategy });
+
+watch(modelValue, (newVal) => {
+  if (newVal) open();
+  else close();
+});
+
+watch(isOpen, (newVal) => {
+  emit('update:modelValue', newVal);
+});
 </script>
 <template>
   <span data-testid="tooltip" v-bind="triggerProps">
     <slot />
     <div
       v-if="label && isOpen"
+      :id="id"
       role="tooltip"
       class="bg-black px-2 py-1.5 rounded-md text-white text-xs w-max max-w-[360px] drop-shadow-sm"
       v-bind="tooltipProps"

--- a/packages/sfui/frameworks/vue/components/SfTooltip/SfTooltip.vue
+++ b/packages/sfui/frameworks/vue/components/SfTooltip/SfTooltip.vue
@@ -44,7 +44,7 @@ const { isOpen, close, open, triggerProps, tooltipProps, arrowProps } = useToolt
 watch(modelValue, (newVal) => {
   if (newVal) open();
   else close();
-});
+}, { immediate: true });
 
 watch(isOpen, (newVal) => {
   emit('update:modelValue', newVal);

--- a/packages/sfui/frameworks/vue/composables/useTooltip/useTooltip.ts
+++ b/packages/sfui/frameworks/vue/composables/useTooltip/useTooltip.ts
@@ -1,6 +1,7 @@
-import { ref, unref, computed, toValue } from 'vue';
+import { ref, unref, computed, toValue, type MaybeRefOrGetter } from 'vue';
 import { arrow, flip, offset, shift, type ReferenceElement, type Side } from '@floating-ui/vue';
 import { type UseTooltipOptions, usePopover, useDisclosure } from '@storefront-ui/vue';
+import { onKeyStroke } from '@vueuse/core';
 
 export function useTooltip<ReferenceEl extends ReferenceElement = ReferenceElement>(
   options?: UseTooltipOptions<ReferenceEl>,
@@ -68,6 +69,8 @@ export function useTooltip<ReferenceEl extends ReferenceElement = ReferenceEleme
     ref: arrowRef,
     style: arrowStyle(),
   }));
+
+  onKeyStroke('Escape', close, { target: referenceRef as MaybeRefOrGetter<EventTarget | null | undefined> });
 
   return {
     referenceRef,

--- a/packages/sfui/frameworks/vue/shared/index.ts
+++ b/packages/sfui/frameworks/vue/shared/index.ts
@@ -2,4 +2,3 @@ export * from './props';
 export * from './reactiveContext';
 export * from './render';
 export * from './types';
-export * from './useId';

--- a/packages/sfui/frameworks/vue/shared/useId.ts
+++ b/packages/sfui/frameworks/vue/shared/useId.ts
@@ -1,3 +1,0 @@
-let id = -1;
-/* eslint-disable-next-line no-plusplus */
-export const useId = () => String(++id);

--- a/packages/sfui/tw-plugin-peer-next/README.md
+++ b/packages/sfui/tw-plugin-peer-next/README.md
@@ -74,7 +74,7 @@ Made with ❤️ by <a href="https://github.com/vuestorefront" target="_blank">A
 
 ## Why?
 
-Targeting next siblings with `~` is not suitable for HTML structure when pairing `input` and `label`, every `label` after changed `input` will also change. Of course we can wrap such groups but having in mind how browser works, nesting and making deeper HTML structure does affect performance of rendering HTML by browser.
+Targeting next siblings with `~` is not suitable for HTML structure when pairing `input` and `label`, every `label` after changed `input` will also change. Of course we can wrap such groups but having in mind how browsers work, nesting and making deeper HTML structure does affect performance of rendering HTML by browser.
 
 ## Installation
 

--- a/packages/tests/components/SfTooltip/SfTooltip.PageObject.ts
+++ b/packages/tests/components/SfTooltip/SfTooltip.PageObject.ts
@@ -1,6 +1,11 @@
 import { BasePage } from '../../utils/BasePage';
 
 export default class SfTooltipObject extends BasePage {
+  hasTooltipId(id: string) {
+    this.tooltip.should('have.attr', 'id', id);
+    return this;
+  }
+
   isTooltipHidden() {
     this.tooltip.should('not.exist');
     return this;

--- a/packages/tests/components/SfTooltip/SfTooltip.cy.tsx
+++ b/packages/tests/components/SfTooltip/SfTooltip.cy.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
-import { mount, useComponent } from '../../utils/mount';
+import { ref } from 'vue';
+import type { Ref } from 'vue';
+import { Wrapper, mount, useComponent } from '../../utils/mount';
 import SfTooltipObject from './SfTooltip.PageObject';
 
 const { vue: SfTooltipVue, react: SfTooltipReact } = useComponent('SfTooltip');
@@ -13,9 +15,20 @@ describe('SfTooltip', () => {
       children?: string | React.ReactElement;
       className?: string;
       showArrow?: boolean;
+      id?: string;
+      'data-testid'?: string;
+      modelValue?: Ref<boolean>;
     } = {},
   ) => {
-    const { label = 'Tooltip text', children = 'Content', showArrow = false, className } = props;
+    const {
+      label = 'Tooltip text',
+      children = 'Content',
+      showArrow = false,
+      className,
+      id,
+      'data-testid': dataTestid,
+      modelValue,
+    } = props;
     return mount({
       vue: {
         component: SfTooltipVue,
@@ -23,15 +36,26 @@ describe('SfTooltip', () => {
           label,
           class: className,
           showArrow,
+          modelValue,
+          id,
+          dataTestid,
         },
         slots: {
           default: children,
         },
       },
       react: (
-        <SfTooltipReact label={label} className={className} showArrow={showArrow}>
+        <Wrapper
+          component={SfTooltipReact}
+          open={modelValue}
+          label={label}
+          className={className}
+          showArrow={showArrow}
+          id={id}
+          data-testid={dataTestid}
+        >
           {children}
-        </SfTooltipReact>
+        </Wrapper>
       ),
     });
   };
@@ -82,6 +106,32 @@ describe('SfTooltip', () => {
       initializeComponent(props);
 
       page().hasClass(props.className);
+    });
+  });
+
+  describe('When id prop is added', () => {
+    it('Should apply given id to tooltip element', () => {
+      const props = { id: 'custom-id', modelValue: ref(true), label: 'Tooltip text' };
+      initializeComponent(props);
+
+      page().hasTooltipId(props.id);
+    });
+  });
+
+  describe('When open modelValue changes', () => {
+    it('Should react to the changes', () => {
+      const modelValue = ref(false);
+      initializeComponent({ modelValue });
+
+      page().isTooltipHidden();
+
+      cy.then(() => {
+        modelValue.value = true;
+        page().isTooltipVisible();
+      }).then(() => {
+        modelValue.value = false;
+        page().isTooltipHidden();
+      });
     });
   });
 });


### PR DESCRIPTION
support for passing id and data-testid attributes
add possibility to open tooltip programatically
close tooltip on Escape keypress
update docs & showcases

# Related issue

<!-- paste a link to related issue -->
https://alokai.atlassian.net/browse/ES-2025

Closes #

# Scope of work

<!-- describe what you did -->

# Screenshots of visual changes

<!-- if visual changes applied -->

# Checklist

- [x] Self code-reviewed
- [x] Changes documented
- [x] Semantic HTML
- [x] SSR-friendly
- [x] Caching friendly
- [x] a11y for WCAG 2.0 AA
- [x] examples created
- [x] blocks created
- [x] cypress tests created
