### PR TITLE
fix: useFocusVisible SSR leak [ES-2268]

### DIFF
--- a/packages/sfui/frameworks/vue/composables/useFocusVisible/useFocusVisible.ts
+++ b/packages/sfui/frameworks/vue/composables/useFocusVisible/useFocusVisible.ts
@@ -7,32 +7,32 @@ const manager = focusVisibleManager();
 export const useFocusVisible = (props: FocusVisibleProps = {}): FocusVisibleResult => {
   const isTextInput = computed(() => unref(props.isTextInput));
   const isFocusVisible = ref(props.autoFocus || manager.isFocusVisible());
-
-  onMounted(() => {
-    manager.setupGlobalFocusEvents();
-  });
-
   // eslint-disable-next-line @typescript-eslint/no-empty-function
   let onCleanup = () => {};
-  watch(
-    isTextInput,
-    () => {
-      onCleanup();
+  
+  onMounted(() => {
+    manager.setupGlobalFocusEvents();
 
-      const handler = (modality: FocusModality, e: FocusHandlerEvent) => {
-        if (!manager.isKeyboardFocusEvent(isTextInput?.value, modality, e)) {
-          return;
-        }
-        isFocusVisible.value = manager.isFocusVisible();
-      };
-      manager.changeHandlers.add(handler);
-
-      onCleanup = () => {
-        manager.changeHandlers.delete(handler);
-      };
-    },
-    { immediate: true },
-  );
+    watch(
+      isTextInput,
+      () => {
+        onCleanup();
+  
+        const handler = (modality: FocusModality, e: FocusHandlerEvent) => {
+          if (!manager.isKeyboardFocusEvent(isTextInput?.value, modality, e)) {
+            return;
+          }
+          isFocusVisible.value = manager.isFocusVisible();
+        };
+        manager.changeHandlers.add(handler);
+  
+        onCleanup = () => {
+          manager.changeHandlers.delete(handler);
+        };
+      },
+      { immediate: true },
+    );
+  });
 
   onUnmounted(() => {
     onCleanup();


### PR DESCRIPTION
# Related issue

https://alokai.atlassian.net/browse/ES-2268

# Scope of work

<!-- describe what you did -->
`useFocusVisible` leaks under SSR as it creates `handler` methods, adds them into a `changedEvents` set and never removes them. This fix changes the method behaviour - now under SSR `handler` function won't be created nor added anywhere. 

# Screenshots of visual changes

<!-- if visual changes applied -->

# Checklist

- [x] Self code-reviewed
- [x] Changes documented
- [x] Semantic HTML
- [x] SSR-friendly
- [x] Caching friendly
- [x] a11y for WCAG 2.0 AA
- [x] examples created
- [x] blocks created
- [x] cypress tests created
