### PR TITLE
chore: add changeset for useFocusVisible SSR leak fix

### DIFF
--- a/.changeset/fix-use-focus-visible-ssr-leak.md
+++ b/.changeset/fix-use-focus-visible-ssr-leak.md
@@ -1,0 +1,5 @@
+---
+'@storefront-ui/vue': patch
+---
+
+**[FIXED]** `useFocusVisible` no longer leaks event listeners in SSR environments by moving `setupGlobalFocusEvents` and the `watch` handler inside `onMounted`.


### PR DESCRIPTION
## Summary

- Adds a changeset for the `useFocusVisible` SSR leak fix from #3464
- Marks `@storefront-ui/vue` as a patch bump

## Test plan

- [x] Verify changeset file is correctly formatted and targets `@storefront-ui/vue` patch

🤖 Generated with [Claude Code](https://claude.com/claude-code)