### PR TITLE
feat: add /healthz and /readyz endpoints to deployed apps

### DIFF
--- a/.vuestorefrontcloud/router/docker/default.conf.template
+++ b/.vuestorefrontcloud/router/docker/default.conf.template
@@ -6,6 +6,14 @@ server {
     return 200 "User-agent: *\nDisallow: /v2-rc-3/\nDisallow: /v2-rc-3-vue/\nDisallow: /v2-rc-3-react/";
   }
 
+  location /healthz {
+    return 200 "OK";
+  }
+
+  location /readyz {
+    return 200 "OK";
+  }
+
   # https://www.oliverdavies.uk/blog/nginx-redirects-query-string-arguments
   location / {
     return 301 ${TARGET_DOMAIN}/v2$uri$is_args$args;

--- a/apps/docs/components/server/routes/healthz.ts
+++ b/apps/docs/components/server/routes/healthz.ts
@@ -1,0 +1,4 @@
+export default defineEventHandler((event) => {
+  setResponseStatus(event, 200);
+  return 'OK';
+});

--- a/apps/docs/components/server/routes/readyz.ts
+++ b/apps/docs/components/server/routes/readyz.ts
@@ -1,0 +1,4 @@
+export default defineEventHandler((event) => {
+  setResponseStatus(event, 200);
+  return 'OK';
+});

--- a/apps/preview/next/pages/healthz.ts
+++ b/apps/preview/next/pages/healthz.ts
@@ -1,0 +1,12 @@
+import type { GetServerSideProps } from 'next';
+
+export const getServerSideProps: GetServerSideProps = async ({ res }) => {
+  res.statusCode = 200;
+  res.setHeader('Content-Type', 'text/plain');
+  res.end('OK');
+  return { props: {} };
+};
+
+export default function Healthz() {
+  return null;
+}

--- a/apps/preview/next/pages/readyz.ts
+++ b/apps/preview/next/pages/readyz.ts
@@ -1,0 +1,12 @@
+import type { GetServerSideProps } from 'next';
+
+export const getServerSideProps: GetServerSideProps = async ({ res }) => {
+  res.statusCode = 200;
+  res.setHeader('Content-Type', 'text/plain');
+  res.end('OK');
+  return { props: {} };
+};
+
+export default function Readyz() {
+  return null;
+}

--- a/apps/preview/nuxt/server/routes/healthz.ts
+++ b/apps/preview/nuxt/server/routes/healthz.ts
@@ -1,0 +1,4 @@
+export default defineEventHandler((event) => {
+  setResponseStatus(event, 200);
+  return 'OK';
+});

--- a/apps/preview/nuxt/server/routes/readyz.ts
+++ b/apps/preview/nuxt/server/routes/readyz.ts
@@ -1,0 +1,4 @@
+export default defineEventHandler((event) => {
+  setResponseStatus(event, 200);
+  return 'OK';
+});


### PR DESCRIPTION
## Summary
- Adds `/healthz` and `/readyz` health check endpoints to all deployed apps: router, docs, vue-preview, and react-preview.
- Router: plain nginx `location` blocks returning 200 "OK".
- docs / vue-preview (Nuxt/Nitro): server routes under `server/routes/{healthz,readyz}.ts` returning 200 "OK".
- react-preview (Next.js pages router): pages using `getServerSideProps` to short-circuit rendering and return a raw 200 "OK" response, keeping the literal `/healthz` and `/readyz` paths (rather than nesting under `/api`).

## Test plan
- [x] Build/run each app locally and curl `/healthz` and `/readyz` to confirm 200 "OK" responses
- [x] Verify router nginx config renders correctly via `envsubst` and serves the new locations
- [ ] Confirm health check paths are reachable in the deployed environment (note: some preview apps can have a `basePath`/`baseURL` set via env vars — verify these routes are probed at the app's own root, not behind that prefix)